### PR TITLE
feat(Snackbar): migrate to design tokens [SIMON]

### DIFF
--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -5,7 +5,7 @@ import { VipBadgeIcon } from "../Icons/VipBadgeIcon";
 import { Snackbar } from "./Snackbar";
 
 const DefaultMessage = (
-  <span className="typography-body-2-semibold">
+  <span className="typography-semibold-body-md">
     <span>@user.with.username</span> changed their subscription price to <span>$43.99</span> per
     month
   </span>
@@ -74,7 +74,7 @@ export const DefaultWithCustomSlots: Story = {
       </Button>
     ),
     secondarySlot: (
-      <a href="#dismiss" className="typography-link-small text-body-200">
+      <a href="#dismiss" className="typography-semibold-link-md text-foreground-secondary">
         Custom link
       </a>
     ),
@@ -113,7 +113,7 @@ export const VipEarnClosable: Story = {
         <button
           type="button"
           onClick={() => setVisible(true)}
-          className="cursor-pointer text-body-100 underline"
+          className="cursor-pointer text-foreground-default underline"
         >
           Show again
         </button>
@@ -148,7 +148,7 @@ export const VipEarnWithCustomSlot: Story = {
     title: "You're killing it! You've earned 1,000pts",
     description: "Find out how to redeem them, and earn more...",
     primarySlot: (
-      <a href="#redeem" className="typography-link-small text-brand-purple-500">
+      <a href="#redeem" className="typography-semibold-link-md text-brand-tertiary-default">
         Redeem now
       </a>
     ),
@@ -196,7 +196,7 @@ export const WelcomeWithCustomSlots: Story = {
       </Button>
     ),
     secondarySlot: (
-      <a href="#explore" className="text-body-200 text-sm underline">
+      <a href="#explore" className="text-foreground-secondary text-sm underline">
         Explore instead
       </a>
     ),
@@ -224,7 +224,7 @@ export const DefaultClosable: Story = {
         <button
           type="button"
           onClick={() => setVisible(true)}
-          className="cursor-pointer text-body-100 underline"
+          className="cursor-pointer text-foreground-default underline"
         >
           Show again
         </button>
@@ -281,7 +281,7 @@ export const MultipleDismissible: Story = {
             <button
               type="button"
               onClick={() => setSnackbars({ vipEarn: true, default: true, welcome: true })}
-              className="cursor-pointer text-body-100 underline"
+              className="cursor-pointer text-foreground-default underline"
             >
               Reset all
             </button>

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -112,8 +112,12 @@ function VipEarnContent({
       )}
       <div className="flex min-w-0 flex-1 flex-col gap-4">
         <div className="flex flex-col">
-          {title && <p className="typography-body-1-semibold text-body-100 leading-6">{title}</p>}
-          {description && <p className="typography-body-2-regular text-body-200">{description}</p>}
+          {title && (
+            <p className="typography-semibold-body-lg text-foreground-default leading-6">{title}</p>
+          )}
+          {description && (
+            <p className="typography-regular-body-md text-foreground-secondary">{description}</p>
+          )}
         </div>
         {showActions && primary && <div className="self-start">{primary}</div>}
       </div>
@@ -152,9 +156,11 @@ function WelcomeContent({
 
   return (
     <>
-      <div className="flex flex-col items-center gap-2 px-8 text-center text-body-100">
-        {title && <p className="typography-heading-4 text-body-100">{title}</p>}
-        {description && <p className="typography-body-2-regular text-body-200">{description}</p>}
+      <div className="flex flex-col items-center gap-2 px-8 text-center text-foreground-default">
+        {title && <p className="typography-bold-heading-xs text-foreground-default">{title}</p>}
+        {description && (
+          <p className="typography-regular-body-md text-foreground-secondary">{description}</p>
+        )}
       </div>
       {showActions && (primary || secondary) && (
         <div className="flex w-full flex-col gap-4 px-8 sm:flex-row sm:*:flex-1">
@@ -197,7 +203,7 @@ function DefaultContent({
 
   return (
     <>
-      <div className="typography-body-1-medium flex min-w-0 flex-1 items-center self-stretch text-body-100">
+      <div className="typography-semibold-body-lg flex min-w-0 flex-1 items-center self-stretch text-foreground-default">
         {children}
       </div>
       {showActions && (primary || secondary) && (
@@ -260,11 +266,10 @@ export const Snackbar = React.forwardRef<HTMLDivElement, SnackbarProps>(
         className={cn(
           "flex gap-4 rounded-2xl",
           (variant === "default" || variant === "vipEarn") &&
-            "border border-neutral-50 bg-background-200 p-4 backdrop-blur-md",
+            "border border-neutral-50 bg-surface-container p-4 backdrop-blur-md",
           variant === "default" && "flex-wrap items-start",
           variant === "vipEarn" && "items-start",
-          variant === "welcome" &&
-            "relative flex-col items-center bg-background-inverse-solid py-6",
+          variant === "welcome" && "relative flex-col items-center bg-surface-page py-6",
           className,
         )}
         {...props}


### PR DESCRIPTION
Breaks out token migration for `Snackbar` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Snackbar component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>