### PR TITLE
fix(Alert,Chip): improve icon visibility and selection UX

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -33,13 +33,13 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const CLOSE_BUTTON_CLASSES: Record<AlertVariant, string> = {
-  info: "hover:bg-info-default active:bg-info-default text-info-default motion-safe:transition-colors motion-safe:duration-150",
+  info: "hover:bg-info-default active:bg-info-default text-foreground-default motion-safe:transition-colors motion-safe:duration-150",
   success:
-    "hover:bg-success-default active:bg-success-default text-success-default motion-safe:transition-colors motion-safe:duration-150",
+    "hover:bg-success-default active:bg-success-default text-foreground-default motion-safe:transition-colors motion-safe:duration-150",
   warning:
-    "hover:bg-warning-default active:bg-warning-default text-warning-default motion-safe:transition-colors motion-safe:duration-150",
+    "hover:bg-warning-default active:bg-warning-default text-foreground-default motion-safe:transition-colors motion-safe:duration-150",
   error:
-    "hover:bg-error-default active:bg-error-default text-error-default motion-safe:transition-colors motion-safe:duration-150",
+    "hover:bg-error-default active:bg-error-default text-foreground-default motion-safe:transition-colors motion-safe:duration-150",
 };
 
 /**
@@ -96,7 +96,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
         {...props}
       >
         {resolvedIcon && (
-          <span className="flex shrink-0 items-start" aria-hidden="true">
+          <span className="flex shrink-0 items-start text-foreground-default" aria-hidden="true">
             {resolvedIcon}
           </span>
         )}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -77,7 +77,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           size === "40" && "h-10 py-2.5",
           // Variant colors
           isDark && "bg-neutral-50 text-foreground-onaccentinverse",
-          !isDark && selected && "bg-brand-accent-muted text-neutral-400",
+          !isDark && selected && "bg-brand-accent-muted text-neutral-400 ring-1 ring-inset ring-brand-accent-default",
           !isDark && !selected && "bg-neutral-100 text-neutral-400",
           // Interactive
           isInteractive && !disabled && "cursor-pointer",
@@ -85,7 +85,12 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             !disabled &&
             !isDark &&
             !selected &&
-            "hover:bg-brand-accent-muted active:bg-brand-accent-muted",
+            "hover:bg-neutral-200 active:bg-brand-accent-muted",
+          isInteractive &&
+            !disabled &&
+            !isDark &&
+            selected &&
+            "hover:bg-brand-accent-hover/20 active:bg-brand-accent-muted",
           // Focus
           "focus-visible:shadow-focus-ring focus-visible:outline-none",
           // Disabled


### PR DESCRIPTION
## Summary

- **Alert**: Icons and close button now use `text-foreground-default` instead of inheriting the variant color via `currentColor`. In dark mode, filled icons (e.g. `ErrorCircleIcon`) on same-hue backgrounds (e.g. `red-400` on `red-950`) had insufficient contrast — cutout details like the × became invisible against the background.
- **Chip**: Selected state now shows a visible `ring-brand-accent-default` ring for clear differentiation from unselected. Hover on unselected chips uses `bg-neutral-200` (distinct from selected state). Selected chips get a hover effect for interactivity feedback.

## Test plan

- [x] Alert unit tests pass (16/16)
- [x] Chip unit tests pass (20/20)
- [ ] Visual review: Alert error variant in dark mode — icon details (× in circle) should be clearly visible
- [ ] Visual review: Alert info/success/warning variants — icons should be high contrast in both themes
- [ ] Visual review: Chip selected state — green ring border should be clearly visible
- [ ] Visual review: Chip hover states — unselected hover is distinct from selected state

🤖 Generated with [Claude Code](https://claude.com/claude-code)