### PR TITLE
test(Loader): add unit tests and Storybook stories

### DIFF
--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Loader } from "./Loader";
+
+const meta = {
+  title: "Components/Loader",
+  component: Loader,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    show: { control: "boolean" },
+    center: { control: "boolean" },
+    centerX: { control: "boolean" },
+    centerY: { control: "boolean" },
+    minHeight: { control: "text" },
+    ariaLabel: { control: "text" },
+  },
+} satisfies Meta<typeof Loader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    minHeight: 200,
+  },
+};
+
+export const Centered: Story = {
+  args: {
+    center: true,
+    minHeight: 200,
+  },
+};
+
+export const CenteredHorizontally: Story = {
+  args: {
+    centerX: true,
+    minHeight: 200,
+  },
+};
+
+export const CenteredVertically: Story = {
+  args: {
+    centerY: true,
+    minHeight: 200,
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    show: false,
+    minHeight: 200,
+  },
+};
+
+export const CustomMinHeight: Story = {
+  args: {
+    center: true,
+    minHeight: 400,
+  },
+};

--- a/src/components/Loader/Loader.test.tsx
+++ b/src/components/Loader/Loader.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Loader } from "./Loader";
+
+describe("Loader", () => {
+  describe("API", () => {
+    it("renders with default props", () => {
+      const { container } = render(<Loader />);
+      expect(container.firstElementChild).toBeInTheDocument();
+      expect(container.firstElementChild?.tagName).toBe("DIV");
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(<Loader className="custom" />);
+      expect(container.firstElementChild).toHaveClass("custom");
+    });
+
+    it("forwards ref correctly", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      const { container } = render(<Loader ref={ref} />);
+      expect(ref.current).toBe(container.firstElementChild);
+    });
+
+    it("spreads additional HTML attributes", () => {
+      const { container } = render(<Loader data-custom="value" />);
+      expect(container.firstElementChild).toHaveAttribute("data-custom", "value");
+    });
+
+    it("renders nothing when show is false", () => {
+      const { container } = render(<Loader show={false} />);
+      expect(container.firstElementChild).toBeNull();
+    });
+
+    it("renders when show is true", () => {
+      const { container } = render(<Loader show />);
+      expect(container.firstElementChild).toBeInTheDocument();
+    });
+
+    it("applies default minHeight of 100%", () => {
+      const { container } = render(<Loader />);
+      expect((container.firstElementChild as HTMLElement).style.minHeight).toBe("100%");
+    });
+
+    it("applies minHeight as pixels when given a number", () => {
+      const { container } = render(<Loader minHeight={200} />);
+      expect((container.firstElementChild as HTMLElement).style.minHeight).toBe("200px");
+    });
+
+    it("applies minHeight as string when given a string", () => {
+      const { container } = render(<Loader minHeight="50vh" />);
+      expect((container.firstElementChild as HTMLElement).style.minHeight).toBe("50vh");
+    });
+
+    it("centers horizontally when centerX is true", () => {
+      const { container } = render(<Loader centerX />);
+      const output = container.querySelector("output");
+      expect(output).toHaveClass("left-1/2", "-translate-x-1/2");
+    });
+
+    it("centers vertically when centerY is true", () => {
+      const { container } = render(<Loader centerY />);
+      const output = container.querySelector("output");
+      expect(output).toHaveClass("top-1/2", "-translate-y-1/2");
+    });
+
+    it("centers both axes when center is true", () => {
+      const { container } = render(<Loader center />);
+      const output = container.querySelector("output");
+      expect(output).toHaveClass("left-1/2", "-translate-x-1/2");
+      expect(output).toHaveClass("top-1/2", "-translate-y-1/2");
+    });
+
+    it("does not apply centering classes by default", () => {
+      const { container } = render(<Loader />);
+      const output = container.querySelector("output");
+      expect(output).not.toHaveClass("left-1/2");
+      expect(output).not.toHaveClass("top-1/2");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has an accessible label on the output element", () => {
+      render(<Loader />);
+      expect(screen.getByRole("status")).toHaveAccessibleName("loading");
+    });
+
+    it("applies custom aria-label", () => {
+      render(<Loader ariaLabel="Please wait" />);
+      expect(screen.getByRole("status")).toHaveAccessibleName("Please wait");
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = render(<Loader />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations when centered", async () => {
+      const { container } = render(<Loader center minHeight={200} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Loader was the only component with zero test files and zero Storybook stories despite being exported and shipped to consumers
- Add `Loader.test.tsx` with 17 tests covering API contracts (className merging, ref forwarding, HTML attribute spreading, `show`/`center`/`centerX`/`centerY` prop logic, `minHeight` handling) and accessibility (vitest-axe)
- Add `Loader.stories.tsx` with 6 stories (Default, Centered, CenteredHorizontally, CenteredVertically, Hidden, CustomMinHeight) using CSF3 format with autodocs

## Test plan
- [x] All 17 unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Stories render correctly in Storybook
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)