### PR TITLE
feat(chromatic): capture dark mode snapshots for visual regression testing

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -26,6 +26,12 @@ const preview: Preview = {
     backgrounds: {
       disable: true,
     },
+    chromatic: {
+      modes: {
+        light: { theme: "light" },
+        dark: { theme: "dark" },
+      },
+    },
     viewport: {
       viewports: {
         mobile: { name: "Mobile", styles: { width: "375px", height: "667px" } },


### PR DESCRIPTION
## Summary

- Adds `chromatic.modes` config to `.storybook/preview.tsx` with `light` and `dark` modes
- Every story now gets **two snapshots** captured automatically — one per theme
- Zero changes needed to individual stories; uses the existing theme decorator and `context.globals.theme`

> **Note:** This will roughly double the Chromatic snapshot count, which may affect billing depending on your plan.

## Test plan

- [ ] Verify Chromatic CI check runs and captures both light and dark snapshots
- [ ] Confirm dark mode snapshots show correct theme styling (dark backgrounds, correct text colors)
- [ ] Review a few component snapshots in Chromatic UI to validate side-by-side light/dark rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)