### PR TITLE
feat(Button): migrate to design tokens

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -74,7 +74,7 @@ const VARIANT_CLASSES: Record<ButtonVariant, string> = {
   destructive:
     "bg-error-default text-foreground-onaccentinverse hover:bg-brand-accent-muted hover:text-foreground-default active:bg-brand-accent-muted active:text-foreground-default",
   white:
-    "bg-primitives-color-gray-white text-foreground-onaccent hover:bg-brand-accent-muted hover:text-foreground-default active:bg-brand-accent-muted active:text-foreground-default",
+    "bg-foreground-onaccentinverse text-foreground-onaccent hover:bg-brand-accent-muted hover:text-foreground-default active:bg-brand-accent-muted active:text-foreground-default",
   tertiaryDestructive:
     "bg-transparent text-error-default hover:bg-error-background active:bg-error-background",
   text: "bg-transparent text-foreground-default hover:underline active:underline",


### PR DESCRIPTION
Breaks out token migration for `Button` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Button component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>