### PR TITLE
fix(Chip): improve hover styles and add toggle stories

### DIFF
--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
 import { CheckCircleIcon } from "../Icons/CheckCircleIcon";
 import { CrossIcon } from "../Icons/CrossIcon";
 import { Chip } from "./Chip";
@@ -247,6 +248,37 @@ export const PaymentMethodDisabled: Story = {
     leftIcon: <PaymentLogo label="P" color="#003087" />,
     children: "PayPal",
     disabled: true,
+  },
+};
+
+export const Toggle: Story = {
+  render: () => {
+    const [selected, setSelected] = useState(false);
+    return (
+      <Chip selected={selected} onClick={() => setSelected((s) => !s)}>
+        Click to toggle
+      </Chip>
+    );
+  },
+};
+
+export const FilterGroup: Story = {
+  render: () => {
+    const [active, setActive] = useState<string>("all");
+    const filters = [
+      { id: "all", label: "All 32" },
+      { id: "polls", label: "Polls (26)" },
+      { id: "collection", label: "Poll collection test" },
+    ];
+    return (
+      <div className="flex flex-wrap gap-2">
+        {filters.map((f) => (
+          <Chip key={f.id} selected={active === f.id} onClick={() => setActive(f.id)}>
+            {f.label}
+          </Chip>
+        ))}
+      </div>
+    );
   },
 };
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -83,13 +83,8 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           isInteractive &&
             !disabled &&
             !isDark &&
-            selected &&
-            "hover:bg-brand-green-500 hover:text-body-black-solid-constant active:bg-brand-green-500 active:text-body-black-solid-constant",
-          isInteractive &&
-            !disabled &&
-            !isDark &&
             !selected &&
-            "hover:bg-hover-300 active:bg-hover-300",
+            "hover:bg-brand-green-50 active:bg-brand-green-50",
           // Focus
           "focus-visible:shadow-focus-ring focus-visible:outline-none",
           // Disabled


### PR DESCRIPTION
## Summary
- **Unselected chip hover** was barely visible (`hover-300` at 10% white vs `neutral-100` at 8% base). Changed to `brand-green-50` so hovering previews the selected state.
- **Selected chip hover** jumped to bright neon green (`brand-green-500` at 100% opacity) which looked jarring for a toggle control. Removed entirely — no intermediate green token exists.
- Added **Toggle** story with interactive click-to-select/deselect behaviour.
- Added **FilterGroup** story showcasing a realistic filter bar (All 32, Polls (26), Poll collection test).

## Test plan
- [x] All 20 existing Chip tests pass
- [x] Visually verify unselected chip hover shows green preview
- [x] Visually verify selected chip hover no longer flashes bright green
- [x] Verify Toggle story toggles on click
- [x] Verify FilterGroup story switches active chip on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)