### PR TITLE
[ui] ENG-8074 Add alert variant to Count and make default neutral

### DIFF
--- a/src/components/Count/Count.stories.tsx
+++ b/src/components/Count/Count.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["default", "brand", "pink", "info", "success", "warning"],
+      options: ["default", "alert", "brand", "pink", "info", "success", "warning"],
     },
     value: {
       control: { type: "number", min: 0, max: 999 },
@@ -32,6 +32,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    value: 5,
+  },
+};
+
+export const Alert: Story = {
+  args: {
+    variant: "alert",
     value: 5,
   },
 };
@@ -94,7 +101,7 @@ export const OnButton: Story = {
   render: () => (
     <Button variant="tertiary" size="40" className="relative">
       Messages
-      <Count value={24} className="absolute -top-2 -right-2" />
+      <Count value={24} variant="alert" className="absolute -top-2 -right-2" />
     </Button>
   ),
 };
@@ -103,6 +110,7 @@ export const MultipleVariants: Story = {
   render: () => (
     <div className="flex items-center gap-4">
       <Count value={5} variant="default" />
+      <Count value={3} variant="alert" />
       <Count value={12} variant="brand" />
       <Count value={8} variant="pink" />
       <Count value={3} variant="info" />

--- a/src/components/Count/Count.tsx
+++ b/src/components/Count/Count.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "../../utils/cn";
 
 /** Colour variant for the count badge. */
-export type CountVariant = "default" | "brand" | "pink" | "info" | "success" | "warning";
+export type CountVariant = "default" | "alert" | "brand" | "pink" | "info" | "success" | "warning";
 
 /** Size of the count badge, aligned with button and icon-button sizes. */
 export type CountSize = "16" | "24" | "32";
@@ -63,7 +63,8 @@ export const Count = React.forwardRef<HTMLSpanElement, CountProps>(
           size === "16" && "h-3 min-w-3 px-0.5 text-[8px]",
           size === "24" && "h-4 min-w-4 px-1 text-[10px]",
           size === "32" && "h-5 min-w-5 px-1.5 text-[12px]",
-          variant === "default" && "bg-error-500 text-body-white-solid-constant",
+          variant === "default" && "bg-body-100 text-body-300",
+          variant === "alert" && "bg-error-500 text-body-white-solid-constant",
           variant === "brand" && "bg-brand-green-500 text-body-black-solid-constant",
           variant === "pink" && "bg-brand-pink-500 text-body-black-solid-constant",
           variant === "info" && "bg-info-500 text-body-white-solid-constant",

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -127,6 +127,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         {counterValue !== undefined && (
           <Count
             value={counterValue}
+            variant="alert"
             size={countSizeMap[size]}
             className="absolute -top-0.5 -right-0.5"
           />


### PR DESCRIPTION
## Summary

- Adds a new `"alert"` variant to the `Count` component that preserves the current red (`bg-error-500`) styling
- Changes the `"default"` variant to a neutral, theme-aware style: dark badge on light theme (`bg-body-100`), white badge on dark theme — matching the old design system
- Updates `IconButton` to explicitly use `variant="alert"` so its counter badge remains red
- Updates stories to showcase all variants including the new `alert`

**BREAKING CHANGE:** The `Count` default variant is now neutral instead of red. Consumers who relied on the red default should switch to `variant="alert"`.

## Linear

https://linear.app/fanvue/issue/ENG-8074/add-alert-variant-to-count-and-make-default-neutral

## Test plan

- [ ] Verify `Count` default variant renders with neutral colors (dark on light theme, white on dark)
- [ ] Verify `Count variant="alert"` renders with red (`error-500`) background
- [ ] Verify `IconButton` counter badge remains red (uses `variant="alert"`)
- [ ] Check all variant stories render correctly in Storybook
- [ ] Verify theme switching works correctly for the default variant

Made with [Cursor](https://cursor.com)