### PR TITLE
feat!: normalize component variant APIs to consistent casing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,29 +217,29 @@ function App() {
         <div className="container mx-auto px-4 py-12">
           <section className="space-y-8">
             <div className="flex flex-wrap items-start gap-8">
-              <Logo type="Full" color="Full colour" />
-              <Logo type="Icon" color="Full colour" />
-              <Logo type="Portrait" color="Full colour" />
-              <Logo type="Wordmark" color="Full colour" />
-              <Logo type="Full" color="Decolour" />
-              <Logo type="Icon" color="Decolour" />
-              <Logo type="Portrait" color="Decolour" />
-              <Logo type="Wordmark" color="Decolour" />
+              <Logo type="full" color="fullColour" />
+              <Logo type="icon" color="fullColour" />
+              <Logo type="portrait" color="fullColour" />
+              <Logo type="wordmark" color="fullColour" />
+              <Logo type="full" color="decolour" />
+              <Logo type="icon" color="decolour" />
+              <Logo type="portrait" color="decolour" />
+              <Logo type="wordmark" color="decolour" />
             </div>
             <div className="rounded-lg bg-background-white-solid-constant p-4">
               <div className="flex flex-wrap items-start gap-8">
-                <Logo type="Full" color="Black Always" />
-                <Logo type="Icon" color="Black Always" />
-                <Logo type="Portrait" color="Black Always" />
-                <Logo type="Wordmark" color="Black Always" />
+                <Logo type="full" color="blackAlways" />
+                <Logo type="icon" color="blackAlways" />
+                <Logo type="portrait" color="blackAlways" />
+                <Logo type="wordmark" color="blackAlways" />
               </div>
             </div>
             <div className="rounded-lg bg-body-black-solid-constant p-4">
               <div className="flex flex-wrap items-start gap-8">
-                <Logo type="Full" color="White Always" />
-                <Logo type="Icon" color="White Always" />
-                <Logo type="Portrait" color="White Always" />
-                <Logo type="Wordmark" color="White Always" />
+                <Logo type="full" color="whiteAlways" />
+                <Logo type="icon" color="whiteAlways" />
+                <Logo type="portrait" color="whiteAlways" />
+                <Logo type="wordmark" color="whiteAlways" />
               </div>
             </div>
 
@@ -828,12 +828,12 @@ function App() {
             </RadioGroup>
 
             <div className="flex flex-wrap items-center gap-4">
-              <Count value={5} variant="Default" />
-              <Count value={12} variant="Brand" />
-              <Count value={8} variant="Pink" />
-              <Count value={3} variant="Info" />
-              <Count value={7} variant="Success" />
-              <Count value={15} variant="Warning" />
+              <Count value={5} variant="default" />
+              <Count value={12} variant="brand" />
+              <Count value={8} variant="pink" />
+              <Count value={3} variant="info" />
+              <Count value={7} variant="success" />
+              <Count value={15} variant="warning" />
             </div>
 
             <div className="flex flex-wrap items-center gap-4">

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -33,7 +33,19 @@ const badgeVariants = {
   },
 } as const;
 
-export type BadgeVariant = keyof typeof badgeVariants.variant;
+export type BadgeVariant =
+  | "default"
+  | "dark"
+  | "success"
+  | "warning"
+  | "error"
+  | "special"
+  | "info"
+  | "online"
+  | "brand"
+  | "pink"
+  | "brandLight"
+  | "pinkLight";
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   /** Visual style variant of the badge */

--- a/src/components/Count/Count.stories.tsx
+++ b/src/components/Count/Count.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["Default", "Brand", "Pink", "Info", "Success", "Warning"],
+      options: ["default", "brand", "pink", "info", "success", "warning"],
     },
     value: {
       control: { type: "number", min: 0, max: 999 },
@@ -38,35 +38,35 @@ export const Default: Story = {
 
 export const Brand: Story = {
   args: {
-    variant: "Brand",
+    variant: "brand",
     value: 12,
   },
 };
 
 export const Pink: Story = {
   args: {
-    variant: "Pink",
+    variant: "pink",
     value: 8,
   },
 };
 
 export const Info: Story = {
   args: {
-    variant: "Info",
+    variant: "info",
     value: 3,
   },
 };
 
 export const Success: Story = {
   args: {
-    variant: "Success",
+    variant: "success",
     value: 7,
   },
 };
 
 export const Warning: Story = {
   args: {
-    variant: "Warning",
+    variant: "warning",
     value: 99,
   },
 };
@@ -102,12 +102,12 @@ export const OnButton: Story = {
 export const MultipleVariants: Story = {
   render: () => (
     <div className="flex items-center gap-4">
-      <Count value={5} variant="Default" />
-      <Count value={12} variant="Brand" />
-      <Count value={8} variant="Pink" />
-      <Count value={3} variant="Info" />
-      <Count value={7} variant="Success" />
-      <Count value={99} variant="Warning" />
+      <Count value={5} variant="default" />
+      <Count value={12} variant="brand" />
+      <Count value={8} variant="pink" />
+      <Count value={3} variant="info" />
+      <Count value={7} variant="success" />
+      <Count value={99} variant="warning" />
     </div>
   ),
 };

--- a/src/components/Count/Count.tsx
+++ b/src/components/Count/Count.tsx
@@ -2,7 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 
-export type CountVariant = "Default" | "Brand" | "Pink" | "Info" | "Success" | "Warning";
+export type CountVariant = "default" | "brand" | "pink" | "info" | "success" | "warning";
 
 function getDisplayValue(value: number, max: number): string {
   return value > max ? `${max}+` : value.toString();
@@ -21,7 +21,7 @@ export interface CountProps extends React.HTMLAttributes<HTMLSpanElement> {
 
 export const Count = React.forwardRef<HTMLSpanElement, CountProps>(
   (
-    { className, variant = "Default", value = 0, max = 99, asChild = false, children, ...props },
+    { className, variant = "default", value = 0, max = 99, asChild = false, children, ...props },
     ref,
   ) => {
     if (value === 0 && !children) {
@@ -35,12 +35,12 @@ export const Count = React.forwardRef<HTMLSpanElement, CountProps>(
         ref={ref}
         className={cn(
           "typography-caption-semibold inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full px-1.5 tabular-nums leading-none",
-          variant === "Default" && "bg-error-500 text-body-white-solid-constant",
-          variant === "Brand" && "bg-brand-green-500 text-body-black-solid-constant",
-          variant === "Pink" && "bg-brand-pink-500 text-body-black-solid-constant",
-          variant === "Info" && "bg-info-500 text-body-white-solid-constant",
-          variant === "Success" && "bg-success-500 text-body-white-solid-constant",
-          variant === "Warning" && "bg-warning-500 text-body-black-solid-constant",
+          variant === "default" && "bg-error-500 text-body-white-solid-constant",
+          variant === "brand" && "bg-brand-green-500 text-body-black-solid-constant",
+          variant === "pink" && "bg-brand-pink-500 text-body-black-solid-constant",
+          variant === "info" && "bg-info-500 text-body-white-solid-constant",
+          variant === "success" && "bg-success-500 text-body-white-solid-constant",
+          variant === "warning" && "bg-warning-500 text-body-black-solid-constant",
           className,
         )}
         {...props}

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -46,8 +46,7 @@ export type IconButtonVariant =
 
 export type IconButtonSize = "24" | "32" | "40" | "52" | "72";
 
-export interface IconButtonProps
-  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "style"> {
+export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual style variant of the icon button */
   variant?: IconButtonVariant;
   /** Size of the button */

--- a/src/components/Logo/Logo.stories.tsx
+++ b/src/components/Logo/Logo.stories.tsx
@@ -15,11 +15,11 @@ const meta = {
   argTypes: {
     type: {
       control: "select",
-      options: ["Full", "Icon", "Wordmark", "Portrait"],
+      options: ["full", "icon", "wordmark", "portrait"],
     },
     color: {
       control: "select",
-      options: ["Full colour", "Decolour", "White Always", "Black Always"],
+      options: ["fullColour", "decolour", "whiteAlways", "blackAlways"],
     },
   },
 } satisfies Meta<typeof Logo>;
@@ -29,22 +29,22 @@ type Story = StoryObj<typeof meta>;
 
 export const FullColour: Story = {
   args: {
-    type: "Full",
-    color: "Full colour",
+    type: "full",
+    color: "fullColour",
   },
 };
 
 export const FullDecolour: Story = {
   args: {
-    type: "Full",
-    color: "Decolour",
+    type: "full",
+    color: "decolour",
   },
 };
 
 export const FullWhiteAlways: Story = {
   args: {
-    type: "Full",
-    color: "White Always",
+    type: "full",
+    color: "whiteAlways",
   },
   parameters: {
     backgrounds: { default: "dark" },
@@ -53,29 +53,29 @@ export const FullWhiteAlways: Story = {
 
 export const FullBlackAlways: Story = {
   args: {
-    type: "Full",
-    color: "Black Always",
+    type: "full",
+    color: "blackAlways",
   },
 };
 
 export const IconFullColour: Story = {
   args: {
-    type: "Icon",
-    color: "Full colour",
+    type: "icon",
+    color: "fullColour",
   },
 };
 
 export const IconDecolour: Story = {
   args: {
-    type: "Icon",
-    color: "Decolour",
+    type: "icon",
+    color: "decolour",
   },
 };
 
 export const IconWhiteAlways: Story = {
   args: {
-    type: "Icon",
-    color: "White Always",
+    type: "icon",
+    color: "whiteAlways",
   },
   parameters: {
     backgrounds: { default: "dark" },
@@ -84,29 +84,29 @@ export const IconWhiteAlways: Story = {
 
 export const IconBlackAlways: Story = {
   args: {
-    type: "Icon",
-    color: "Black Always",
+    type: "icon",
+    color: "blackAlways",
   },
 };
 
 export const WordmarkFullColour: Story = {
   args: {
-    type: "Wordmark",
-    color: "Full colour",
+    type: "wordmark",
+    color: "fullColour",
   },
 };
 
 export const WordmarkDecolour: Story = {
   args: {
-    type: "Wordmark",
-    color: "Decolour",
+    type: "wordmark",
+    color: "decolour",
   },
 };
 
 export const WordmarkWhiteAlways: Story = {
   args: {
-    type: "Wordmark",
-    color: "White Always",
+    type: "wordmark",
+    color: "whiteAlways",
   },
   parameters: {
     backgrounds: { default: "dark" },
@@ -115,29 +115,29 @@ export const WordmarkWhiteAlways: Story = {
 
 export const WordmarkBlackAlways: Story = {
   args: {
-    type: "Wordmark",
-    color: "Black Always",
+    type: "wordmark",
+    color: "blackAlways",
   },
 };
 
 export const PortraitFullColour: Story = {
   args: {
-    type: "Portrait",
-    color: "Full colour",
+    type: "portrait",
+    color: "fullColour",
   },
 };
 
 export const PortraitDecolour: Story = {
   args: {
-    type: "Portrait",
-    color: "Decolour",
+    type: "portrait",
+    color: "decolour",
   },
 };
 
 export const PortraitWhiteAlways: Story = {
   args: {
-    type: "Portrait",
-    color: "White Always",
+    type: "portrait",
+    color: "whiteAlways",
   },
   parameters: {
     backgrounds: { default: "dark" },
@@ -146,7 +146,7 @@ export const PortraitWhiteAlways: Story = {
 
 export const PortraitBlackAlways: Story = {
   args: {
-    type: "Portrait",
-    color: "Black Always",
+    type: "portrait",
+    color: "blackAlways",
   },
 };

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -20,8 +20,8 @@ describe("Logo", () => {
   });
 
   describe("Type variants", () => {
-    it("renders Full type with both icon and wordmark", () => {
-      const { container } = render(<Logo type="Full" />);
+    it("renders full type with both icon and wordmark", () => {
+      const { container } = render(<Logo type="full" />);
       const logo = container.querySelector('[data-testid="logo"]');
       const svg = logo?.querySelector('[data-testid="logo-icon"]');
       const text = logo?.querySelector('[data-testid="logo-wordmark"]');
@@ -30,8 +30,8 @@ describe("Logo", () => {
       expect(text).toBeInTheDocument();
     });
 
-    it("renders Icon type with only icon", () => {
-      const { container } = render(<Logo type="Icon" />);
+    it("renders icon type with only icon", () => {
+      const { container } = render(<Logo type="icon" />);
       const logo = container.querySelector('[data-testid="logo"]');
       const svg = logo?.querySelector("svg");
       const text = logo?.querySelector("span");
@@ -40,8 +40,8 @@ describe("Logo", () => {
       expect(text).not.toBeInTheDocument();
     });
 
-    it("renders Wordmark type with only text", () => {
-      const { container } = render(<Logo type="Wordmark" />);
+    it("renders wordmark type with only text", () => {
+      const { container } = render(<Logo type="wordmark" />);
       const logo = container.querySelector('[data-testid="logo"]');
       const svg = logo?.querySelector('[data-testid="logo-icon"]');
       const text = logo?.querySelector('[data-testid="logo-wordmark"]');
@@ -50,8 +50,8 @@ describe("Logo", () => {
       expect(text).toBeInTheDocument();
     });
 
-    it("renders Portrait type with both icon and wordmark in column", () => {
-      const { container } = render(<Logo type="Portrait" />);
+    it("renders portrait type with both icon and wordmark in column", () => {
+      const { container } = render(<Logo type="portrait" />);
       const logo = container.querySelector('[data-testid="logo"]');
       const svg = logo?.querySelector('[data-testid="logo-icon"]');
       const text = logo?.querySelector('[data-testid="logo-wordmark"]');
@@ -76,25 +76,25 @@ describe("Logo", () => {
     });
 
     it("supports aria-label for icon-only variant", () => {
-      const { container } = render(<Logo type="Icon" aria-label="Fanvue home" />);
+      const { container } = render(<Logo type="icon" aria-label="Fanvue home" />);
       const logo = container.querySelector('[data-testid="logo"]');
       expect(logo).toHaveAttribute("aria-label", "Fanvue home");
     });
 
     it("adds role='img' when aria-label is provided", () => {
-      const { container } = render(<Logo type="Icon" aria-label="Fanvue home" />);
+      const { container } = render(<Logo type="icon" aria-label="Fanvue home" />);
       const logo = container.querySelector('[data-testid="logo"]');
       expect(logo).toHaveAttribute("role", "img");
     });
 
     it("does not add role when aria-label is not provided", () => {
-      const { container } = render(<Logo type="Icon" />);
+      const { container } = render(<Logo type="icon" />);
       const logo = container.querySelector('[data-testid="logo"]');
       expect(logo).not.toHaveAttribute("role");
     });
 
     it("has no accessibility violations with icon-only variant and aria-label", async () => {
-      const { container } = render(<Logo type="Icon" aria-label="Fanvue home" />);
+      const { container } = render(<Logo type="icon" aria-label="Fanvue home" />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cn } from "../../utils/cn";
 
 const getLogoColors = (color: LogoColor, type: LogoType) => {
-  if (color === "Full colour") {
+  if (color === "fullColour") {
     return {
       icon: "var(--color-brand-green-500)",
       iconInner: "var(--color-body-black-solid-constant)",
@@ -10,7 +10,7 @@ const getLogoColors = (color: LogoColor, type: LogoType) => {
     };
   }
 
-  if (color === "Decolour") {
+  if (color === "decolour") {
     return {
       iconClass: "fill-[#151515] dark:fill-[#ffffff]",
       iconInnerClass: "fill-[#ffffff] dark:fill-[#151515]",
@@ -18,21 +18,21 @@ const getLogoColors = (color: LogoColor, type: LogoType) => {
     };
   }
 
-  if (color === "White Always") {
+  if (color === "whiteAlways") {
     return {
       icon:
-        type === "Icon" ? "var(--color-body-white-solid-constant)" : "var(--color-brand-green-500)",
+        type === "icon" ? "var(--color-body-white-solid-constant)" : "var(--color-brand-green-500)",
       iconInner: "var(--color-body-black-solid-constant)",
       textClass: "text-body-white-solid-constant",
     };
   }
 
-  if (color === "Black Always") {
+  if (color === "blackAlways") {
     return {
       icon:
-        type === "Icon" ? "var(--color-body-black-solid-constant)" : "var(--color-brand-green-500)",
+        type === "icon" ? "var(--color-body-black-solid-constant)" : "var(--color-brand-green-500)",
       iconInner:
-        type === "Icon"
+        type === "icon"
           ? "var(--color-body-white-solid-constant)"
           : "var(--color-body-black-solid-constant)",
       textClass: "text-body-black-solid-constant",
@@ -46,8 +46,8 @@ const getLogoColors = (color: LogoColor, type: LogoType) => {
   };
 };
 
-export type LogoType = "Full" | "Icon" | "Wordmark" | "Portrait";
-export type LogoColor = "Full colour" | "Decolour" | "White Always" | "Black Always";
+export type LogoType = "full" | "icon" | "wordmark" | "portrait";
+export type LogoColor = "fullColour" | "decolour" | "whiteAlways" | "blackAlways";
 
 export interface LogoProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Logo layout type (matches Figma "Type" property) */
@@ -107,10 +107,10 @@ const WordmarkSVG = ({ className }: { className?: string }) => {
 };
 
 export const Logo = React.forwardRef<HTMLDivElement, LogoProps>(
-  ({ className, type = "Full", color = "Full colour", ...props }, ref) => {
+  ({ className, type = "full", color = "fullColour", ...props }, ref) => {
     const colors = getLogoColors(color, type);
-    const showIcon = type === "Full" || type === "Icon" || type === "Portrait";
-    const showWordmark = type === "Full" || type === "Wordmark" || type === "Portrait";
+    const showIcon = type === "full" || type === "icon" || type === "portrait";
+    const showWordmark = type === "full" || type === "wordmark" || type === "portrait";
 
     // When aria-label is provided, add role="img" for proper accessibility
     const ariaProps = props["aria-label"] ? { role: "img" as const } : {};
@@ -121,8 +121,8 @@ export const Logo = React.forwardRef<HTMLDivElement, LogoProps>(
         data-testid="logo"
         className={cn(
           "inline-flex items-center text-body-900 dark:text-body-100",
-          type === "Portrait" ? "flex-col" : "flex-row",
-          type === "Full" && "gap-2",
+          type === "portrait" ? "flex-col" : "flex-row",
+          type === "full" && "gap-2",
           className,
         )}
         {...ariaProps}
@@ -133,19 +133,19 @@ export const Logo = React.forwardRef<HTMLDivElement, LogoProps>(
             viewBox="0 0 39 39"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-            className={cn("shrink-0", type === "Icon" ? "h-10 w-10" : "h-8 w-8")}
+            className={cn("shrink-0", type === "icon" ? "h-10 w-10" : "h-8 w-8")}
             aria-hidden="true"
             data-testid="logo-icon"
           >
             <path
               d="M0 11.2339C0 5.02957 5.02957 0 11.2339 0H27.7661C33.9704 0 39 5.02957 39 11.2339V27.7661C39 33.9704 33.9704 39 27.7661 39H11.2339C5.02957 39 0 33.9704 0 27.7661V11.2339Z"
-              {...(color === "Decolour" ? { className: colors.iconClass } : { fill: colors.icon })}
+              {...(color === "decolour" ? { className: colors.iconClass } : { fill: colors.icon })}
             />
             <path
               fillRule="evenodd"
               clipRule="evenodd"
               d="M12.277 30.5825C11.4418 30.5825 11.0355 29.8659 11.2059 29.1153C11.4275 28.0916 12.5838 25.0548 11.7145 23.6899C10.4361 21.6938 7.25562 21.9838 6.5397 20.9602C6.02371 20.2089 6.48355 19.478 7.19738 19.0493C8.79967 18.0257 11.902 18.3157 14.9191 16.3025C16.5895 15.2106 18.1237 12.9927 18.993 11.662C20.2203 9.78527 20.7487 9.39287 23.3226 9.39287H32.3376C33.7574 9.39287 34.202 11.8036 31.8852 12.0686C31.2886 12.1368 29.6977 12.3757 27.4306 12.6487C25.2658 12.9216 20.4589 13.5728 22.351 16.6608C23.7658 18.2816 26.7488 18.0769 27.4306 19.0493C27.9238 19.7225 27.4875 20.4384 26.9505 20.7824C25.3311 21.8061 21.8737 21.6938 18.8566 23.6899C16.8111 25.0548 15.1478 28.0916 14.4659 29.1153C13.9716 29.8659 13.1293 30.5825 12.294 30.5825H12.277Z"
-              {...(color === "Decolour"
+              {...(color === "decolour"
                 ? { className: colors.iconInnerClass }
                 : { fill: colors.iconInner })}
             />

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -17,7 +17,17 @@ const pillVariants = {
   },
 } as const;
 
-export type PillVariant = keyof typeof pillVariants.variant;
+export type PillVariant =
+  | "green"
+  | "grey"
+  | "blue"
+  | "gold"
+  | "pinkLight"
+  | "base"
+  | "brand"
+  | "brandLight"
+  | "beta"
+  | "error";
 
 export interface PillProps extends React.HTMLAttributes<HTMLSpanElement> {
   /** Visual style variant of the pill */

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -10,15 +10,7 @@ import { InfoIcon } from "../Icons/InfoIcon";
 import { SuccessIcon } from "../Icons/SuccessIcon";
 import { WarningIcon } from "../Icons/WarningIcon";
 
-export enum toastVariants {
-  info = "info",
-  warning = "warning",
-  success = "success",
-  error = "error",
-  messageToast = "messageToast",
-}
-
-export type ToastVariant = keyof typeof toastVariants;
+export type ToastVariant = "info" | "warning" | "success" | "error" | "messageToast";
 
 // Override "title" prop to allow React.ReactNode instead of string | undefined
 export interface ToastProps


### PR DESCRIPTION
BREAKING CHANGE: Variant types for Badge, Pill, Count, Logo, and Toast
now use lowercase camelCase string unions instead of mixed casing or enums.

- Normalize CountVariant to lowercase camelCase
- Normalize LogoType and LogoColor to lowercase camelCase
- Make BadgeVariant and PillVariant explicit union types
- Convert ToastVariant from enum to string union type
- Restore style prop on IconButton
- Update showcase app for new variant casing