### PR TITLE
fix: target svg via tailwind + add disabled control to icon button stories

### DIFF
--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -35,6 +35,7 @@ const meta = {
       control: "select",
       options: ["24", "32", "40", "52", "72"],
     },
+    disabled: { control: "boolean" },
     counterValue: { control: "number" },
   },
 } satisfies Meta<typeof IconButton>;

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -25,11 +25,11 @@ const iconButtonVariants = {
 };
 
 const iconSizeVariants = {
-  24: "size-4",
-  32: "size-5",
-  40: "size-6",
-  52: "size-7",
-  72: "size-8",
+  24: "[&>svg]:size-4",
+  32: "[&>svg]:size-5",
+  40: "[&>svg]:size-6",
+  52: "[&>svg]:size-7",
+  72: "[&>svg]:size-8",
 } as const;
 
 const sizeVariants = {
@@ -90,10 +90,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         {...props}
       >
         <span
-          className={cn(
-            "flex shrink-0 items-center justify-center overflow-clip",
-            iconSizeVariants[size],
-          )}
+          className={cn("flex shrink-0 items-center justify-center", iconSizeVariants[size])}
           aria-hidden="true"
         >
           {icon}


### PR DESCRIPTION
## Summary
Correctly set icon size according to size prop on icon buttons and adds disabled control to icon button stories

completes ENG-7468

## Changes

- Set svg size according to size prop on IconButton.tsx
- Add disabled control to IconButton.stories.tsx
