### PR TITLE
feat(build): enable preserveModules for proper tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@fanvue/ui",
-  "version": "0.1.0-alpha.3",
+  "version": "0.0.0",
   "description": "React component library built with Tailwind CSS for Fanvue ecosystem",
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/cjs/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -18,7 +18,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs"
+        "default": "./dist/cjs/index.cjs"
       }
     },
     "./styles/*": "./dist/styles/*"
@@ -123,7 +123,13 @@
   "size-limit": [
     {
       "path": "dist/index.mjs",
-      "limit": "60 KB"
+      "limit": "30 KB",
+      "ignore": [
+        "@radix-ui/*",
+        "clsx",
+        "tailwind-merge",
+        "react-day-picker"
+      ]
     }
   ],
   "lint-staged": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,24 +16,41 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(import.meta.dirname, "src/index.ts"),
-      formats: ["es", "cjs"],
-      fileName: (format) => `index.${format === "es" ? "mjs" : "cjs"}`,
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime", "tailwindcss", "react-day-picker"],
-      output: {
-        preserveModules: false,
-        banner: '"use client";',
-        globals: {
-          react: "React",
-          "react-dom": "ReactDOM",
-          "react/jsx-runtime": "jsxRuntime",
+      external: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "tailwindcss",
+        "react-day-picker",
+        /^@radix-ui\//,
+        "clsx",
+        "tailwind-merge",
+      ],
+      output: [
+        {
+          format: "es",
+          dir: "dist",
+          preserveModules: true,
+          preserveModulesRoot: "src",
+          entryFileNames: "[name].mjs",
+          banner: '"use client";',
         },
-      },
+        {
+          format: "cjs",
+          dir: "dist/cjs",
+          preserveModules: true,
+          preserveModulesRoot: "src",
+          entryFileNames: "[name].cjs",
+          exports: "named",
+          banner: '"use client";',
+        },
+      ],
     },
     cssCodeSplit: false,
     sourcemap: true,
-    minify: "esbuild",
+    minify: false,
     target: "es2022",
   },
   resolve: {


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link related issues with "Closes #123". -->

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<!-- Paste screenshots or a link to the Chromatic/Storybook build. -->
