### PR TITLE
feat: add Tailwind CSS v4 theming system

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
 		"react-dom": "^18.0.0 || ^19.0.0",
 		"tailwindcss": "^4.0.0"
 	},
+	"dependencies": {
+		"clsx": "^2.1.1",
+		"tailwind-merge": "^3.0.1"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.0.0",
 		"@tailwindcss/postcss": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      tailwind-merge:
+        specifier: ^3.0.1
+        version: 3.4.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.0.0
@@ -763,6 +770,10 @@ packages:
   caniuse-lite@1.0.30001765:
     resolution: {integrity: sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
@@ -1120,6 +1131,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.4.0:
+    resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
@@ -1853,6 +1867,8 @@ snapshots:
 
   caniuse-lite@1.0.30001765: {}
 
+  clsx@2.1.1: {}
+
   compare-versions@6.1.1: {}
 
   confbox@0.1.8: {}
@@ -2171,6 +2187,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@3.4.0: {}
 
   tailwindcss@4.1.18: {}
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,59 @@
+@import "./theme.css";
+
+:root {
+  --fanv-primary: 253 100% 72%;
+  --fanv-primary-foreground: 0 0% 100%;
+  --fanv-secondary: 0 0% 96%;
+  --fanv-secondary-foreground: 0 0% 8%;
+  --fanv-destructive: 0 75% 56%;
+  --fanv-destructive-foreground: 0 0% 100%;
+  --fanv-muted: 0 0% 96%;
+  --fanv-muted-foreground: 0 0% 45%;
+  --fanv-accent: 0 0% 96%;
+  --fanv-accent-foreground: 0 0% 8%;
+  --fanv-background: 0 0% 100%;
+  --fanv-foreground: 0 0% 8%;
+  --fanv-card: 0 0% 100%;
+  --fanv-card-foreground: 0 0% 8%;
+  --fanv-popover: 0 0% 100%;
+  --fanv-popover-foreground: 0 0% 8%;
+  --fanv-border: 0 0% 90%;
+  --fanv-input: 0 0% 90%;
+  --fanv-ring: 253 100% 72%;
+  --fanv-radius: 0.5rem;
+  --fanv-font-sans: "Inter";
+}
+
+.dark {
+  --fanv-primary: 253 100% 72%;
+  --fanv-primary-foreground: 0 0% 100%;
+  --fanv-secondary: 0 0% 15%;
+  --fanv-secondary-foreground: 0 0% 100%;
+  --fanv-destructive: 0 100% 72%;
+  --fanv-destructive-foreground: 0 0% 100%;
+  --fanv-muted: 0 0% 15%;
+  --fanv-muted-foreground: 0 0% 64%;
+  --fanv-accent: 0 0% 15%;
+  --fanv-accent-foreground: 0 0% 100%;
+  --fanv-background: 0 0% 8%;
+  --fanv-foreground: 0 0% 100%;
+  --fanv-card: 0 0% 17%;
+  --fanv-card-foreground: 0 0% 100%;
+  --fanv-popover: 0 0% 17%;
+  --fanv-popover-foreground: 0 0% 100%;
+  --fanv-border: 0 0% 22%;
+  --fanv-input: 0 0% 22%;
+  --fanv-ring: 253 100% 72%;
+}
+
+*,
+*::before,
+*::after {
+  border-color: hsl(var(--fanv-border));
+}
+
+body {
+  background-color: hsl(var(--fanv-background));
+  color: hsl(var(--fanv-foreground));
+  font-family: var(--font-sans);
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,30 @@
+@import "tailwindcss";
+
+@theme {
+  --color-primary: hsl(var(--fanv-primary));
+  --color-primary-foreground: hsl(var(--fanv-primary-foreground));
+  --color-secondary: hsl(var(--fanv-secondary));
+  --color-secondary-foreground: hsl(var(--fanv-secondary-foreground));
+  --color-destructive: hsl(var(--fanv-destructive));
+  --color-destructive-foreground: hsl(var(--fanv-destructive-foreground));
+  --color-muted: hsl(var(--fanv-muted));
+  --color-muted-foreground: hsl(var(--fanv-muted-foreground));
+  --color-accent: hsl(var(--fanv-accent));
+  --color-accent-foreground: hsl(var(--fanv-accent-foreground));
+  --color-background: hsl(var(--fanv-background));
+  --color-foreground: hsl(var(--fanv-foreground));
+  --color-card: hsl(var(--fanv-card));
+  --color-card-foreground: hsl(var(--fanv-card-foreground));
+  --color-popover: hsl(var(--fanv-popover));
+  --color-popover-foreground: hsl(var(--fanv-popover-foreground));
+  --color-border: hsl(var(--fanv-border));
+  --color-input: hsl(var(--fanv-input));
+  --color-ring: hsl(var(--fanv-ring));
+
+  --radius-lg: var(--fanv-radius);
+  --radius-md: calc(var(--fanv-radius) - 2px);
+  --radius-sm: calc(var(--fanv-radius) - 4px);
+
+  --font-sans: var(--fanv-font-sans), ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
- Add theme.css with @theme directive for Tailwind v4 design tokens
- Add globals.css with CSS variables for light/dark mode
- Add cn() utility function for merging Tailwind classes
- Add clsx and tailwind-merge as runtime dependencies

The theming system uses CSS variables with the --fanv-* prefix for customization. Colors use HSL format for flexibility.