### PR TITLE
feat(Tooltip): migrate to design tokens [SIMON]

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -42,7 +42,7 @@ export const Bottom: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -55,7 +55,7 @@ export const Left: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -68,7 +68,7 @@ export const Right: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -81,7 +81,7 @@ export const NoArrow: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -94,7 +94,7 @@ export const LongContent: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -110,7 +110,7 @@ export const InfoboxDefault: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -125,13 +125,13 @@ export const InfoboxWithIcon: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
       <TooltipContent
         variant="infobox"
-        icon={<InfoCircleIcon className="size-5 text-background-inverse-solid" />}
+        icon={<InfoCircleIcon className="size-5 text-surface-page" />}
         heading="Title"
       >
         Info text
@@ -144,7 +144,7 @@ export const InfoboxWithPill: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -152,7 +152,7 @@ export const InfoboxWithPill: Story = {
         variant="infobox"
         heading="Title"
         pill={
-          <span className="typography-caption-semibold rounded-full bg-neutral-solid px-3 py-1 text-background-inverse-solid">
+          <span className="typography-semibold-body-sm rounded-full bg-neutral-solid px-3 py-1 text-surface-page">
             Example
           </span>
         }
@@ -167,7 +167,7 @@ export const InfoboxWithActions: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
@@ -187,16 +187,16 @@ export const InfoboxFull: Story = {
   render: () => (
     <Tooltip defaultOpen>
       <TooltipTrigger asChild>
-        <button type="button" className="text-body-200">
+        <button type="button" className="text-foreground-secondary">
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
       <TooltipContent
         variant="infobox"
-        icon={<InfoCircleIcon className="size-5 text-background-inverse-solid" />}
+        icon={<InfoCircleIcon className="size-5 text-surface-page" />}
         heading="Title"
         pill={
-          <span className="typography-caption-semibold rounded-full bg-neutral-solid px-3 py-1 text-background-inverse-solid">
+          <span className="typography-semibold-body-sm rounded-full bg-neutral-solid px-3 py-1 text-surface-page">
             Example
           </span>
         }
@@ -214,7 +214,7 @@ export const AllPlacements: Story = {
     <div className="flex flex-col items-center gap-24 py-16">
       <Tooltip defaultOpen>
         <TooltipTrigger asChild>
-          <button type="button" className="text-body-200">
+          <button type="button" className="text-foreground-secondary">
             <InfoCircleIcon className="size-5" />
           </button>
         </TooltipTrigger>
@@ -223,7 +223,7 @@ export const AllPlacements: Story = {
       <div className="flex gap-48">
         <Tooltip defaultOpen>
           <TooltipTrigger asChild>
-            <button type="button" className="text-body-200">
+            <button type="button" className="text-foreground-secondary">
               <InfoCircleIcon className="size-5" />
             </button>
           </TooltipTrigger>
@@ -231,7 +231,7 @@ export const AllPlacements: Story = {
         </Tooltip>
         <Tooltip defaultOpen>
           <TooltipTrigger asChild>
-            <button type="button" className="text-body-200">
+            <button type="button" className="text-foreground-secondary">
               <InfoCircleIcon className="size-5" />
             </button>
           </TooltipTrigger>
@@ -240,7 +240,7 @@ export const AllPlacements: Story = {
       </div>
       <Tooltip defaultOpen>
         <TooltipTrigger asChild>
-          <button type="button" className="text-body-200">
+          <button type="button" className="text-foreground-secondary">
             <InfoCircleIcon className="size-5" />
           </button>
         </TooltipTrigger>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -148,7 +148,7 @@ export const TooltipContent = React.forwardRef<
           sideOffset={sideOffset}
           style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
           className={cn(
-            "typography-body-2-regular max-w-[320px] overflow-hidden rounded-3xl bg-background-solid p-4 text-background-inverse-solid shadow-[0px_2px_4px_0px_rgba(17,24,39,0.08)]",
+            "typography-regular-body-md max-w-[320px] overflow-hidden rounded-3xl bg-surface-pageInverse p-4 text-surface-page shadow-[0px_2px_4px_0px_rgba(17,24,39,0.08)]",
             isInfobox && "border border-neutral-200",
             className,
           )}
@@ -163,7 +163,7 @@ export const TooltipContent = React.forwardRef<
                 <div className="flex items-center gap-3">
                   {icon && <div className="size-5 shrink-0">{icon}</div>}
                   {heading && (
-                    <p className="typography-subtitle min-w-0 flex-1 text-background-inverse-solid">
+                    <p className="typography-bold-heading-xs min-w-0 flex-1 text-surface-page">
                       {heading}
                     </p>
                   )}
@@ -171,9 +171,7 @@ export const TooltipContent = React.forwardRef<
                 </div>
               )}
               {children && (
-                <div className="typography-body-2-regular text-background-inverse-solid">
-                  {children}
-                </div>
+                <div className="typography-regular-body-md text-surface-page">{children}</div>
               )}
               {hasActions && (
                 <div className="flex items-center gap-1">
@@ -201,7 +199,9 @@ export const TooltipContent = React.forwardRef<
           )}
           {showArrow && (
             <TooltipPrimitive.Arrow
-              className={"-translate-y-px! fill-background-solid stroke-2 stroke-background-solid"}
+              className={
+                "-translate-y-px! fill-surface-pageInverse stroke-2 stroke-surface-pageInverse"
+              }
               width={12}
               height={6}
             />


### PR DESCRIPTION
Breaks out token migration for `Tooltip` from monolith PR #206.

Migrates legacy numeric/primitive token class names to semantic design tokens, e.g.:
- `text-info-500` → `text-info-default`
- `bg-error-50` → `bg-error-background`
- `typography-body-2-semibold` → `typography-semibold-body-md`

Migrate Tooltip component to use the new design token system.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>