### PR TITLE
fix(deps): patch minimatch ReDoS vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "overrides": {
       "@isaacs/brace-expansion": ">=5.0.1",
       "qs": ">=6.14.2",
-      "minimatch": ">=10.2.1",
+      "minimatch": ">=10.2.3",
       "rollup": ">=4.59.0",
       "storybook": ">=10.2.10"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   qs: '>=6.14.2'
-  minimatch: '>=10.2.1'
+  minimatch: '>=10.2.3'
   rollup: '>=4.59.0'
   storybook: '>=10.2.10'
 
@@ -3079,9 +3079,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@10.2.1:
-    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -4644,7 +4644,7 @@ snapshots:
       '@rushstack/ts-command-line': 5.1.5(@types/node@25.0.10)
       diff: 8.0.3
       lodash: 4.17.23
-      minimatch: 10.2.1
+      minimatch: 10.2.4
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
@@ -5692,7 +5692,7 @@ snapshots:
       '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.27
       alien-signals: 0.4.14
-      minimatch: 10.2.1
+      minimatch: 10.2.4
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
@@ -6271,7 +6271,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 10.2.1
+      minimatch: 10.2.4
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -6280,7 +6280,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.2.1
+      minimatch: 10.2.4
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -6997,7 +6997,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.2.1:
+  minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.2
 


### PR DESCRIPTION
## Summary

- Bumps pnpm `minimatch` override from `>=10.2.1` to `>=10.2.3`
- Resolves two high-severity ReDoS vulnerabilities:
  - [GHSA-7r86-cg39-jmmj](https://github.com/advisories/GHSA-7r86-cg39-jmmj) — combinatorial backtracking via multiple non-adjacent GLOBSTAR segments
  - [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) — catastrophically backtracking regular expressions from nested `*()` extglobs

## Affected transitive paths

- `@storybook/react-vite` → `glob` → `minimatch@10.2.1`
- `style-dictionary` → `@bundled-es-modules/glob` → `glob` → `minimatch@10.2.1`
- `vite-plugin-dts` → `@microsoft/api-extractor` → `minimatch@10.2.1`

## Test plan

- [x] `pnpm audit --audit-level=high` passes (0 high vulnerabilities)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)