### PR TITLE
feat(Loader): migrate to design tokens

### DIFF
--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -56,7 +56,7 @@ export const Loader = React.forwardRef<HTMLDivElement, LoaderProps>(
           )}
           aria-label={ariaLabel ?? "loading"}
         >
-          <SpinnerIcon className="size-9 animate-spin text-body-200" />
+          <SpinnerIcon className="size-9 animate-spin text-foreground-secondary" />
         </output>
       </div>
     );


### PR DESCRIPTION
Breaks out token migration for `Loader` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Loader component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>