### PR TITLE
feat: add Button component with variants, sizes, and states

### DIFF
--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -1,3 +1,0 @@
-export const Button = () => {
-  return <button>Click me</button>
-}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,0 @@
-export * from './components/Button/Button';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,46 @@
-import { Button } from "../"
+import { Button } from "./index";
+import "./styles/globals.css";
 
 function App() {
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-      <h1>Demo Page</h1>
-      <Button />
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="container mx-auto px-4 py-12">
+        <h1 className="mb-8 font-bold text-3xl">fanv-ui Demo</h1>
+
+        <section className="space-y-8">
+          <div>
+            <h2 className="mb-4 font-semibold text-xl">Button Variants</h2>
+            <div className="flex flex-wrap gap-4">
+              <Button variant="default">Default</Button>
+              <Button variant="primary">Primary</Button>
+              <Button variant="secondary">Secondary</Button>
+              <Button variant="outline">Outline</Button>
+              <Button variant="ghost">Ghost</Button>
+              <Button variant="destructive">Destructive</Button>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="mb-4 font-semibold text-xl">Button Sizes</h2>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button size="sm">Small</Button>
+              <Button size="md">Medium</Button>
+              <Button size="lg">Large</Button>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="mb-4 font-semibold text-xl">Button States</h2>
+            <div className="flex flex-wrap gap-4">
+              <Button disabled>Disabled</Button>
+              <Button loading>Loading</Button>
+              <Button fullWidth>Full Width</Button>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,116 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+const buttonVariants = {
+  variant: {
+    default: "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
+    primary: "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
+    secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-sm",
+    outline:
+      "border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground shadow-sm",
+    ghost: "text-foreground hover:bg-accent hover:text-accent-foreground",
+    destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-sm",
+  },
+  size: {
+    sm: "h-8 px-3 text-sm rounded-sm gap-1.5",
+    md: "h-10 px-4 text-sm rounded-md gap-2",
+    lg: "h-12 px-6 text-base rounded-lg gap-2.5",
+  },
+} as const;
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof buttonVariants.variant;
+  size?: keyof typeof buttonVariants.size;
+  loading?: boolean;
+  fullWidth?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  asChild?: boolean;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant = "default",
+      size = "md",
+      loading = false,
+      fullWidth = false,
+      leftIcon,
+      rightIcon,
+      asChild = false,
+      disabled,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const isDisabled = disabled || loading;
+
+    const buttonClassName = cn(
+      "inline-flex items-center justify-center font-medium",
+      "transition-colors duration-150",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:pointer-events-none disabled:opacity-50",
+      buttonVariants.variant[variant],
+      buttonVariants.size[size],
+      fullWidth && "w-full",
+      loading && "cursor-wait",
+      className,
+    );
+
+    if (asChild) {
+      return (
+        <Slot
+          ref={ref}
+          className={buttonClassName}
+          aria-disabled={isDisabled || undefined}
+          {...props}
+        >
+          {children}
+        </Slot>
+      );
+    }
+
+    return (
+      <button
+        ref={ref}
+        className={buttonClassName}
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
+        aria-busy={loading}
+        {...props}
+      >
+        {loading && (
+          <svg
+            className="h-4 w-4 animate-spin"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+        )}
+        {!loading && leftIcon}
+        {children}
+        {!loading && rightIcon}
+      </button>
+    );
+  },
+);
+
+Button.displayName = "Button";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export type { ButtonProps } from "./components/Button/Button";
+export { Button } from "./components/Button/Button";
+export { cn } from "./utils/cn";


### PR DESCRIPTION
- Add Button component with forwardRef and TypeScript support
- Support variants: default, primary, secondary, outline, ghost, destructive
- Support sizes: sm, md, lg
- Add loading state with spinner
- Add fullWidth prop for full-width buttons
- Add leftIcon and rightIcon props
- Add asChild prop for polymorphic rendering via Radix Slot
- Include cn utility and Tailwind theming (globals.css, theme.css)
- Restructure from lib/ to src/components/
- Update demo app to showcase Button variants

Dependencies added:
- @radix-ui/react-slot for polymorphic rendering
- clsx and tailwind-merge for class name merging