### PR TITLE
feat(Switch): migrate to design tokens [SIMON]

### DIFF
--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -104,7 +104,7 @@ export const ControlledExample: Story = {
     return (
       <div className="flex items-center gap-3">
         <Switch checked={checked} onCheckedChange={setChecked} aria-label="Toggle feature" />
-        <span className="text-body-200 text-sm">{checked ? "On" : "Off"}</span>
+        <span className="text-foreground-secondary text-sm">{checked ? "On" : "Off"}</span>
       </div>
     );
   },
@@ -116,11 +116,11 @@ export const UncontrolledExample: Story = {
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-3">
         <Switch aria-label="Default unchecked" />
-        <span className="text-body-200 text-sm">Default (unchecked)</span>
+        <span className="text-foreground-secondary text-sm">Default (unchecked)</span>
       </div>
       <div className="flex items-center gap-3">
         <Switch defaultChecked aria-label="Default checked" />
-        <span className="text-body-200 text-sm">Default checked</span>
+        <span className="text-foreground-secondary text-sm">Default checked</span>
       </div>
     </div>
   ),
@@ -130,7 +130,7 @@ export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-3">
-        <span className="typography-body-2-semibold text-body-200">Default Size</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">Default Size</span>
         <div className="flex items-center gap-4">
           <Switch checked={true} aria-label="On" />
           <Switch checked={false} aria-label="Off" />
@@ -139,7 +139,7 @@ export const AllVariants: Story = {
         </div>
       </div>
       <div className="flex flex-col gap-3">
-        <span className="typography-body-2-semibold text-body-200">Small Size</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">Small Size</span>
         <div className="flex items-center gap-4">
           <Switch size="small" checked={true} aria-label="On" />
           <Switch size="small" checked={false} aria-label="Off" />

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -36,7 +36,7 @@ export const Switch = React.forwardRef<
       className={cn(
         "inline-flex shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors duration-150",
         "focus-visible:shadow-focus-ring focus-visible:outline-none",
-        "data-[state=checked]:border-neutral-200 data-[state=checked]:bg-brand-green-500",
+        "data-[state=checked]:border-neutral-200 data-[state=checked]:bg-brand-accent-default",
         "data-[state=unchecked]:bg-neutral-400",
         "not-disabled:active:opacity-80",
         "disabled:cursor-not-allowed disabled:opacity-50",
@@ -48,7 +48,7 @@ export const Switch = React.forwardRef<
     >
       <SwitchPrimitive.Thumb
         className={cn(
-          "pointer-events-none rounded-full bg-body-white-solid-constant shadow-sm transition-transform duration-150 dark:bg-body-black-solid-constant",
+          "pointer-events-none rounded-full bg-foreground-onaccentinverse shadow-sm transition-transform duration-150 dark:bg-foreground-onaccent",
           thumbSizeClass,
         )}
       />


### PR DESCRIPTION
Breaks out token migration for `Switch` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Switch component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>