### PR TITLE
fix: TextField shift on focus and improve composability/a11y

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,26 +174,61 @@ function TextFieldShowcase() {
     setValue(e.target.value);
   };
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex max-w-2xl flex-col gap-4">
-        <TextField label="Size 48" placeholder="Placeholder" size="48" />
-        <TextField label="Size 40" placeholder="Placeholder" size="40" />
-        <TextField label="Size 32" placeholder="Placeholder" size="32" />
-        <TextField label="Disabled" placeholder="Placeholder" disabled />
-        <TextField label="Error" placeholder="Placeholder" error errorMessage="Error message" />
-        <TextField label="Left icon" leftIcon={<HomeIcon />} placeholder="Placeholder" />
-        <TextField label="Right icon" rightIcon={<HomeIcon />} placeholder="Placeholder" />
-        <TextField
-          label="Controlled Input"
-          fullWidth
-          placeholder="Placeholder"
-          value={value}
-          onChange={handleChange}
-        />
-        <div className="typography-caption-regular text-body-200">
-          {" "}
-          Current value: {value || "(empty)"}{" "}
-        </div>
+    <div className="flex max-w-2xl flex-col gap-4">
+      <TextField label="Size 48" placeholder="Placeholder" size="48" autoComplete="off" />
+      <TextField label="Size 40" placeholder="Placeholder" size="40" autoComplete="off" />
+      <TextField label="Size 32" placeholder="Placeholder" size="32" autoComplete="off" />
+      <TextField
+        label="With helper"
+        placeholder="Placeholder"
+        helperText="Helper text below"
+        autoComplete="off"
+      />
+      <TextField placeholder="No label" aria-label="Search" autoComplete="off" />
+      <TextField
+        label="Left icon"
+        leftIcon={<HomeIcon />}
+        placeholder="Placeholder"
+        autoComplete="off"
+      />
+      <TextField
+        label="Right icon"
+        rightIcon={<InfoCircleIcon />}
+        placeholder="Placeholder"
+        autoComplete="off"
+      />
+      <TextField
+        label="Both icons"
+        leftIcon={<HomeIcon />}
+        rightIcon={<InfoCircleIcon />}
+        placeholder="Placeholder"
+        autoComplete="off"
+      />
+      <TextField
+        label="Error"
+        placeholder="Placeholder"
+        error
+        errorMessage="Error message"
+        autoComplete="off"
+      />
+      <TextField label="Error + helper" error helperText="Required field" autoComplete="off" />
+      <TextField label="Disabled" placeholder="Placeholder" disabled autoComplete="off" />
+      <TextField
+        label="Disabled with value"
+        defaultValue="Cannot edit"
+        disabled
+        autoComplete="off"
+      />
+      <TextField
+        label="Controlled Input"
+        fullWidth
+        placeholder="Placeholder"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+      />
+      <div className="typography-caption-regular text-body-200">
+        Current value: {value || "(empty)"}
       </div>
     </div>
   );

