### PR TITLE
fix(Select): add missing focus-visible ring to trigger

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -139,7 +139,7 @@ export const Select = React.forwardRef<
               aria-describedby={bottomText ? helperTextId : undefined}
               aria-invalid={error || undefined}
               className={cn(
-                "flex w-full cursor-pointer items-center justify-between rounded-xl border bg-neutral-100 outline-none motion-safe:transition-colors",
+                "flex w-full cursor-pointer items-center justify-between rounded-xl border bg-neutral-100 focus-visible:shadow-focus-ring focus-visible:outline-none motion-safe:transition-colors",
                 TRIGGER_HEIGHT[size],
                 TRIGGER_PADDING_X[size],
                 TRIGGER_GAP[size],


### PR DESCRIPTION
## Summary
- The Select trigger had `outline-none` but no visible focus indicator, making it inaccessible for keyboard users
- Added `focus-visible:shadow-focus-ring focus-visible:outline-none` to match the pattern used by Button, Chip, and other interactive components

<img width="460" height="217" alt="Screenshot 2026-03-15 at 09 18 05" src="https://github.com/user-attachments/assets/d4b0997f-aa86-4f34-80cc-a73781818056" />


## Test plan
- [x] Verified visually in Storybook — focus ring appears when tabbing to the Select trigger
- [x] Focus ring disappears when dropdown opens (expected — focus moves to listbox)
- [x] Focus ring reappears on trigger after selecting an option or pressing Escape