### PR TITLE
feat(PasswordField): migrate to design tokens

### DIFF
--- a/src/components/PasswordField/PasswordField.stories.tsx
+++ b/src/components/PasswordField/PasswordField.stories.tsx
@@ -211,7 +211,7 @@ export const ControlledExample: Story = {
           errorMessage={error ? "Password must be at least 8 characters" : undefined}
           helperText={!error ? `${value.length} characters` : undefined}
         />
-        <div className="typography-caption-regular text-body-200">
+        <div className="typography-regular-body-sm text-foreground-secondary">
           Current value: {value || "(empty)"}
         </div>
       </div>

--- a/src/components/PasswordField/PasswordField.test.tsx
+++ b/src/components/PasswordField/PasswordField.test.tsx
@@ -105,7 +105,7 @@ describe("PasswordField", () => {
       const { container } = render(<PasswordField placeholder="No label" />);
       const input = screen.getByPlaceholderText("No label");
       expect(input).toBeInTheDocument();
-      const textLabel = container.querySelector("label.typography-caption-semibold");
+      const textLabel = container.querySelector("label.typography-semibold-body-sm");
       expect(textLabel).toBeNull();
     });
 
@@ -138,7 +138,7 @@ describe("PasswordField", () => {
   describe("error state", () => {
     it("applies error state styling", () => {
       const { container } = render(<PasswordField error />);
-      const inputContainer = container.querySelector('div[class*="border-error-500"]');
+      const inputContainer = container.querySelector('div[class*="border-error-default"]');
       expect(inputContainer).toBeInTheDocument();
     });
 
@@ -167,7 +167,7 @@ describe("PasswordField", () => {
     it("applies error styling to helper text when error is true", () => {
       render(<PasswordField error helperText="Helper text" />);
       const helperText = screen.getByText("Helper text");
-      expect(helperText).toHaveClass("text-error-500");
+      expect(helperText).toHaveClass("text-error-default");
     });
 
     it("supports disabled state", () => {

--- a/src/components/PasswordField/PasswordField.tsx
+++ b/src/components/PasswordField/PasswordField.tsx
@@ -25,7 +25,7 @@ export const PasswordField = React.forwardRef<HTMLInputElement, PasswordFieldPro
         disabled={disabled}
         aria-label={showPassword ? "Hide password" : "Show password"}
         tabIndex={-1}
-        className="flex size-5 shrink-0 items-center justify-center text-body-200 transition-colors hover:text-body-100 focus:outline-none disabled:cursor-not-allowed"
+        className="flex size-5 shrink-0 items-center justify-center text-foreground-secondary transition-colors hover:text-foreground-default focus:outline-none disabled:cursor-not-allowed"
       >
         {showPassword ? <EyeClosedIcon /> : <EyeIcon />}
       </button>


### PR DESCRIPTION
Breaks out token migration for `PasswordField` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate PasswordField component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>