### PR TITLE
fix(ci): isolate PR comment from gh-pages deploy to fix bad credentials

### DIFF
--- a/.github/workflows/showcase-preview.yml
+++ b/.github/workflows/showcase-preview.yml
@@ -47,6 +47,14 @@ jobs:
           destination_dir: pr-${{ github.event.number }}
           keep_files: true
 
+  comment:
+    name: Comment on PR
+    needs: deploy
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
## Summary

- Moves the "Comment on PR" step in the Showcase Preview workflow from the `deploy` job into its own `comment` job
- The `comment` job gets a fresh `GITHUB_TOKEN` isolated from the `peaceiris/actions-gh-pages` git push operation, fixing the intermittent "Bad credentials" error

## Root cause

The `marocchino/sticky-pull-request-comment@v2` action was getting `401 Bad credentials` when running as a step after `peaceiris/actions-gh-pages@v4` in the same job. The gh-pages action uses the `GITHUB_TOKEN` for a git push to the `gh-pages` branch, which can interfere with the token's validity for subsequent API calls in the same job.

The Chromatic workflow's identical comment step never had this issue because it doesn't use `peaceiris/actions-gh-pages` — confirming the gh-pages action is the differentiating factor.

**This is not related to the release-please PAT.** The error occurs in a completely separate workflow.

## Test plan

- [ ] Verify the Showcase Preview workflow passes on this PR (comment job should succeed)
- [ ] Confirm the Chromatic workflow continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)