### PR TITLE
fix(checkbox): styling bug with tick not visible in dark mode

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -102,9 +102,9 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             // Default state
             "border-body-100 bg-transparent text-transparent",
             // Checked state
-            "data-[state=checked]:border-body-100 data-[state=checked]:bg-body-100 data-[state=checked]:text-body-white-solid-constant",
+            "data-[state=checked]:border-body-100 data-[state=checked]:bg-body-100 data-[state=checked]:text-body-300",
             // Indeterminate state
-            "data-[state=indeterminate]:border-body-100 data-[state=indeterminate]:bg-body-100 data-[state=indeterminate]:text-body-white-solid-constant",
+            "data-[state=indeterminate]:border-body-100 data-[state=indeterminate]:bg-body-100 data-[state=indeterminate]:text-body-300",
             // Hover state
             "hover:ring-2 hover:ring-brand-green-500 group-hover:ring-2 group-hover:ring-brand-green-500",
             // Focus state
@@ -118,7 +118,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           <CheckboxPrimitive.Indicator
             forceMount
             className={cn(
-              "flex size-3 items-center justify-center text-body-white-solid-constant",
+              "flex size-3 items-center justify-center text-body-300",
               "data-[state=unchecked]:invisible",
             )}
           >


### PR DESCRIPTION
<img width="170" height="96" alt="Screenshot 2026-02-06 at 15 02 59" src="https://github.com/user-attachments/assets/332cb1f6-66a5-45a3-89f3-04adbf2a821c" />
<img width="175" height="82" alt="Screenshot 2026-02-06 at 15 03 27" src="https://github.com/user-attachments/assets/36eaed50-5f60-4b9f-9402-57b5e4c1bcad" />
