### PR TITLE
fix(Select): truncate long text in trigger

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -151,7 +151,7 @@ export const Select = React.forwardRef<
                 disabled && "cursor-not-allowed opacity-50",
               )}
             >
-              <div className="flex items-center gap-2">
+              <div className="flex min-w-0 items-center gap-2">
                 {leftIcon && (
                   <span
                     className="flex size-5 shrink-0 items-center justify-center text-body-200"


### PR DESCRIPTION
## Summary
- Add `min-w-0` to the Select trigger's inner flex container so long option text (e.g. "United Kingdom of Great Britain and Northern Ireland") is properly truncated with ellipsis instead of wrapping to multiple lines
- The `SelectPrimitive.Value` already has `truncate` but the parent div's implicit `min-width: auto` prevented the flex item from shrinking below its content width

🤖 Generated with [Claude Code](https://claude.com/claude-code)