### PR TITLE
feat(SwitchField): migrate to design tokens [SIMON]

### DIFF
--- a/src/components/SwitchField/SwitchField.stories.tsx
+++ b/src/components/SwitchField/SwitchField.stories.tsx
@@ -135,17 +135,21 @@ export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-3">
-        <span className="typography-body-2-semibold text-body-200">
+        <span className="typography-semibold-body-md text-foreground-secondary">
           Default - Right orientation
         </span>
         <SwitchField label="Toggle" helperText="Helper" orientation="right" checked={true} />
       </div>
       <div className="flex flex-col gap-3">
-        <span className="typography-body-2-semibold text-body-200">Default - Left orientation</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">
+          Default - Left orientation
+        </span>
         <SwitchField label="Toggle" helperText="Helper" orientation="left" checked={true} />
       </div>
       <div className="flex flex-col gap-3">
-        <span className="typography-body-2-semibold text-body-200">Small - Right orientation</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">
+          Small - Right orientation
+        </span>
         <SwitchField
           label="Toggle"
           helperText="Helper"
@@ -155,7 +159,9 @@ export const AllVariants: Story = {
         />
       </div>
       <div className="flex flex-col gap-3">
-        <span className="typography-body-2-semibold text-body-200">Small - Left orientation</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">
+          Small - Left orientation
+        </span>
         <SwitchField
           label="Toggle"
           helperText="Helper"

--- a/src/components/SwitchField/SwitchField.tsx
+++ b/src/components/SwitchField/SwitchField.tsx
@@ -84,9 +84,9 @@ export const SwitchField = React.forwardRef<React.ComponentRef<typeof Switch>, S
             <label
               htmlFor={id}
               className={cn(
-                "cursor-pointer select-none text-body-100",
-                disabled && "cursor-not-allowed text-disabled-100",
-                size === "default" ? "typography-body-1-semibold" : "typography-body-2-semibold",
+                "cursor-pointer select-none text-foreground-default",
+                disabled && "cursor-not-allowed text-neutral-250",
+                size === "default" ? "typography-semibold-body-lg" : "typography-semibold-body-md",
               )}
             >
               {label}
@@ -96,7 +96,10 @@ export const SwitchField = React.forwardRef<React.ComponentRef<typeof Switch>, S
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button type="button" aria-label={infoLabel} className="flex shrink-0 pt-0.5">
-                      <InfoCircleIcon aria-hidden="true" className="size-5 text-body-200" />
+                      <InfoCircleIcon
+                        aria-hidden="true"
+                        className="size-5 text-foreground-secondary"
+                      />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">{infoText}</TooltipContent>
@@ -109,9 +112,9 @@ export const SwitchField = React.forwardRef<React.ComponentRef<typeof Switch>, S
           <span
             id={helperTextId}
             className={cn(
-              "text-body-200", // !TODO https://linear.app/fanvue/issue/ENG-7301/swap-out-typography-tailwind-utility-classes
-              disabled && "text-disabled-100",
-              size === "default" ? "typography-body-2-regular" : "typography-caption-regular",
+              "text-foreground-secondary", // !TODO https://linear.app/fanvue/issue/ENG-7301/swap-out-typography-tailwind-utility-classes
+              disabled && "text-neutral-250",
+              size === "default" ? "typography-regular-body-md" : "typography-regular-body-sm",
             )}
           >
             {helperText}


### PR DESCRIPTION
Breaks out token migration for `SwitchField` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate SwitchField component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>