### PR TITLE
fix(release): remove release-as override blocking new releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "release-as": "1.1.0",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

- Removes `release-as: 1.1.0` from `release-please-config.json` which was forcing every release-please run to create a 1.1.0 release PR
- This override caused duplicate tag errors (`already_exists`) since `ui-v1.1.0` already exists
- Once merged, release-please will auto-detect the next version (1.1.1) based on conventional commits since the `ui-v1.1.0` tag

## Context

The `release-as` was originally added to force a 1.1.0 release but was never cleaned up after the release was created. This caused:
1. PR #88 created the `ui-v1.1.0` GitHub release (but npm publish failed due to a server error)
2. PR #93 was a duplicate 1.1.0 release PR that failed with `already_exists`
3. PR #95 was yet another duplicate — closed and branch deleted

## What happens after merge

1. Release-please will run and create a **1.1.1** release PR (picking up fix commits #92 and #94)
2. Merging that PR will publish `@fanvue/ui@1.1.1` to npm (note: 1.1.0 was never published to npm)

Made with [Cursor](https://cursor.com)