### PR TITLE
[ui] ENG-7901 Change Button default size from 48 to 40

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -21,7 +21,7 @@ export type ButtonSize = "48" | "40" | "32" | "24";
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual style variant of the button. @default "primary" */
   variant?: ButtonVariant;
-  /** Height of the button in pixels. @default "48" */
+  /** Height of the button in pixels. @default "40" */
   size?: ButtonSize;
   /** Icon element displayed before the label. */
   leftIcon?: React.ReactNode;
@@ -178,7 +178,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     {
       className,
       variant = "primary",
-      size = "48",
+      size = "40",
       leftIcon,
       rightIcon,
       loading = false,


### PR DESCRIPTION
## Summary
- Changes the `Button` component's default `size` prop from `"48"` to `"40"`
- Updates both the JSDoc `@default` annotation and the destructured default value

## Test plan
- [x] Verify existing stories render correctly with the new default size
- [x] Confirm `size="48"` still works when explicitly passed
- [x] Run `pnpm typecheck` and `pnpm lint` with no errors

Closes ENG-7901


Made with [Cursor](https://cursor.com)