### PR TITLE
feat(SwitchToggle): migrate to design tokens [SIMON]

### DIFF
--- a/src/components/SwitchToggle/SwitchToggle.stories.tsx
+++ b/src/components/SwitchToggle/SwitchToggle.stories.tsx
@@ -95,7 +95,7 @@ export const ControlledExample: Story = {
           onChange={setValue}
           aria-label="Toggle view"
         />
-        <span className="text-body-200 text-sm">Selected: {value}</span>
+        <span className="text-foreground-secondary text-sm">Selected: {value}</span>
       </div>
     );
   },
@@ -110,11 +110,13 @@ export const UncontrolledExample: Story = {
   render: () => (
     <div className="flex flex-col items-start gap-4">
       <div className="flex flex-col gap-2">
-        <span className="text-body-200 text-sm">Default (first option selected)</span>
+        <span className="text-foreground-secondary text-sm">Default (first option selected)</span>
         <SwitchToggle options={defaultOptions} aria-label="Default toggle" />
       </div>
       <div className="flex flex-col gap-2">
-        <span className="text-body-200 text-sm">With defaultValue (second option selected)</span>
+        <span className="text-foreground-secondary text-sm">
+          With defaultValue (second option selected)
+        </span>
         <SwitchToggle options={defaultOptions} defaultValue="gross" aria-label="Preset toggle" />
       </div>
     </div>
@@ -139,15 +141,15 @@ export const AllSizes: Story = {
   render: () => (
     <div className="flex flex-col items-start gap-4">
       <div className="flex flex-col gap-2">
-        <span className="typography-body-2-semibold text-body-200">Small (24)</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">Small (24)</span>
         <SwitchToggle size="24" options={defaultOptions} aria-label="Small toggle" />
       </div>
       <div className="flex flex-col gap-2">
-        <span className="typography-body-2-semibold text-body-200">Medium (32)</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">Medium (32)</span>
         <SwitchToggle size="32" options={defaultOptions} aria-label="Medium toggle" />
       </div>
       <div className="flex flex-col gap-2">
-        <span className="typography-body-2-semibold text-body-200">Large (40)</span>
+        <span className="typography-semibold-body-md text-foreground-secondary">Large (40)</span>
         <SwitchToggle size="40" options={defaultOptions} aria-label="Large toggle" />
       </div>
     </div>

--- a/src/components/SwitchToggle/SwitchToggle.tsx
+++ b/src/components/SwitchToggle/SwitchToggle.tsx
@@ -80,10 +80,10 @@ export const SwitchToggle = React.forwardRef<HTMLDivElement, SwitchToggleProps>(
 
     const sizeClass =
       size === "24"
-        ? "px-2 py-1 typography-caption-semibold"
+        ? "px-2 py-1 typography-semibold-body-sm"
         : size === "32"
-          ? "px-3 py-1.75 typography-body-2-semibold"
-          : "h-10 px-4 py-2.25 typography-button-small";
+          ? "px-3 py-1.75 typography-semibold-body-md"
+          : "h-10 px-4 py-2.25 typography-semibold-body-lg";
 
     const handleSelect = (optionValue: string) => {
       if (disabled || optionValue === currentValue) return;
@@ -121,7 +121,7 @@ export const SwitchToggle = React.forwardRef<HTMLDivElement, SwitchToggleProps>(
         <span
           aria-hidden="true"
           className={cn(
-            "absolute inset-y-1 left-1 w-[calc(50%-4px)] rounded-full border border-brand-green-500 bg-brand-green-50",
+            "absolute inset-y-1 left-1 w-[calc(50%-4px)] rounded-full border border-brand-accent-default bg-brand-accent-muted",
             "motion-safe:transition-transform motion-safe:duration-200 motion-safe:ease-in-out",
             isSecondSelected && "translate-x-full",
           )}
@@ -143,9 +143,9 @@ export const SwitchToggle = React.forwardRef<HTMLDivElement, SwitchToggleProps>(
               onClick={() => handleSelect(option.value)}
               onKeyDown={(e) => handleKeyDown(e, index)}
               className={cn(
-                "relative z-10 inline-flex shrink-0 cursor-pointer items-center justify-center rounded-full border border-transparent text-body-100",
+                "relative z-10 inline-flex shrink-0 cursor-pointer items-center justify-center rounded-full border border-transparent text-foreground-default",
                 "focus-visible:shadow-focus-ring focus-visible:outline-none",
-                "active:rounded-full active:bg-brand-green-50",
+                "active:rounded-full active:bg-brand-accent-muted",
                 disabled && "pointer-events-none",
                 sizeClass,
               )}


### PR DESCRIPTION
Breaks out token migration for `SwitchToggle` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate SwitchToggle component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>