--- a/src/components/Icons/EyeIcon.tsx
+++ b/src/components/Icons/EyeIcon.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+import type { IconProps } from "./types";
+
+export const EyeIcon = React.forwardRef<SVGSVGElement, IconProps>(
+  ({ className, ...props }, ref) => (
+    <svg
+      ref={ref}
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-hidden="true"
+      className={cn("size-5", className)}
+      {...props}
+    >
+      <path
+        d="M1 10s3-7 9-7 9 7 9 7-3 7-9 7-9-7-9-7Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="10"
+        cy="10"
+        r="3"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+);
+
+EyeIcon.displayName = "EyeIcon";

--- a/src/components/Icons/Icons.test.tsx
+++ b/src/components/Icons/Icons.test.tsx
@@ -10,6 +10,7 @@ import { ChevronRightIcon } from "./ChevronRightIcon";
 import { CrossIcon } from "./CrossIcon";
 import { CrownIcon } from "./CrownIcon";
 import { ErrorCircleIcon } from "./ErrorCircleIcon";
+import { EyeIcon } from "./EyeIcon";
 import { FireIcon } from "./FireIcon";
 import { HomeIcon } from "./HomeIcon";
 import { InfoCircleIcon } from "./InfoCircleIcon";
@@ -33,6 +34,7 @@ const icons = [
   { name: "CrossIcon", Component: CrossIcon },
   { name: "CrownIcon", Component: CrownIcon },
   { name: "ErrorCircleIcon", Component: ErrorCircleIcon },
+  { name: "EyeIcon", Component: EyeIcon },
   { name: "FireIcon", Component: FireIcon },
   { name: "HomeIcon", Component: HomeIcon },
   { name: "InfoCircleIcon", Component: InfoCircleIcon },

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
+import { ErrorCircleIcon } from "../Icons/ErrorCircleIcon";
+import { EyeIcon } from "../Icons/EyeIcon";
 import { HomeIcon } from "../Icons/HomeIcon";
+import { InfoCircleIcon } from "../Icons/InfoCircleIcon";
 import { TextField } from "./TextField";
 
 const meta: Meta<typeof TextField> = {
@@ -60,6 +63,13 @@ export const Default: Story = {
   },
 };
 
+export const WithoutLabel: Story = {
+  args: {
+    placeholder: "No label",
+    "aria-label": "Search",
+  },
+};
+
 export const Size48: Story = {
   args: {
     size: "48",
@@ -105,27 +115,16 @@ export const WithRightIcon: Story = {
     label: "Password",
     type: "password",
     placeholder: "Enter password",
-    rightIcon: (
-      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-label="Show password">
-        <title>Eye</title>
-        <path
-          d="M1 10s3-7 9-7 9 7 9 7-3 7-9 7-9-7-9-7Z"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <circle
-          cx="10"
-          cy="10"
-          r="3"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    ),
+    rightIcon: <EyeIcon />,
+  },
+};
+
+export const WithBothIcons: Story = {
+  args: {
+    label: "Search",
+    placeholder: "Search...",
+    leftIcon: <HomeIcon />,
+    rightIcon: <InfoCircleIcon />,
   },
 };
 
@@ -146,6 +145,18 @@ export const ErrorWithoutMessage: Story = {
     error: true,
     helperText: "This field is required",
     defaultValue: "",
+  },
+};
+
+export const ErrorWithIcons: Story = {
+  args: {
+    label: "Email",
+    placeholder: "you@example.com",
+    error: true,
+    errorMessage: "Invalid email",
+    leftIcon: <HomeIcon />,
+    rightIcon: <ErrorCircleIcon />,
+    defaultValue: "bad-email",
   },
 };
 
@@ -217,6 +228,28 @@ export const ControlledExample: Story = {
       </div>
     );
   },
+};
+
+export const AllStates: Story = {
+  name: "All States",
+  render: () => (
+    <div className="flex w-[375px] flex-col gap-6">
+      <TextField label="Default" placeholder="Placeholder" />
+      <TextField label="With helper" placeholder="Placeholder" helperText="Helper text" />
+      <TextField label="With value" defaultValue="Typed text" />
+      <TextField label="Error" error errorMessage="Error message" defaultValue="invalid" />
+      <TextField label="Disabled" placeholder="Placeholder" disabled />
+      <TextField label="Disabled with value" defaultValue="Value" disabled />
+      <TextField label="Left icon" placeholder="Placeholder" leftIcon={<HomeIcon />} />
+      <TextField label="Right icon" placeholder="Placeholder" rightIcon={<InfoCircleIcon />} />
+      <TextField
+        label="Both icons"
+        placeholder="Placeholder"
+        leftIcon={<HomeIcon />}
+        rightIcon={<InfoCircleIcon />}
+      />
+    </div>
+  ),
 };
 
 export const AllSizeVariants: Story = {

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -1,21 +1,24 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
+import { EyeIcon } from "../Icons/EyeIcon";
+import { HomeIcon } from "../Icons/HomeIcon";
+import { InfoCircleIcon } from "../Icons/InfoCircleIcon";
 import { TextField } from "./TextField";
 
 describe("TextField", () => {
   describe("API", () => {
     it("applies custom className to container", () => {
-      const { container } = render(<TextField className="custom-class" />);
+      const { container } = render(<TextField aria-label="Test" className="custom-class" />);
       const wrapper = container.querySelector('[class*="custom-class"]') as HTMLElement;
       expect(wrapper).toHaveClass("custom-class");
     });
 
     it("forwards ref to input element", () => {
       const ref = React.createRef<HTMLInputElement>();
-      render(<TextField ref={ref} />);
+      render(<TextField aria-label="Test" ref={ref} />);
       expect(ref.current).toBeInstanceOf(HTMLInputElement);
       expect(ref.current?.tagName.toLowerCase()).toBe("input");
     });
@@ -23,11 +26,10 @@ describe("TextField", () => {
     it("associates label with input using htmlFor", () => {
       render(<TextField id="test-input" label="Test Label" />);
       const input = screen.getByRole("textbox");
-      const label = input.closest("label");
-      expect(label).toBeInTheDocument();
+      const label = screen.getByText("Test Label");
+      expect(label.tagName.toLowerCase()).toBe("label");
       expect(label).toHaveAttribute("for", "test-input");
       expect(input).toHaveAttribute("id", "test-input");
-      expect(screen.getByText("Test Label")).toBeInTheDocument();
     });
 
     it("generates unique id when not provided", () => {
@@ -38,7 +40,7 @@ describe("TextField", () => {
     });
 
     it("applies fullWidth className when fullWidth is true", () => {
-      const { container } = render(<TextField fullWidth />);
+      const { container } = render(<TextField aria-label="Test" fullWidth />);
       const wrapper = container.querySelector('[class*="w-full"]') as HTMLElement;
       expect(wrapper).toBeInTheDocument();
     });
@@ -46,33 +48,31 @@ describe("TextField", () => {
 
   describe("sizes", () => {
     it("applies size 48 by default", () => {
-      const { container } = render(<TextField />);
+      const { container } = render(<TextField aria-label="Test" />);
       const inputContainer = container.querySelector('[class*="h-12"]');
       expect(inputContainer).toBeInTheDocument();
     });
 
     it("applies size 40 when specified", () => {
-      const { container } = render(<TextField size="40" />);
+      const { container } = render(<TextField aria-label="Test" size="40" />);
       const inputContainer = container.querySelector('[class*="h-10"]');
       expect(inputContainer).toBeInTheDocument();
     });
 
     it("applies size 32 when specified", () => {
-      const { container } = render(<TextField size="32" />);
+      const { container } = render(<TextField aria-label="Test" size="32" />);
       const inputContainer = container.querySelector('[class*="h-8"]');
       expect(inputContainer).toBeInTheDocument();
     });
   });
 
   describe("label and helper text", () => {
-    it("renders without label text", () => {
-      render(<TextField placeholder="No label" />);
+    it("renders without label text when no label prop", () => {
+      const { container } = render(<TextField aria-label="Test" placeholder="No label" />);
       const input = screen.getByPlaceholderText("No label");
       expect(input).toBeInTheDocument();
-      const label = input.closest("label");
-      expect(label).toBeInTheDocument();
-      const labelSpan = label?.querySelector("span");
-      expect(labelSpan).toBeNull();
+      const textLabel = container.querySelector("label.typography-caption-semibold");
+      expect(textLabel).toBeNull();
     });
 
     it("renders with label", () => {
@@ -81,12 +81,12 @@ describe("TextField", () => {
     });
 
     it("renders with helper text", () => {
-      render(<TextField helperText="Enter your username" />);
+      render(<TextField aria-label="Test" helperText="Enter your username" />);
       expect(screen.getByText("Enter your username")).toBeInTheDocument();
     });
 
     it("associates helper text with input using aria-describedby", () => {
-      render(<TextField id="test-input" helperText="Helper description" />);
+      render(<TextField id="test-input" aria-label="Test" helperText="Helper description" />);
       const input = screen.getByRole("textbox");
       const helperText = screen.getByText("Helper description");
 
@@ -95,7 +95,7 @@ describe("TextField", () => {
     });
 
     it("does not set aria-describedby when helperText is not provided", () => {
-      render(<TextField />);
+      render(<TextField aria-label="Test" />);
       const input = screen.getByRole("textbox");
       expect(input).not.toHaveAttribute("aria-describedby");
     });
@@ -103,41 +103,43 @@ describe("TextField", () => {
 
   describe("error state", () => {
     it("applies error state styling", () => {
-      const { container } = render(<TextField error />);
-      const inputContainer = container.querySelector('div[class*="border-error-500"]');
+      const { container } = render(<TextField aria-label="Test" error />);
+      const inputContainer = container.querySelector('[class*="border-error-500"]');
       expect(inputContainer).toBeInTheDocument();
     });
 
     it("sets aria-invalid when error is true", () => {
-      render(<TextField error />);
+      render(<TextField aria-label="Test" error />);
       const input = screen.getByRole("textbox");
       expect(input).toHaveAttribute("aria-invalid", "true");
     });
 
     it("displays error message when provided", () => {
-      render(<TextField error errorMessage="This field is required" />);
+      render(<TextField aria-label="Test" error errorMessage="This field is required" />);
       expect(screen.getByText("This field is required")).toBeInTheDocument();
     });
 
     it("error message overrides helper text", () => {
-      render(<TextField error helperText="Helper text" errorMessage="Error message" />);
+      render(
+        <TextField aria-label="Test" error helperText="Helper text" errorMessage="Error message" />,
+      );
       expect(screen.getByText("Error message")).toBeInTheDocument();
       expect(screen.queryByText("Helper text")).not.toBeInTheDocument();
     });
 
     it("shows helper text when error is true but no errorMessage", () => {
-      render(<TextField error helperText="Helper text" />);
+      render(<TextField aria-label="Test" error helperText="Helper text" />);
       expect(screen.getByText("Helper text")).toBeInTheDocument();
     });
 
     it("applies error styling to helper text when error is true", () => {
-      render(<TextField error helperText="Helper text" />);
+      render(<TextField aria-label="Test" error helperText="Helper text" />);
       const helperText = screen.getByText("Helper text");
       expect(helperText).toHaveClass("text-error-500");
     });
 
     it("supports disabled state", () => {
-      render(<TextField disabled />);
+      render(<TextField aria-label="Test" disabled />);
       const input = screen.getByRole("textbox");
       expect(input).toBeDisabled();
     });
@@ -145,31 +147,30 @@ describe("TextField", () => {
 
   describe("icons", () => {
     it("renders left icon", () => {
-      render(<TextField leftIcon={<span data-testid="left-icon">🔍</span>} />);
-      expect(screen.getByTestId("left-icon")).toBeInTheDocument();
+      const { container } = render(<TextField aria-label="Test" leftIcon={<HomeIcon />} />);
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
     });
 
     it("renders right icon", () => {
-      render(<TextField rightIcon={<span data-testid="right-icon">👁️</span>} />);
-      expect(screen.getByTestId("right-icon")).toBeInTheDocument();
+      const { container } = render(<TextField aria-label="Test" rightIcon={<EyeIcon />} />);
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
     });
 
     it("renders both left and right icons", () => {
-      render(
-        <TextField
-          leftIcon={<span data-testid="left-icon">🔍</span>}
-          rightIcon={<span data-testid="right-icon">👁️</span>}
-        />,
+      const { container } = render(
+        <TextField aria-label="Test" leftIcon={<HomeIcon />} rightIcon={<InfoCircleIcon />} />,
       );
-      expect(screen.getByTestId("left-icon")).toBeInTheDocument();
-      expect(screen.getByTestId("right-icon")).toBeInTheDocument();
+      const svgs = container.querySelectorAll("svg");
+      expect(svgs).toHaveLength(2);
     });
   });
 
   describe("user interaction", () => {
     it("allows typing in the input", async () => {
       const user = userEvent.setup();
-      render(<TextField />);
+      render(<TextField aria-label="Test" />);
       const input = screen.getByRole("textbox");
       await user.type(input, "Hello");
       expect(input).toHaveValue("Hello");
@@ -178,7 +179,7 @@ describe("TextField", () => {
     it("calls onChange when value changes", async () => {
       const user = userEvent.setup();
       const onChange = vi.fn();
-      render(<TextField onChange={onChange} />);
+      render(<TextField aria-label="Test" onChange={onChange} />);
       const input = screen.getByRole("textbox");
       await user.type(input, "H");
       expect(onChange).toHaveBeenCalled();
@@ -187,56 +188,135 @@ describe("TextField", () => {
     it("supports controlled input", async () => {
       const user = userEvent.setup();
       const onChange = vi.fn();
-      render(<TextField value="test" onChange={onChange} />);
+      render(<TextField aria-label="Test" value="test" onChange={onChange} />);
       const input = screen.getByRole("textbox");
       expect(input).toHaveValue("test");
       await user.type(input, "H");
       expect(onChange).toHaveBeenCalled();
     });
 
-    it("focuses input when label area is clicked", async () => {
+    it("focuses input when clicking the label", async () => {
       const user = userEvent.setup();
-      render(<TextField id="test-input" />);
+      render(<TextField label="Test" />);
       const input = screen.getByRole("textbox");
-      const label = input.closest("label");
+      const label = screen.getByText("Test");
 
-      expect(label).toBeInTheDocument();
-      if (label) {
-        await user.click(label);
-        expect(input).toHaveFocus();
-      }
+      await user.click(label);
+      expect(input).toHaveFocus();
+    });
+  });
+
+  describe("data attributes", () => {
+    it("sets data-disabled on root when disabled", () => {
+      const { container } = render(<TextField aria-label="Test" disabled />);
+      const root = container.firstElementChild;
+      expect(root).toHaveAttribute("data-disabled");
+    });
+
+    it("does not set data-disabled when not disabled", () => {
+      const { container } = render(<TextField aria-label="Test" />);
+      const root = container.firstElementChild;
+      expect(root).not.toHaveAttribute("data-disabled");
+    });
+
+    it("sets data-error on root when error is true", () => {
+      const { container } = render(<TextField aria-label="Test" error />);
+      const root = container.firstElementChild;
+      expect(root).toHaveAttribute("data-error");
+    });
+
+    it("does not set data-error when error is false", () => {
+      const { container } = render(<TextField aria-label="Test" />);
+      const root = container.firstElementChild;
+      expect(root).not.toHaveAttribute("data-error");
+    });
+  });
+
+  describe("border stability", () => {
+    it("always renders a border class on the input container", () => {
+      const { container } = render(<TextField aria-label="Test" />);
+      const inputContainer = container.querySelector('[class*="border"]');
+      expect(inputContainer).toBeInTheDocument();
+      expect(inputContainer).toHaveClass("border");
+      expect(inputContainer).toHaveClass("border-transparent");
+    });
+
+    it("renders border-error-500 instead of border-transparent when error", () => {
+      const { container } = render(<TextField aria-label="Test" error />);
+      const inputContainer = container.querySelector('[class*="border-error-500"]');
+      expect(inputContainer).toBeInTheDocument();
+      expect(inputContainer).toHaveClass("border");
+      expect(inputContainer).not.toHaveClass("border-transparent");
+    });
+
+    it("renders focus ring class on input container", () => {
+      const { container } = render(<TextField aria-label="Test" />);
+      const inputContainer = container.querySelector('[class*="has-focus-visible"]');
+      expect(inputContainer).toBeInTheDocument();
     });
   });
 
   describe("accessibility", () => {
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+    });
+
     it("has no accessibility violations", async () => {
       const { container } = render(<TextField label="Accessible Input" />);
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
 
+    it("has no accessibility violations with aria-label instead of label", async () => {
+      const { container } = render(<TextField aria-label="Search" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
     it("has proper role", () => {
-      render(<TextField />);
+      render(<TextField label="Test" />);
       const input = screen.getByRole("textbox");
       expect(input).toBeInTheDocument();
     });
 
-    it("applies default aria-label when no label is provided", () => {
-      render(<TextField />);
-      const input = screen.getByRole("textbox");
-      expect(input).toHaveAttribute("aria-label", "Text field");
+    it("does not render duplicate labels for the same input", () => {
+      const { container } = render(<TextField label="Username" />);
+      const labels = container.querySelectorAll("label");
+      expect(labels).toHaveLength(1);
     });
 
-    it("does not apply aria-label when label is provided", () => {
-      render(<TextField label="Username" />);
-      const input = screen.getByRole("textbox");
-      expect(input).not.toHaveAttribute("aria-label");
-    });
-
-    it("allows custom aria-label to override default", () => {
+    it("allows custom aria-label via props", () => {
       render(<TextField aria-label="Custom label" />);
       const input = screen.getByRole("textbox");
       expect(input).toHaveAttribute("aria-label", "Custom label");
+    });
+
+    it("warns in dev when no accessible name is provided", () => {
+      render(<TextField />);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no accessible name provided"),
+      );
+    });
+
+    it("does not warn when label is provided", () => {
+      render(<TextField label="Username" />);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when aria-label is provided", () => {
+      render(<TextField aria-label="Search" />);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when aria-labelledby is provided", () => {
+      render(<TextField aria-labelledby="external-label" />);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -23,6 +23,112 @@ export interface TextFieldProps
   fullWidth?: boolean;
 }
 
+const CONTAINER_HEIGHT: Record<TextFieldSize, string> = {
+  "48": "h-12",
+  "40": "h-10",
+  "32": "h-8",
+};
+
+const INPUT_SIZE_CLASSES: Record<TextFieldSize, string> = {
+  "48": "py-3 typography-body-1-regular",
+  "40": "py-2 typography-body-1-regular",
+  "32": "py-2 typography-body-2-regular",
+};
+
+const PADDING_LEFT: Record<TextFieldSize, [base: string, withIcon: string]> = {
+  "48": ["pl-4", "pl-11"],
+  "40": ["pl-4", "pl-11"],
+  "32": ["pl-3", "pl-10"],
+};
+
+const PADDING_RIGHT: Record<TextFieldSize, [base: string, withIcon: string]> = {
+  "48": ["pr-4", "pr-11"],
+  "40": ["pr-4", "pr-11"],
+  "32": ["pr-3", "pr-10"],
+};
+
+const ICON_LEFT: Record<TextFieldSize, string> = {
+  "48": "left-4",
+  "40": "left-4",
+  "32": "left-3",
+};
+
+const ICON_RIGHT: Record<TextFieldSize, string> = {
+  "48": "right-4",
+  "40": "right-4",
+  "32": "right-3",
+};
+
+function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: boolean) {
+  return cn(
+    "relative rounded-xl border bg-neutral-100 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    error ? "border-error-500" : "border-transparent",
+    !disabled && !error && "hover:border-neutral-400",
+    CONTAINER_HEIGHT[size],
+    disabled && "opacity-50",
+  );
+}
+
+function getInputClassName(size: TextFieldSize, hasLeftIcon: boolean, hasRightIcon: boolean) {
+  return cn(
+    "h-full w-full rounded-xl bg-transparent text-body-100 placeholder:text-body-200 placeholder:opacity-40 focus:outline-none disabled:cursor-not-allowed",
+    INPUT_SIZE_CLASSES[size],
+    PADDING_LEFT[size][hasLeftIcon ? 1 : 0],
+    PADDING_RIGHT[size][hasRightIcon ? 1 : 0],
+  );
+}
+
+const ICON_BASE =
+  "pointer-events-none absolute top-1/2 flex size-5 -translate-y-1/2 items-center justify-center text-body-200";
+
+function TextFieldIcon({
+  children,
+  size,
+  side,
+}: {
+  children: React.ReactNode;
+  size: TextFieldSize;
+  side: "left" | "right";
+}) {
+  return (
+    <div className={cn(ICON_BASE, side === "left" ? ICON_LEFT[size] : ICON_RIGHT[size])}>
+      {children}
+    </div>
+  );
+}
+
+function TextFieldHelperText({
+  id,
+  error,
+  children,
+}: {
+  id: string;
+  error: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <p
+      id={id}
+      className={cn(
+        "typography-caption-regular px-2 pt-1 pb-0.5",
+        error ? "text-error-500" : "text-body-200",
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+function warnMissingAccessibleName(label?: string, ariaLabel?: string, ariaLabelledBy?: string) {
+  if (process.env.NODE_ENV !== "production") {
+    if (!label && !ariaLabel && !ariaLabelledBy) {
+      console.warn(
+        "TextField: no accessible name provided. Pass a `label`, `aria-label`, or `aria-labelledby` prop.",
+      );
+    }
+  }
+}
+
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
@@ -44,63 +150,53 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     const generatedId = React.useId();
     const inputId = id || generatedId;
     const helperTextId = `${inputId}-helper`;
+    const bottomText = error && errorMessage ? errorMessage : helperText;
+
+    warnMissingAccessibleName(label, props["aria-label"], props["aria-labelledby"]);
 
     return (
-      <div className={cn("flex flex-col", fullWidth ? "w-full" : "", className)}>
-        <label htmlFor={inputId} className="flex flex-col">
-          {label && (
-            <span className="typography-caption-semibold px-1 pt-1 pb-2 text-body-100">
-              {label}
-            </span>
+      <div
+        className={cn("flex flex-col", fullWidth && "w-full", className)}
+        data-disabled={disabled ? "" : undefined}
+        data-error={error ? "" : undefined}
+      >
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="typography-caption-semibold px-1 pt-1 pb-2 text-body-100"
+          >
+            {label}
+          </label>
+        )}
+
+        <div className={getContainerClassName(size, error, disabled)}>
+          {leftIcon && (
+            <TextFieldIcon size={size} side="left">
+              {leftIcon}
+            </TextFieldIcon>
           )}
 
-          <div
-            className={cn(
-              "flex cursor-text items-center gap-2 rounded-[12px] bg-neutral-100 px-4 transition-colors focus-within:border focus-within:border-neutral-400 hover:border hover:border-neutral-400",
-              size === "48" && "h-12 py-3",
-              size === "40" && "h-10 py-2",
-              size === "32" && "h-8 p-2",
-              error && "border border-error-500",
-              disabled && "cursor-not-allowed opacity-50",
-            )}
-          >
-            {leftIcon && (
-              <div className="flex size-5 shrink-0 items-center justify-center text-body-200">
-                {leftIcon}
-              </div>
-            )}
+          <input
+            ref={ref}
+            id={inputId}
+            disabled={disabled}
+            aria-describedby={bottomText ? helperTextId : undefined}
+            aria-invalid={error || undefined}
+            className={getInputClassName(size, !!leftIcon, !!rightIcon)}
+            {...props}
+          />
 
-            <input
-              ref={ref}
-              id={inputId}
-              disabled={disabled}
-              aria-label={!label ? "Text field" : undefined}
-              aria-describedby={helperText || errorMessage ? helperTextId : undefined}
-              aria-invalid={error ? true : undefined}
-              className={cn(
-                "typography-body-1-regular flex-1 bg-transparent text-body-200 placeholder:text-body-200 placeholder:opacity-40 focus:outline-none disabled:cursor-not-allowed",
-              )}
-              {...props}
-            />
+          {rightIcon && (
+            <TextFieldIcon size={size} side="right">
+              {rightIcon}
+            </TextFieldIcon>
+          )}
+        </div>
 
-            {rightIcon && (
-              <div className="flex size-5 shrink-0 items-center justify-center text-body-200">
-                {rightIcon}
-              </div>
-            )}
-          </div>
-        </label>
-
-        {(helperText || errorMessage) && (
-          <p
-            id={helperTextId}
-            className={cn(
-              "typography-caption-regular px-2 pt-1",
-              error ? "text-error-500" : "text-body-200",
-            )}
-          >
-            {error && errorMessage ? errorMessage : helperText}
-          </p>
+        {bottomText && (
+          <TextFieldHelperText id={helperTextId} error={error}>
+            {bottomText}
+          </TextFieldHelperText>
         )}
       </div>
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export { CrossIcon } from "./components/Icons/CrossIcon";
 export { CrownIcon } from "./components/Icons/CrownIcon";
 export { ErrorCircleIcon } from "./components/Icons/ErrorCircleIcon";
 export { ErrorIcon } from "./components/Icons/ErrorIcon";
+export { EyeIcon } from "./components/Icons/EyeIcon";
 export { FireIcon } from "./components/Icons/FireIcon";
 export { HomeIcon } from "./components/Icons/HomeIcon";
 export { InfoCircleIcon } from "./components/Icons/InfoCircleIcon";


### PR DESCRIPTION
- Fix input text color (text-body-200 → text-body-100) and border handling
- Replace dual <label> with single label + div to prevent duplicate screen reader announcements
- Add dev-mode warning when no accessible name (label/aria-label/aria-labelledby) is provided
- Fix bottom text edge case where empty p could render when errorMessage set without error
- Extract size class maps and helper functions for readability
- Replace inline SVG in stories with new EyeIcon component
- Add new stories (WithoutLabel, WithBothIcons, ErrorWithIcons, AllStates)
- Expand test coverage: data attributes, border stability, a11y warning, duplicate label check