### PR TITLE
feat(TextArea): migrate to design tokens [SIMON]

### DIFF
--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -258,7 +258,7 @@ export const ControlledExample: Story = {
           errorMessage={error ? "Description must be at least 10 characters" : undefined}
           helperText={!error ? `${value.length} characters` : undefined}
         />
-        <div className="typography-caption-regular text-body-200">
+        <div className="typography-regular-body-sm text-foreground-secondary">
           Current value: {value || "(empty)"}
         </div>
       </div>

--- a/src/components/TextArea/TextArea.test.tsx
+++ b/src/components/TextArea/TextArea.test.tsx
@@ -89,13 +89,13 @@ describe("TextArea", () => {
   describe("validated state", () => {
     it("shows validation icon when validated is true", () => {
       const { container } = render(<TextArea label="Test" validated defaultValue="Valid text" />);
-      const icon = container.querySelector(".text-success-500");
+      const icon = container.querySelector(".text-success-default");
       expect(icon).toBeInTheDocument();
     });
 
     it("does not show validation icon when validated is false", () => {
       const { container } = render(<TextArea label="Test" defaultValue="Text" />);
-      const icon = container.querySelector(".text-success-500");
+      const icon = container.querySelector(".text-success-default");
       expect(icon).not.toBeInTheDocument();
     });
 
@@ -103,7 +103,7 @@ describe("TextArea", () => {
       const { container } = render(
         <TextArea label="Test" validated showClearButton value="Text" />,
       );
-      const validationIcon = container.querySelector(".text-success-500");
+      const validationIcon = container.querySelector(".text-success-default");
       const clearButton = screen.getByLabelText("Clear text");
       expect(clearButton).toBeInTheDocument();
       expect(validationIcon).not.toBeInTheDocument();

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -42,9 +42,9 @@ const CONTAINER_MIN_HEIGHT: Record<TextAreaSize, string> = {
 };
 
 const TEXTAREA_SIZE_CLASSES: Record<TextAreaSize, string> = {
-  "48": "py-3 typography-body-1-regular",
-  "40": "py-2 typography-body-1-regular",
-  "32": "py-2 typography-body-2-regular",
+  "48": "py-3 typography-regular-body-lg",
+  "40": "py-2 typography-regular-body-lg",
+  "32": "py-2 typography-regular-body-md",
 };
 
 const PADDING_HORIZONTAL: Record<TextAreaSize, string> = {
@@ -68,7 +68,7 @@ const CLEAR_BUTTON_RIGHT: Record<TextAreaSize, string> = {
 function getContainerClassName(size: TextAreaSize, error: boolean, disabled?: boolean) {
   return cn(
     "relative rounded-xl border bg-neutral-100 has-focus-visible:outline-none motion-safe:transition-colors",
-    error ? "border-error-500" : "border-transparent",
+    error ? "border-error-default" : "border-transparent",
     !disabled && !error && "hover:border-neutral-400",
     CONTAINER_MIN_HEIGHT[size],
     disabled && "opacity-50",
@@ -82,7 +82,7 @@ function getTextareaClassName(
   resizable: boolean,
 ) {
   return cn(
-    "w-full rounded-xl bg-transparent text-body-100 no-underline placeholder:text-body-200 placeholder:opacity-40 focus:outline-none disabled:cursor-not-allowed",
+    "w-full rounded-xl bg-transparent text-foreground-default no-underline placeholder:text-foreground-secondary placeholder:opacity-40 focus:outline-none disabled:cursor-not-allowed",
     resizable ? "resize-y" : "resize-none",
     !hasMinRows && "min-h-[80px]",
     TEXTAREA_SIZE_CLASSES[size],
@@ -104,8 +104,8 @@ function TextAreaHelperText({
     <p
       id={id}
       className={cn(
-        "typography-caption-regular px-2 pt-1 pb-0.5",
-        error ? "text-error-500" : "text-body-200",
+        "typography-regular-body-sm px-2 pt-1 pb-0.5",
+        error ? "text-error-default" : "text-foreground-secondary",
       )}
     >
       {children}
@@ -251,7 +251,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         {label && (
           <label
             htmlFor={inputId}
-            className="typography-caption-semibold px-1 pt-1 pb-2 text-body-100"
+            className="typography-semibold-body-sm px-1 pt-1 pb-2 text-foreground-default"
           >
             {label}
           </label>
@@ -293,7 +293,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                 CLEAR_BUTTON_RIGHT[size],
               )}
             >
-              <CheckOutlineIcon className="text-success-500" />
+              <CheckOutlineIcon className="text-success-default" />
             </div>
           )}
         </div>


### PR DESCRIPTION
Breaks out token migration for `TextArea` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate TextArea component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>