### PR TITLE
feat: add Playwright E2E testing infrastructure

### DIFF
--- a/e2e/button.spec.ts
+++ b/e2e/button.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * E2E tests for Button component
+ *
+ * These tests run against Storybook stories to verify
+ * component behavior across browsers.
+ */
+
+test.describe("Button", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the Button story
+    await page.goto("/iframe.html?id=components-button--default");
+  });
+
+  test("renders correctly", async ({ page }) => {
+    const button = page.getByRole("button");
+    await expect(button).toBeVisible();
+  });
+
+  test("is keyboard accessible", async ({ page }) => {
+    const button = page.getByRole("button");
+
+    // Tab to the button
+    await page.keyboard.press("Tab");
+    await expect(button).toBeFocused();
+
+    // Verify focus is visible
+    const focusRing = await button.evaluate((el) => {
+      const styles = window.getComputedStyle(el);
+      return styles.outlineStyle !== "none" || styles.boxShadow !== "none";
+    });
+    expect(focusRing).toBe(true);
+  });
+
+  test("can be activated with Enter key", async ({ page }) => {
+    const button = page.getByRole("button");
+
+    // Focus and press Enter
+    await button.focus();
+    await page.keyboard.press("Enter");
+
+    // Button should still be in normal state (not loading)
+    await expect(button).not.toHaveAttribute("aria-busy", "true");
+  });
+
+  test("can be activated with Space key", async ({ page }) => {
+    const button = page.getByRole("button");
+
+    // Focus and press Space
+    await button.focus();
+    await page.keyboard.press("Space");
+
+    // Button should still be in normal state
+    await expect(button).toBeEnabled();
+  });
+});
+
+test.describe("Button - Disabled State", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/iframe.html?id=components-button--disabled");
+  });
+
+  test("disabled button is not clickable", async ({ page }) => {
+    const button = page.getByRole("button");
+
+    await expect(button).toBeDisabled();
+    await expect(button).toHaveAttribute("aria-disabled", "true");
+  });
+});
+
+test.describe("Button - Loading State", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/iframe.html?id=components-button--loading");
+  });
+
+  test("loading button shows spinner and is disabled", async ({ page }) => {
+    const button = page.getByRole("button");
+
+    await expect(button).toBeDisabled();
+    await expect(button).toHaveAttribute("aria-busy", "true");
+
+    // Should have a spinner (svg element)
+    const spinner = button.locator("svg");
+    await expect(spinner).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "prepublishOnly": "pnpm run build:lib"
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
+    "@playwright/test": "^1.50.0",
     "@storybook/addon-a11y": "^8.6.0",
     "@storybook/addon-essentials": "^8.6.0",
     "@storybook/addon-interactions": "^8.6.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "html",
+  use: {
+    baseURL: "http://localhost:6006",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+    { name: "Mobile Chrome", use: { ...devices["Pixel 5"] } },
+    { name: "Mobile Safari", use: { ...devices["iPhone 12"] } },
+  ],
+  webServer: {
+    command: "pnpm storybook",
+    url: "http://localhost:6006",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.0.0
         version: 2.3.13
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.58.0
       '@storybook/addon-a11y':
         specifier: ^8.6.0
         version: 8.6.15(storybook@8.6.15)
@@ -675,6 +678,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.58.0':
+    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -1681,6 +1689,11 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2095,6 +2108,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.58.0:
+    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.0:
+    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -3016,6 +3039,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.58.0':
+    dependencies:
+      playwright: 1.58.0
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
@@ -4076,6 +4103,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4470,6 +4500,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.58.0: {}
+
+  playwright@1.58.0:
+    dependencies:
+      playwright-core: 1.58.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   polished@4.3.1:
     dependencies:

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -21,6 +21,7 @@
   },
   "include": [
     "vite.config.ts",
-    "vitest.config.ts"
+    "vitest.config.ts",
+    "playwright.config.ts"
   ]
 }


### PR DESCRIPTION
- Add playwright.config.ts with multi-browser configuration
- Configure test projects for Chrome, Firefox, Safari, and mobile
- Auto-start Storybook as webServer for E2E tests
- Add e2e/button.spec.ts with Button component tests
- Test keyboard accessibility and component states
- Add playwright.config.ts to tsconfig.node.json include

Scripts added:
- test:e2e: Run Playwright tests

Dependencies added:
- @playwright/test

Note: E2E tests run against Storybook stories. Requires Storybook and Button component branches to be merged first.