### PR TITLE
feat(Pill): migrate to design tokens

### DIFF
--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -4,16 +4,16 @@ import { cn } from "../../utils/cn";
 
 const pillVariants = {
   variant: {
-    green: "bg-success-50 text-success-500",
-    grey: "bg-neutral-100 text-body-200",
-    blue: "bg-info-50 text-info-500",
-    gold: "bg-warning-50 text-warning-500",
-    pinkLight: "bg-brand-pink-50 text-body-100",
-    base: "bg-neutral-400 text-body-300",
-    brand: "bg-brand-green-500 text-body-black-solid-constant",
-    brandLight: "bg-brand-green-50 text-body-black-solid-constant",
-    beta: "bg-brand-pink-500 text-body-black-solid-constant",
-    error: "bg-error-500 text-error-50",
+    green: "bg-success-background text-success-default",
+    grey: "bg-neutral-100 text-foreground-secondary",
+    blue: "bg-info-background text-info-default",
+    gold: "bg-warning-background text-warning-default",
+    pinkLight: "bg-brand-secondary-muted text-foreground-default",
+    base: "bg-neutral-400 text-foreground-inverse",
+    brand: "bg-brand-accent-default text-foreground-onaccent",
+    brandLight: "bg-brand-accent-muted text-foreground-onaccent",
+    beta: "bg-brand-secondary-default text-foreground-onaccent",
+    error: "bg-error-default text-error-background",
   },
 } as const;
 
@@ -64,7 +64,7 @@ export const Pill = React.forwardRef<HTMLSpanElement, PillProps>(
           // Base styles
           "inline-flex items-center justify-center gap-2 rounded-full px-3 py-1",
           // Typography
-          "typography-caption-semibold",
+          "typography-semibold-body-sm",
           // Variant styles
           pillVariants.variant[variant],
           // Manual CSS overrides


### PR DESCRIPTION
Breaks out token migration for `Pill` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Pill component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>