### PR TITLE
feat(Badge): migrate to design tokens

### DIFF
--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -55,7 +55,7 @@ describe("Badge", () => {
     it("renders correct dot color for dark variant", () => {
       const { container } = render(<Badge variant="dark">Dark</Badge>);
       const dot = container.querySelector('[aria-hidden="true"].rounded-full');
-      expect(dot).toHaveClass("bg-body-300");
+      expect(dot).toHaveClass("bg-foreground-inverse");
     });
   });
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -4,32 +4,40 @@ import { cn } from "../../utils/cn";
 
 const badgeVariants = {
   variant: {
-    default: "bg-neutral-100 text-neutral-400",
-    dark: "bg-background-800 text-body-300 dark:text-body-white-solid-constant",
-    success: "bg-neutral-100 text-neutral-400",
-    warning: "bg-neutral-100 text-neutral-400",
-    error: "bg-neutral-100 text-neutral-400",
-    special: "bg-neutral-100 text-neutral-400",
-    info: "bg-neutral-100 text-neutral-400",
-    online: "bg-background-200 text-brand-green-500",
-    brand: "bg-brand-green-500 text-body-black-solid-constant",
-    pink: "bg-brand-pink-500 text-body-black-solid-constant",
-    brandLight: "bg-brand-green-50 text-body-black-solid-constant",
-    pinkLight: "bg-brand-pink-50 text-body-black-solid-constant",
+    default: "gap-2 bg-neutral-50 text-neutral-solid",
+    dark: "gap-2 bg-primitives-color-blackalpha-600 text-foreground-onaccentinverse",
+    success: "gap-2 bg-neutral-50 text-neutral-solid",
+    warning: "gap-2 bg-neutral-50 text-neutral-solid",
+    error: "gap-2 bg-neutral-50 text-neutral-solid",
+    special: "gap-2 bg-neutral-50 text-neutral-solid",
+    info: "gap-2 bg-neutral-50 text-neutral-solid",
+    online: "gap-1 bg-surface-page text-brand-accent-default",
+    brand: "gap-1 bg-brand-accent-default text-foreground-onaccent",
+    pink: "gap-1 bg-brand-secondary-default text-foreground-onaccent",
+    brandLight: "gap-1 bg-brand-accent-muted text-foreground-default",
+    pinkLight: "gap-1 bg-brand-secondary-muted text-foreground-default",
+    successBg: "gap-1 bg-success-background text-foreground-default",
+    warningBg: "gap-1 bg-warning-background text-foreground-default",
+    errorBg: "gap-1 bg-error-background text-foreground-default",
+    infoBg: "gap-1 bg-info-background text-foreground-default",
   },
   dotColor: {
-    default: "bg-body-black-solid-constant",
-    dark: "bg-body-300 dark:bg-body-white-solid-constant",
-    success: "bg-success-500",
-    warning: "bg-warning-500",
-    error: "bg-error-500",
-    special: "bg-special-500",
-    info: "bg-info-500",
-    online: "bg-brand-green-500",
-    brand: "bg-body-black-solid-constant",
-    pink: "bg-body-black-solid-constant",
-    brandLight: "bg-body-black-solid-constant",
-    pinkLight: "bg-body-black-solid-constant",
+    default: "bg-foreground-default",
+    dark: "bg-foreground-default",
+    success: "bg-success-default",
+    warning: "bg-warning-default",
+    error: "bg-error-default",
+    special: "bg-special-default",
+    info: "bg-info-default",
+    online: "bg-brand-accent-default",
+    brand: "bg-foreground-onaccent",
+    pink: "bg-foreground-onaccent",
+    brandLight: "bg-foreground-default",
+    pinkLight: "bg-foreground-default",
+    successBg: "bg-success-default",
+    warningBg: "bg-warning-default",
+    errorBg: "bg-error-default",
+    infoBg: "bg-info-default",
   },
 } as const;
 
@@ -46,7 +54,11 @@ export type BadgeVariant =
   | "brand"
   | "pink"
   | "brandLight"
-  | "pinkLight";
+  | "pinkLight"
+  | "successBg"
+  | "warningBg"
+  | "errorBg"
+  | "infoBg";
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   /** Visual style variant of the badge. @default "default" */
@@ -91,7 +103,7 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
         data-testid="badge"
         className={cn(
           // Base styles
-          "typography-caption-semibold inline-flex h-5 items-center gap-2 rounded-full px-2",
+          "typography-semibold-body-sm inline-flex h-5 items-center rounded-full px-2",
           // Variant styles
           badgeVariants.variant[variant],
           // Manual CSS overrides


### PR DESCRIPTION
Breaks out token migration for `Badge` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Badge component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>