### PR TITLE
feat(Slider): migrate to design tokens [SIMON]

### DIFF
--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -158,7 +158,7 @@ export const ControlledExample: Story = {
           minLabel="0"
           maxLabel="100"
         />
-        <p className="text-body-200 text-sm">
+        <p className="text-foreground-secondary text-sm">
           Current value: <strong>{value[0]}</strong>
         </p>
       </div>

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -86,7 +86,7 @@ export const Slider = React.forwardRef<
         {...props}
       >
         <SliderPrimitive.Track className="relative h-3 w-full overflow-hidden rounded-full border border-neutral-100 bg-neutral-100">
-          <SliderPrimitive.Range className="absolute h-full rounded-full bg-brand-green-500" />
+          <SliderPrimitive.Range className="absolute h-full rounded-full bg-brand-accent-default" />
         </SliderPrimitive.Track>
 
         {Array.from({ length: thumbCount }, (_, i) => (

--- a/src/components/Slider/SliderLayout.tsx
+++ b/src/components/Slider/SliderLayout.tsx
@@ -22,16 +22,23 @@ export function SliderLayout({
     return (
       <div className="flex items-center gap-3">
         {label && (
-          <span id={labelId} className="typography-body-1-semibold shrink-0 text-body-100">
+          <span
+            id={labelId}
+            className="typography-semibold-body-lg shrink-0 text-foreground-default"
+          >
             {label}
           </span>
         )}
         {minLabel && (
-          <span className="typography-body-2-regular shrink-0 text-body-200">{minLabel}</span>
+          <span className="typography-regular-body-md shrink-0 text-foreground-secondary">
+            {minLabel}
+          </span>
         )}
         {children}
         {maxLabel && (
-          <span className="typography-body-2-regular shrink-0 text-body-200">{maxLabel}</span>
+          <span className="typography-regular-body-md shrink-0 text-foreground-secondary">
+            {maxLabel}
+          </span>
         )}
       </div>
     );
@@ -40,12 +47,12 @@ export function SliderLayout({
   return (
     <div className="flex w-full flex-col gap-3">
       {label && (
-        <span id={labelId} className="typography-body-1-semibold text-body-100">
+        <span id={labelId} className="typography-semibold-body-lg text-foreground-default">
           {label}
         </span>
       )}
       {(minLabel || maxLabel) && (
-        <div className="flex w-full items-start justify-between text-body-200 text-sm leading-[18px]">
+        <div className="flex w-full items-start justify-between text-foreground-secondary text-sm leading-[18px]">
           {minLabel && <span>{minLabel}</span>}
           {maxLabel && <span className="ml-auto">{maxLabel}</span>}
         </div>

--- a/src/components/Slider/SliderThumb.tsx
+++ b/src/components/Slider/SliderThumb.tsx
@@ -43,21 +43,21 @@ export function SliderThumb({
         }
       }}
       className={cn(
-        "flex size-6 items-center justify-center rounded-full border border-neutral-100 bg-background-inverse-solid shadow-sm",
+        "flex size-6 items-center justify-center rounded-full border border-neutral-100 bg-surface-page shadow-sm",
         "transition-shadow duration-150",
-        "hover:ring-2 hover:ring-brand-green-500",
-        "not-data-disabled:active:ring-2 not-data-disabled:active:ring-brand-green-500",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background-inverse-solid",
+        "hover:ring-2 hover:ring-brand-accent-default",
+        "not-data-disabled:active:ring-2 not-data-disabled:active:ring-brand-accent-default",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-tertiary-default focus-visible:ring-offset-2 focus-visible:ring-offset-surface-page",
         "data-disabled:cursor-not-allowed",
       )}
     >
-      <span className="block size-3 rounded-full bg-brand-green-500 shadow-[inset_0px_1px_2px_0px_rgba(0,0,0,0.1)]" />
+      <span className="block size-3 rounded-full bg-brand-accent-default shadow-[inset_0px_1px_2px_0px_rgba(0,0,0,0.1)]" />
 
       {showTooltip && (
         <span
           role="tooltip"
           data-slider-tooltip
-          className="typography-caption-semibold pointer-events-none absolute bottom-full mb-2 rounded-3xl bg-background-solid px-2 py-1 text-background-inverse-solid shadow-sm"
+          className="typography-semibold-body-sm pointer-events-none absolute bottom-full mb-2 rounded-3xl bg-surface-pageInverse px-2 py-1 text-surface-page shadow-sm"
         />
       )}
     </SliderPrimitive.Thumb>


### PR DESCRIPTION
Breaks out token migration for `Slider` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Slider component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>