### PR TITLE
fix(Skeleton): use opaque background instead of semi-transparent neutral-200

### DIFF
--- a/src/components/Skeleton/Skeleton.test.tsx
+++ b/src/components/Skeleton/Skeleton.test.tsx
@@ -125,9 +125,9 @@ describe("Skeleton", () => {
       expect(getSkeleton(container)).not.toHaveClass("h-[1em]");
     });
 
-    it("includes dark mode background class", () => {
+    it("has an opaque background using color-mix", () => {
       const { container } = render(<Skeleton />);
-      expect(getSkeleton(container)).toHaveClass("dark:bg-neutral-200");
+      expect(getSkeleton(container).className).toContain("bg-[color-mix(");
     });
   });
 

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -55,8 +55,12 @@ export const Skeleton = React.forwardRef<HTMLSpanElement, SkeletonProps>(
     const hasChildren = React.Children.count(children) > 0;
     const sizeStyle: React.CSSProperties = {
       ...style,
-      ...(width !== undefined && { width: typeof width === "number" ? `${width}px` : width }),
-      ...(height !== undefined && { height: typeof height === "number" ? `${height}px` : height }),
+      ...(width !== undefined && {
+        width: typeof width === "number" ? `${width}px` : width,
+      }),
+      ...(height !== undefined && {
+        height: typeof height === "number" ? `${height}px` : height,
+      }),
     };
 
     return (
@@ -64,7 +68,7 @@ export const Skeleton = React.forwardRef<HTMLSpanElement, SkeletonProps>(
         ref={ref}
         aria-hidden="true"
         className={cn(
-          "block bg-neutral-200 dark:bg-neutral-200",
+          "block bg-[color-mix(in_srgb,var(--color-foreground-default)_11%,var(--color-surface-page))]",
           VARIANT_CLASSES[variant],
           variant === "text" && !height && !hasChildren && "h-[1em]",
           animation === "pulse" && "animate-pulse",


### PR DESCRIPTION
## Summary
- Skeleton component used `bg-neutral-200` which is semi-transparent (`#15151533` / `#ffffff33`), causing content underneath to show through
- Replaced with `color-mix(in srgb, var(--color-foreground-default) 11%, var(--color-surface-page))` which produces the same visual weight but is fully opaque
- Works correctly in both light and dark modes using existing semantic tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)