### PR TITLE
fix: prevent pill overflow in button icon wrapper

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -409,6 +409,19 @@ export const WithPillAllSizes: Story = {
   ),
 };
 
+export const WithPillAsRightIcon: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-4">
+      <Button variant="secondary" size="48" rightIcon={<Pill variant="beta">Beta</Pill>}>
+        Register as a Manager
+      </Button>
+      <Button variant="tertiary" size="40" rightIcon={<Pill variant="beta">Beta</Pill>}>
+        Become a Manager
+      </Button>
+    </div>
+  ),
+};
+
 export const AllStatesMatrix: Story = {
   render: () => (
     <div className="flex flex-col gap-4">

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -51,6 +51,14 @@ const ICON_SIZE_CLASS: Record<ButtonSize, string> = {
   "24": "size-3.5",
 };
 
+/** Targets only direct SVG children so non-icon content (e.g. Pill) can size naturally. */
+const ICON_WRAPPER_CLASS: Record<ButtonSize, string> = {
+  "48": "[&>svg]:size-5",
+  "40": "[&>svg]:size-5",
+  "32": "[&>svg]:size-4",
+  "24": "[&>svg]:size-3.5",
+};
+
 const VARIANT_CLASSES: Record<ButtonVariant, string> = {
   primary:
     "bg-neutral-400 text-body-300 hover:bg-brand-green-500 hover:text-body-black-solid-constant active:bg-brand-green-500 active:text-body-black-solid-constant",
@@ -193,10 +201,14 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const Comp = asChild ? Slot : "button";
     const isDisabled = disabled || loading;
-    const iconSizeClass = ICON_SIZE_CLASS[size];
+    const iconSizeClass = ICON_WRAPPER_CLASS[size];
 
     const buttonSpecificProps = !asChild
-      ? { type: "button" as const, "data-testid": "button", disabled: isDisabled }
+      ? {
+          type: "button" as const,
+          "data-testid": "button",
+          disabled: isDisabled,
+        }
       : isDisabled
         ? { "aria-disabled": true }
         : {};


### PR DESCRIPTION
## Summary

- The `leftIcon`/`rightIcon` wrapper applied a fixed `size-*` class (e.g. `size-5` = 20×20px), constraining all content to icon dimensions
- When a `<Pill>` was passed as `rightIcon`, the flex layout only allocated 20px while the Pill rendered at ~70px, causing button text to be clipped
- Switch the wrapper to `[&>svg]:size-*` so only SVG icons are sized — non-icon content like Pills now sizes naturally
- Added `WithPillAsRightIcon` story for visual regression coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)