### PR TITLE
chore(ci): make Chromatic a manual trigger to reduce costs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,7 +5,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    types: [labeled]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,6 +15,10 @@ permissions:
 jobs:
   chromatic:
     name: Visual Regression
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'chromatic')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Chromatic no longer runs automatically on every PR commit — was costing ~$2k/2 weeks
- Now triggers only when the `chromatic` label is added to a PR, or via manual workflow_dispatch
- Main branch pushes still auto-run for baselines (auto-accepted)

## Notes
- Create a `chromatic` label in the repo if it doesn't exist
- After pushing new commits to a labelled PR, remove and re-add the label to re-trigger (or use workflow_dispatch from Actions tab)
- `Visual Regression` required status check will block merge until Chromatic is manually triggered

## Test plan
- [ ] Verify workflow doesn't trigger on regular PR pushes
- [ ] Verify adding `chromatic` label triggers the workflow
- [ ] Verify workflow_dispatch works from Actions tab
- [ ] Verify main branch pushes still trigger automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)