### PR TITLE
fix(ci): remove forced status checks for release-please PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,4 @@
 # Chromatic Workflow - Visual regression testing
-# NOTE: If you rename the job, update the CHECKS array in release.yml
-# which sets status checks for release-please PRs via the Statuses API.
 name: Chromatic
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
 # CI Workflow - Runs on all pull requests and pushes to main
-# NOTE: If you add/rename/remove jobs, update the CHECKS array in release.yml
-# which sets status checks for release-please PRs via the Statuses API.
 name: CI
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
-  statuses: write
 
 jobs:
   release:
@@ -29,67 +28,6 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      # Release-please PRs are created by a PAT, which doesn't trigger
-      # pull_request events and therefore never gets CI status checks.
-      # Since the PR only contains version bumps and changelog updates (all
-      # code was already CI-tested when merged to main), we set the required
-      # status checks to success via the Statuses API so the PR can merge.
-      #
-      # Previously this was handled via pull_request_target triggers in the
-      # CI workflows, but that caused phantom "Expected" status checks on
-      # ALL PRs because skipped jobs still register as expected checks.
-      #
-      # IMPORTANT: The CHECKS array must match the required status check
-      # names in branch protection. If you add/rename/remove CI jobs, update
-      # this array to match. Source jobs are in:
-      #   - .github/workflows/ci.yml
-      #   - .github/workflows/chromatic.yml
-      #   - .github/workflows/showcase-preview.yml
-      - name: Set status checks for release-please PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          for attempt in 1 2 3 4 5; do
-            HEAD_SHA=$(gh pr list \
-              --json headRefOid,headRefName \
-              --jq '.[] | select(.headRefName | startswith("release-please--")) | .headRefOid' \
-              | head -1)
-            if [ -n "$HEAD_SHA" ]; then
-              break
-            fi
-            echo "No release-please PR found (attempt $attempt/5), retrying in 2s..."
-            sleep 2
-          done
-
-          if [ -z "$HEAD_SHA" ]; then
-            echo "No open release-please PR found, skipping"
-            exit 0
-          fi
-
-          echo "Setting status checks for release-please PR (SHA: $HEAD_SHA)"
-          CHECKS=(
-            "Lint & Type Check"
-            "Unit & Storybook Tests"
-            "Build"
-            "E2E Tests"
-            "Security Audit"
-            "Visual Regression"
-            "Deploy Preview"
-            "Analyze (actions)"
-            "Analyze (javascript-typescript)"
-            "CodeQL"
-            "Storybook Publish"
-            "UI Tests"
-          )
-          for context in "${CHECKS[@]}"; do
-            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
-              -f state=success \
-              -f context="$context" \
-              -f description="Skipped for release-please PR" \
-              || { echo "Failed to set status check: $context"; exit 1; }
-          done
-          echo "All status checks set to success"
 
       - name: Setup pnpm
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/showcase-preview.yml
+++ b/.github/workflows/showcase-preview.yml
@@ -1,5 +1,3 @@
-# NOTE: If you rename the deploy job, update the CHECKS array in release.yml
-# which sets status checks for release-please PRs via the Statuses API.
 name: Showcase Preview
 
 on:


### PR DESCRIPTION
## Summary
- Removes the step that force-set all CI status checks to "success" on release-please PRs
- Now that release-please uses a PAT (from #149), its PRs trigger CI workflows naturally, making the forced statuses redundant
- The forced statuses were also setting checks to "success" before real CI finished, which could mask failures
- Removes the now-unnecessary `statuses: write` permission
- Cleans up related comments in ci.yml, chromatic.yml, and showcase-preview.yml

## Test plan
- [ ] Merge to main and verify the release-please PR (#150) gets real CI checks running on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)