### PR TITLE
feat: MainContainerHeader and ScreenHeader (v2 tokens)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,6 +124,10 @@ import {
   Logo,
   LogoutIcon,
   LoveIcon,
+  MainContainerHeader,
+  MainContainerHeaderEnd,
+  MainContainerHeaderStart,
+  MainContainerHeaderTitle,
   MegaphoneIcon,
   MenuCloseIcon,
   MenuIcon,
@@ -151,6 +155,14 @@ import {
   RepeatIcon,
   Reply2Icon,
   ReplyIcon,
+  ScreenHeader,
+  ScreenHeaderActions,
+  ScreenHeaderDotIndicators,
+  ScreenHeaderGreeting,
+  ScreenHeaderOnboardingRow,
+  ScreenHeaderSteps,
+  ScreenHeaderTitle,
+  ScreenHeaderToolbar,
   SearchField,
   SearchIcon,
   Select,
@@ -2709,6 +2721,161 @@ function MobileStepperDemo() {
   );
 }
 
+function HeaderDemoPreviewShell({
+  caption,
+  maxWidthClass,
+  children,
+}: {
+  caption: string;
+  maxWidthClass: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="typography-regular-body-sm text-content-secondary">{caption}</p>
+      <div
+        className={`w-full overflow-hidden rounded-md border border-border-primary bg-bg-primary shadow-sm ${maxWidthClass}`}
+      >
+        {children}
+        <div className="typography-regular-body-sm bg-surface-tertiary px-4 py-12 text-content-tertiary">
+          Page content
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MainContainerHeaderDemo() {
+  const demoAvatar =
+    "https://images.unsplash.com/photo-1527980965255-d3b416303d12?w=80&h=80&fit=crop";
+
+  return (
+    <div id="maincontainerheader" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-bold-heading-sm mb-4">Main container header</h2>
+      <p className="typography-regular-body-md -mt-2 mb-2 max-w-2xl text-content-secondary">
+        Previews sit in a rounded panel with a placeholder body so the header reads like the top of
+        a real column or screen.
+      </p>
+      <div className="flex flex-col gap-8">
+        <HeaderDemoPreviewShell caption="Desktop-width main column" maxWidthClass="max-w-[568px]">
+          <MainContainerHeader className="rounded-none">
+            <MainContainerHeaderStart>
+              <Avatar src={demoAvatar} alt="Creator" fallback="C" size={40} onlineIndicator />
+              <MainContainerHeaderTitle>Title</MainContainerHeaderTitle>
+              <Badge variant="success" className="text-content-primary" leftDot>
+                Live
+              </Badge>
+            </MainContainerHeaderStart>
+            <MainContainerHeaderEnd>
+              <IconButton variant="tertiary" size="32" icon={<SearchIcon />} aria-label="Search" />
+              <span className="typography-semibold-body-sm inline-flex items-center justify-center rounded-full bg-brand-secondary-default px-2 py-1 text-content-on-brand">
+                Beta
+              </span>
+              <IconButton
+                variant="tertiary"
+                size="32"
+                icon={<MoreIcon />}
+                aria-label="More options"
+              />
+              <IconButton
+                variant="tertiary"
+                size="32"
+                icon={<BoltIcon />}
+                aria-label="Quick actions"
+              />
+              <IconButton variant="tertiary" size="32" icon={<PlusIcon />} aria-label="Add" />
+            </MainContainerHeaderEnd>
+          </MainContainerHeader>
+        </HeaderDemoPreviewShell>
+        <HeaderDemoPreviewShell caption="Mobile-width panel" maxWidthClass="max-w-[375px]">
+          <MainContainerHeader device="mobile" className="rounded-none">
+            <MainContainerHeaderStart>
+              <Avatar src={demoAvatar} alt="Creator" fallback="C" size={40} onlineIndicator />
+              <MainContainerHeaderTitle>Title</MainContainerHeaderTitle>
+            </MainContainerHeaderStart>
+            <MainContainerHeaderEnd>
+              <span className="typography-semibold-body-sm inline-flex items-center justify-center rounded-full bg-brand-secondary-default px-2 py-1 text-content-on-brand">
+                Beta
+              </span>
+              <IconButton
+                variant="tertiary"
+                size="32"
+                icon={<MoreIcon />}
+                aria-label="More options"
+              />
+            </MainContainerHeaderEnd>
+          </MainContainerHeader>
+        </HeaderDemoPreviewShell>
+      </div>
+    </div>
+  );
+}
+
+function ScreenHeaderDemo() {
+  return (
+    <div id="screenheader" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-bold-heading-sm mb-4">Screen header</h2>
+      <p className="typography-regular-body-md -mt-2 mb-2 max-w-2xl text-content-secondary">
+        Each example is framed at a typical phone width (375px) with content below the header
+        region.
+      </p>
+      <div className="flex flex-col gap-8">
+        <HeaderDemoPreviewShell caption="Toolbar + search" maxWidthClass="max-w-[375px]">
+          <ScreenHeader className="rounded-none border-border-primary border-b">
+            <ScreenHeaderToolbar>
+              <ScreenHeaderTitle className="min-w-0 flex-1">Home</ScreenHeaderTitle>
+              <ScreenHeaderActions>
+                <IconButton
+                  variant="tertiary"
+                  size="32"
+                  icon={<SearchIcon />}
+                  aria-label="Search"
+                />
+              </ScreenHeaderActions>
+            </ScreenHeaderToolbar>
+          </ScreenHeader>
+        </HeaderDemoPreviewShell>
+        <HeaderDemoPreviewShell caption="Greeting block" maxWidthClass="max-w-[375px]">
+          <ScreenHeader className="rounded-none border-border-primary border-b">
+            <ScreenHeaderToolbar>
+              <ScreenHeaderGreeting greetingTitle="Hello, [Name]" greetingSubtitle="Profile" />
+            </ScreenHeaderToolbar>
+          </ScreenHeader>
+        </HeaderDemoPreviewShell>
+        <HeaderDemoPreviewShell caption="Step segments (page ticker)" maxWidthClass="max-w-[375px]">
+          <ScreenHeader className="flex-col items-stretch rounded-none border-border-primary border-b">
+            <ScreenHeaderSteps total={6} activeIndex={0} />
+          </ScreenHeader>
+        </HeaderDemoPreviewShell>
+        <HeaderDemoPreviewShell caption="Onboarding carousel bar" maxWidthClass="max-w-[375px]">
+          <ScreenHeader className="flex-col items-stretch gap-0 rounded-none border-border-primary border-b p-0">
+            <ScreenHeaderOnboardingRow>
+              <IconButton
+                variant="tertiary"
+                size="32"
+                icon={<ChevronLeftIcon />}
+                aria-label="Previous"
+              />
+              <div className="flex flex-col items-center gap-3">
+                <p className="typography-semibold-body-lg text-center text-content-primary">
+                  Title
+                </p>
+                <ScreenHeaderDotIndicators count={11} activeIndex={0} className="w-[168px]" />
+              </div>
+              <IconButton
+                variant="tertiary"
+                size="32"
+                icon={<ChevronRightIcon />}
+                aria-label="Next"
+              />
+            </ScreenHeaderOnboardingRow>
+          </ScreenHeader>
+        </HeaderDemoPreviewShell>
+      </div>
+    </div>
+  );
+}
+
 function TooltipDemo() {
   const [open, setOpen] = useState(false);
   return (
@@ -3343,6 +3510,7 @@ function App() {
     { id: "infobox", label: "InfoBox" },
     { id: "loader", label: "Loader" },
     { id: "logo", label: "Logo" },
+    { id: "maincontainerheader", label: "Main Container Header" },
     { id: "mobilestepper", label: "Mobile Stepper" },
     { id: "pagination", label: "Pagination" },
     { id: "passwordfield", label: "Password Field" },
@@ -3350,6 +3518,7 @@ function App() {
     { id: "progressbar", label: "Progress Bar" },
     { id: "radio", label: "Radio" },
     { id: "searchfield", label: "Search Field" },
+    { id: "screenheader", label: "Screen Header" },
     { id: "select", label: "Select" },
     { id: "skeleton", label: "Skeleton" },
     { id: "slider", label: "Slider" },
@@ -3539,6 +3708,10 @@ function App() {
 
             {/* MobileStepper */}
             <MobileStepperDemo />
+
+            <MainContainerHeaderDemo />
+
+            <ScreenHeaderDemo />
 
             {/* Tooltip */}
             <TooltipDemo />

--- a/src/components/MainContainerHeader/MainContainerHeader.stories.tsx
+++ b/src/components/MainContainerHeader/MainContainerHeader.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Avatar } from "../Avatar/Avatar";
+import { Badge } from "../Badge/Badge";
+import { IconButton } from "../IconButton/IconButton";
+import { BoltIcon } from "../Icons/BoltIcon";
+import { MoreIcon } from "../Icons/MoreIcon";
+import { PlusIcon } from "../Icons/PlusIcon";
+import { SearchIcon } from "../Icons/SearchIcon";
+import {
+  MainContainerHeader,
+  MainContainerHeaderEnd,
+  MainContainerHeaderStart,
+  MainContainerHeaderTitle,
+} from "./MainContainerHeader";
+
+const meta = {
+  title: "Components/MainContainerHeader",
+  component: MainContainerHeader,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=1445-23497",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    device: {
+      control: "select",
+      options: ["desktop", "mobile"],
+    },
+  },
+} satisfies Meta<typeof MainContainerHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const demoAvatar =
+  "https://images.unsplash.com/photo-1527980965255-d3b416303d12?w=80&h=80&fit=crop";
+
+export const DesktopDefault: Story = {
+  render: (args) => (
+    <MainContainerHeader {...args} className="max-w-xl">
+      <MainContainerHeaderStart>
+        <Avatar src={demoAvatar} alt="Creator" fallback="C" size={40} onlineIndicator />
+        <MainContainerHeaderTitle>Title</MainContainerHeaderTitle>
+        <Badge variant="success" className="text-content-primary" leftDot>
+          Live
+        </Badge>
+      </MainContainerHeaderStart>
+      <MainContainerHeaderEnd>
+        <IconButton variant="tertiary" size="32" icon={<SearchIcon />} aria-label="Search" />
+        <span className="typography-semibold-body-sm inline-flex items-center justify-center rounded-full bg-brand-secondary-default px-2 py-1 text-content-on-brand">
+          Beta
+        </span>
+        <IconButton variant="tertiary" size="32" icon={<MoreIcon />} aria-label="More options" />
+        <IconButton variant="tertiary" size="32" icon={<BoltIcon />} aria-label="Quick actions" />
+        <IconButton variant="tertiary" size="32" icon={<PlusIcon />} aria-label="Add" />
+      </MainContainerHeaderEnd>
+    </MainContainerHeader>
+  ),
+  args: {
+    device: "desktop",
+  },
+};
+
+export const Mobile: Story = {
+  render: (args) => (
+    <MainContainerHeader {...args} className="max-w-sm">
+      <MainContainerHeaderStart>
+        <Avatar src={demoAvatar} alt="Creator" fallback="C" size={40} onlineIndicator />
+        <MainContainerHeaderTitle>Title</MainContainerHeaderTitle>
+        <Badge variant="success" className="text-content-primary" leftDot>
+          Live
+        </Badge>
+      </MainContainerHeaderStart>
+      <MainContainerHeaderEnd>
+        <span className="typography-semibold-body-sm inline-flex items-center justify-center rounded-full bg-brand-secondary-default px-2 py-1 text-content-on-brand">
+          Beta
+        </span>
+        <IconButton variant="tertiary" size="32" icon={<MoreIcon />} aria-label="More options" />
+        <IconButton variant="tertiary" size="32" icon={<BoltIcon />} aria-label="Quick actions" />
+        <IconButton variant="tertiary" size="32" icon={<PlusIcon />} aria-label="Add" />
+      </MainContainerHeaderEnd>
+    </MainContainerHeader>
+  ),
+  args: {
+    device: "mobile",
+  },
+};

--- a/src/components/MainContainerHeader/MainContainerHeader.test.tsx
+++ b/src/components/MainContainerHeader/MainContainerHeader.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import {
+  MainContainerHeader,
+  MainContainerHeaderEnd,
+  MainContainerHeaderStart,
+  MainContainerHeaderTitle,
+} from "./MainContainerHeader";
+
+describe("MainContainerHeader", () => {
+  describe("API", () => {
+    it("applies custom className on the root", () => {
+      render(
+        <MainContainerHeader className="custom-root" data-testid="header">
+          <span>child</span>
+        </MainContainerHeader>,
+      );
+      expect(screen.getByTestId("header")).toHaveClass("custom-root");
+    });
+
+    it("forwards ref on the root", () => {
+      const ref = createRef<HTMLDivElement>();
+      render(
+        <MainContainerHeader ref={ref}>
+          <span>x</span>
+        </MainContainerHeader>,
+      );
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("applies mobile padding when device is mobile", () => {
+      render(
+        <MainContainerHeader device="mobile" data-testid="header">
+          <span>x</span>
+        </MainContainerHeader>,
+      );
+      expect(screen.getByTestId("header")).toHaveClass("p-4");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations for a typical composition", async () => {
+      const { container } = render(
+        <MainContainerHeader>
+          <MainContainerHeaderStart>
+            <MainContainerHeaderTitle>Conversation</MainContainerHeaderTitle>
+          </MainContainerHeaderStart>
+          <MainContainerHeaderEnd>
+            <button type="button">Action</button>
+          </MainContainerHeaderEnd>
+        </MainContainerHeader>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/MainContainerHeader/MainContainerHeader.tsx
+++ b/src/components/MainContainerHeader/MainContainerHeader.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Layout preset for horizontal padding on the header bar. */
+export type MainContainerHeaderDevice = "desktop" | "mobile";
+
+export interface MainContainerHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Horizontal padding preset. @default "desktop" */
+  device?: MainContainerHeaderDevice;
+}
+
+export interface MainContainerHeaderStartProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface MainContainerHeaderEndProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface MainContainerHeaderTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+/**
+ * Top bar for a main content area: bottom border, vertical centering, and
+ * optional {@link MainContainerHeaderStart} / {@link MainContainerHeaderEnd}
+ * regions. Compose with {@link Avatar}, {@link Badge}, {@link Button},
+ * {@link IconButton}, and {@link MainContainerHeaderTitle}.
+ *
+ * @example
+ * ```tsx
+ * <MainContainerHeader className="max-w-xl">
+ *   <MainContainerHeaderStart>
+ *     <Avatar src={src} alt="User" fallback="U" onlineIndicator />
+ *     <MainContainerHeaderTitle>Title</MainContainerHeaderTitle>
+ *   </MainContainerHeaderStart>
+ *   <MainContainerHeaderEnd>
+ *     <IconButton variant="tertiary" size="32" icon={<MoreIcon />} aria-label="More" />
+ *   </MainContainerHeaderEnd>
+ * </MainContainerHeader>
+ * ```
+ */
+export const MainContainerHeader = React.forwardRef<HTMLDivElement, MainContainerHeaderProps>(
+  ({ className, device = "desktop", ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex min-h-16 w-full items-center justify-between border-border-primary border-b",
+          device === "mobile" ? "p-4" : "px-6 py-4",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+MainContainerHeader.displayName = "MainContainerHeader";
+
+/**
+ * Leading cluster inside {@link MainContainerHeader} (avatar, title, badges).
+ */
+export const MainContainerHeaderStart = React.forwardRef<
+  HTMLDivElement,
+  MainContainerHeaderStartProps
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn("flex min-h-0 min-w-0 flex-1 items-center gap-3", className)}
+      {...props}
+    />
+  );
+});
+MainContainerHeaderStart.displayName = "MainContainerHeaderStart";
+
+/**
+ * Trailing actions inside {@link MainContainerHeader}, right-aligned.
+ */
+export const MainContainerHeaderEnd = React.forwardRef<HTMLDivElement, MainContainerHeaderEndProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("flex min-h-0 min-w-0 flex-1 items-center justify-end gap-2", className)}
+        {...props}
+      />
+    );
+  },
+);
+MainContainerHeaderEnd.displayName = "MainContainerHeaderEnd";
+
+/**
+ * Primary title line for {@link MainContainerHeaderStart}.
+ */
+export const MainContainerHeaderTitle = React.forwardRef<
+  HTMLHeadingElement,
+  MainContainerHeaderTitleProps
+>(({ className, ...props }, ref) => {
+  return (
+    <h2
+      ref={ref}
+      className={cn(
+        "typography-bold-heading-xs min-w-0 shrink truncate text-content-primary leading-[26px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+MainContainerHeaderTitle.displayName = "MainContainerHeaderTitle";

--- a/src/components/ScreenHeader/ScreenHeader.stories.tsx
+++ b/src/components/ScreenHeader/ScreenHeader.stories.tsx
@@ -1,0 +1,205 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../Button/Button";
+import { IconButton } from "../IconButton/IconButton";
+import { BoltIcon } from "../Icons/BoltIcon";
+import { ChartIcon } from "../Icons/ChartIcon";
+import { ChevronLeftIcon } from "../Icons/ChevronLeftIcon";
+import { ChevronRightIcon } from "../Icons/ChevronRightIcon";
+import { MoreIcon } from "../Icons/MoreIcon";
+import { PlusIcon } from "../Icons/PlusIcon";
+import { SearchIcon } from "../Icons/SearchIcon";
+import { UploadIcon } from "../Icons/UploadIcon";
+import { UsersIcon } from "../Icons/UsersIcon";
+import {
+  ScreenHeader,
+  ScreenHeaderActions,
+  ScreenHeaderDotIndicators,
+  ScreenHeaderGreeting,
+  ScreenHeaderOnboardingRow,
+  ScreenHeaderSteps,
+  ScreenHeaderTitle,
+  ScreenHeaderToolbar,
+} from "./ScreenHeader";
+
+const meta = {
+  title: "Components/ScreenHeader",
+  component: ScreenHeader,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=87-5436",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    device: { control: "select", options: ["mobile", "desktop"] },
+    surface: { control: "select", options: ["default", "frosted"] },
+  },
+} satisfies Meta<typeof ScreenHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const HomeWithSearch: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md">
+      <ScreenHeaderToolbar>
+        <ScreenHeaderTitle className="min-w-0 flex-1">Home</ScreenHeaderTitle>
+        <ScreenHeaderActions>
+          <IconButton variant="tertiary" size="32" icon={<SearchIcon />} aria-label="Search" />
+        </ScreenHeaderActions>
+      </ScreenHeaderToolbar>
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const MessagesToolbar: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md">
+      <ScreenHeaderToolbar>
+        <ScreenHeaderTitle className="min-w-0 flex-1">Messages</ScreenHeaderTitle>
+        <ScreenHeaderActions>
+          <IconButton variant="tertiary" size="32" icon={<UsersIcon />} aria-label="Add contact" />
+          <IconButton variant="tertiary" size="32" icon={<ChartIcon />} aria-label="Statistics" />
+          <IconButton variant="tertiary" size="32" icon={<BoltIcon />} aria-label="Quick actions" />
+          <IconButton variant="tertiary" size="32" icon={<PlusIcon />} aria-label="Create" />
+        </ScreenHeaderActions>
+      </ScreenHeaderToolbar>
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const CreateProfileDiscover: Story = {
+  render: (args) => (
+    <div className="flex max-w-md flex-col gap-4">
+      {(["Create", "Profile", "Discover"] as const).map((label) => (
+        <ScreenHeader
+          key={label}
+          {...args}
+          surface={label === "Discover" ? "frosted" : "default"}
+          className="max-w-md rounded-lg"
+        >
+          <ScreenHeaderToolbar>
+            <ScreenHeaderTitle className="min-w-0 flex-1">{label}</ScreenHeaderTitle>
+            <ScreenHeaderActions>
+              <IconButton
+                variant="tertiary"
+                size="32"
+                icon={<ChartIcon />}
+                aria-label="Statistics"
+              />
+              <IconButton
+                variant="tertiary"
+                size="32"
+                icon={<BoltIcon />}
+                aria-label="Quick actions"
+              />
+              <IconButton variant="tertiary" size="32" icon={<PlusIcon />} aria-label="Create" />
+            </ScreenHeaderActions>
+          </ScreenHeaderToolbar>
+        </ScreenHeader>
+      ))}
+    </div>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const Greeting: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md">
+      <ScreenHeaderToolbar>
+        <ScreenHeaderGreeting greetingTitle="Hello, [Name]" greetingSubtitle="Profile" />
+        <ScreenHeaderActions>
+          <IconButton variant="tertiary" size="32" icon={<MoreIcon />} aria-label="More" />
+        </ScreenHeaderActions>
+      </ScreenHeaderToolbar>
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const TitleWithSave: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md">
+      <ScreenHeaderToolbar>
+        <ScreenHeaderTitle className="min-w-0 flex-1">Title</ScreenHeaderTitle>
+        <ScreenHeaderActions>
+          <Button variant="tertiary" size="32">
+            Save
+          </Button>
+        </ScreenHeaderActions>
+      </ScreenHeaderToolbar>
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const PageTicker: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md flex-col items-stretch">
+      <ScreenHeaderSteps total={6} activeIndex={0} className="flex-1" />
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const PaginationCarousel: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md flex-col items-stretch gap-0 p-0">
+      <ScreenHeaderOnboardingRow>
+        <IconButton variant="tertiary" size="32" icon={<ChevronLeftIcon />} aria-label="Previous" />
+        <div className="flex flex-col items-center gap-3">
+          <p className="typography-semibold-body-lg text-center text-content-primary">Title</p>
+          <ScreenHeaderDotIndicators count={11} activeIndex={0} className="w-[168px]" />
+        </div>
+        <IconButton variant="tertiary" size="32" icon={<ChevronRightIcon />} aria-label="Next" />
+      </ScreenHeaderOnboardingRow>
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const Insight: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md">
+      <ScreenHeaderToolbar>
+        <ScreenHeaderTitle className="min-w-0 flex-1">Insight</ScreenHeaderTitle>
+        <ScreenHeaderActions className="gap-4">
+          <IconButton variant="tertiary" size="32" icon={<UploadIcon />} aria-label="Upload" />
+          <div className="flex items-center gap-0">
+            <IconButton
+              variant="tertiary"
+              size="32"
+              icon={<ChevronLeftIcon />}
+              aria-label="Previous day"
+            />
+            <Button variant="tertiary" size="32" className="typography-semibold-body-lg underline">
+              Today
+            </Button>
+            <IconButton
+              variant="tertiary"
+              size="32"
+              icon={<ChevronRightIcon />}
+              aria-label="Next day"
+            />
+          </div>
+        </ScreenHeaderActions>
+      </ScreenHeaderToolbar>
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};
+
+export const SimpleText: Story = {
+  render: (args) => (
+    <ScreenHeader {...args} className="max-w-md">
+      <ScreenHeaderToolbar>
+        <ScreenHeaderTitle className="min-w-0 flex-1">Text</ScreenHeaderTitle>
+      </ScreenHeaderToolbar>
+    </ScreenHeader>
+  ),
+  args: { device: "mobile", surface: "default" },
+};

--- a/src/components/ScreenHeader/ScreenHeader.test.tsx
+++ b/src/components/ScreenHeader/ScreenHeader.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import {
+  ScreenHeader,
+  ScreenHeaderActions,
+  ScreenHeaderDotIndicators,
+  ScreenHeaderGreeting,
+  ScreenHeaderSteps,
+  ScreenHeaderTitle,
+  ScreenHeaderToolbar,
+} from "./ScreenHeader";
+
+describe("ScreenHeader", () => {
+  describe("API", () => {
+    it("applies custom className on the root", () => {
+      render(
+        <ScreenHeader className="custom-shell" data-testid="shell">
+          <span>x</span>
+        </ScreenHeader>,
+      );
+      expect(screen.getByTestId("shell")).toHaveClass("custom-shell");
+    });
+
+    it("forwards ref on the root", () => {
+      const ref = createRef<HTMLDivElement>();
+      render(
+        <ScreenHeader ref={ref}>
+          <span>x</span>
+        </ScreenHeader>,
+      );
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("applies frosted surface classes", () => {
+      render(
+        <ScreenHeader surface="frosted" data-testid="shell">
+          <span>x</span>
+        </ScreenHeader>,
+      );
+      expect(screen.getByTestId("shell").className).toContain("backdrop-blur");
+    });
+  });
+
+  describe("ScreenHeaderSteps", () => {
+    it("renders the requested number of segments", () => {
+      render(<ScreenHeaderSteps total={6} activeIndex={0} />);
+      const group = screen.getByRole("group", { name: "Step progress" });
+      expect(group.querySelectorAll(":scope > div").length).toBe(6);
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations for a typical toolbar", async () => {
+      const { container } = render(
+        <ScreenHeader>
+          <ScreenHeaderToolbar>
+            <ScreenHeaderTitle className="min-w-0 flex-1">Home</ScreenHeaderTitle>
+            <ScreenHeaderActions>
+              <button type="button">Action</button>
+            </ScreenHeaderActions>
+          </ScreenHeaderToolbar>
+        </ScreenHeader>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations for greeting and steps", async () => {
+      const { container } = render(
+        <ScreenHeader>
+          <ScreenHeaderGreeting greetingTitle="Hello" greetingSubtitle="Profile" />
+          <ScreenHeaderSteps total={4} activeIndex={1} />
+          <ScreenHeaderDotIndicators count={5} activeIndex={2} />
+        </ScreenHeader>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/ScreenHeader/ScreenHeader.tsx
+++ b/src/components/ScreenHeader/ScreenHeader.tsx
@@ -1,0 +1,224 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Horizontal padding preset for the screen header shell. */
+export type ScreenHeaderDevice = "desktop" | "mobile";
+
+/** Background treatment for the shell (e.g. frosted bar over imagery). */
+export type ScreenHeaderSurface = "default" | "frosted";
+
+export interface ScreenHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Horizontal / vertical padding preset. @default "mobile" */
+  device?: ScreenHeaderDevice;
+  /** Background blur and translucent fill when `frosted`. @default "default" */
+  surface?: ScreenHeaderSurface;
+}
+
+export interface ScreenHeaderToolbarProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface ScreenHeaderTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+export interface ScreenHeaderActionsProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface ScreenHeaderGreetingProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Primary line (e.g. “Hello, [Name]”). */
+  greetingTitle: React.ReactNode;
+  /** Secondary line (e.g. “Profile”). */
+  greetingSubtitle?: React.ReactNode;
+}
+
+export interface ScreenHeaderStepsProps extends React.FieldsetHTMLAttributes<HTMLFieldSetElement> {
+  /** Number of segments. */
+  total: number;
+  /** Zero-based index of the filled segment. */
+  activeIndex: number;
+  /** Legend text for the fieldset. @default "Step progress" */
+  progressLabel?: string;
+}
+
+export interface ScreenHeaderDotIndicatorsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Number of dots. */
+  count: number;
+  /** Zero-based index of the active dot. */
+  activeIndex: number;
+}
+
+export interface ScreenHeaderOnboardingRowProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+/**
+ * Shell for mobile-first screen top bars (Figma “Header”). Compose with
+ * {@link ScreenHeaderToolbar}, {@link ScreenHeaderTitle}, {@link ScreenHeaderActions},
+ * {@link ScreenHeaderSteps}, and {@link ScreenHeaderDotIndicators}.
+ *
+ * @example
+ * ```tsx
+ * <ScreenHeader device="mobile">
+ *   <ScreenHeaderToolbar>
+ *     <ScreenHeaderTitle className="min-w-0 flex-1">Home</ScreenHeaderTitle>
+ *     <ScreenHeaderActions>
+ *       <IconButton variant="tertiary" size="32" icon={<SearchIcon />} aria-label="Search" />
+ *     </ScreenHeaderActions>
+ *   </ScreenHeaderToolbar>
+ * </ScreenHeader>
+ * ```
+ */
+export const ScreenHeader = React.forwardRef<HTMLDivElement, ScreenHeaderProps>(
+  ({ className, device = "mobile", surface = "default", ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex min-h-16 w-full flex-wrap items-center gap-2",
+          device === "mobile" ? "p-4" : "px-6 py-4",
+          surface === "frosted" &&
+            "bg-surface-primary/80 backdrop-blur-[20px] supports-[backdrop-filter]:bg-surface-primary/60",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+ScreenHeader.displayName = "ScreenHeader";
+
+/**
+ * Single-row toolbar: place {@link ScreenHeaderTitle} and {@link ScreenHeaderActions} as children.
+ */
+export const ScreenHeaderToolbar = React.forwardRef<HTMLDivElement, ScreenHeaderToolbarProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("flex w-full min-w-0 items-center gap-2", className)}
+        {...props}
+      />
+    );
+  },
+);
+ScreenHeaderToolbar.displayName = "ScreenHeaderToolbar";
+
+/** Bold title line (heading-2 scale). */
+export const ScreenHeaderTitle = React.forwardRef<HTMLHeadingElement, ScreenHeaderTitleProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <h2
+        ref={ref}
+        className={cn(
+          "typography-bold-heading-xs min-w-0 shrink truncate text-content-primary leading-[26px]",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+ScreenHeaderTitle.displayName = "ScreenHeaderTitle";
+
+/** Trailing icon buttons or controls in a {@link ScreenHeaderToolbar}. */
+export const ScreenHeaderActions = React.forwardRef<HTMLDivElement, ScreenHeaderActionsProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cn("flex shrink-0 items-center gap-2", className)} {...props} />
+    );
+  },
+);
+ScreenHeaderActions.displayName = "ScreenHeaderActions";
+
+/**
+ * Two-line greeting block (e.g. home dashboard).
+ */
+export const ScreenHeaderGreeting = React.forwardRef<HTMLDivElement, ScreenHeaderGreetingProps>(
+  ({ className, greetingTitle, greetingSubtitle, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("flex min-w-0 flex-1 flex-col items-start gap-0.5", className)}
+        {...props}
+      >
+        <p className="typography-bold-heading-xs w-full min-w-0 text-content-primary leading-[26px]">
+          {greetingTitle}
+        </p>
+        {greetingSubtitle !== undefined && greetingSubtitle !== null && (
+          <p className="typography-regular-body-md text-content-secondary">{greetingSubtitle}</p>
+        )}
+      </div>
+    );
+  },
+);
+ScreenHeaderGreeting.displayName = "ScreenHeaderGreeting";
+
+/**
+ * Segmented horizontal progress (Figma “Page Ticker”).
+ */
+export const ScreenHeaderSteps = React.forwardRef<HTMLFieldSetElement, ScreenHeaderStepsProps>(
+  ({ className, total, activeIndex, progressLabel = "Step progress", ...props }, ref) => {
+    const safeTotal = Math.max(0, Math.floor(total));
+    const safeActive = Math.min(Math.max(0, Math.floor(activeIndex)), Math.max(0, safeTotal - 1));
+
+    return (
+      <fieldset
+        ref={ref}
+        className={cn("m-0 flex w-full min-w-0 flex-1 gap-2 border-0 px-4 py-2.5", className)}
+        {...props}
+      >
+        <legend className="sr-only">{progressLabel}</legend>
+        {Array.from({ length: safeTotal }, (_, i) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed segment count; order is stable
+            key={i}
+            className={cn(
+              "h-1 min-h-px min-w-0 flex-1 rounded-2xl",
+              i === safeActive ? "bg-buttons-primary" : "bg-neutral-alphas-100",
+            )}
+          />
+        ))}
+      </fieldset>
+    );
+  },
+);
+ScreenHeaderSteps.displayName = "ScreenHeaderSteps";
+
+/**
+ * Row of pagination dots (e.g. under a centered title).
+ */
+export const ScreenHeaderDotIndicators = React.forwardRef<
+  HTMLDivElement,
+  ScreenHeaderDotIndicatorsProps
+>(({ className, count, activeIndex, ...props }, ref) => {
+  const safeCount = Math.max(0, Math.floor(count));
+  const safeActive = Math.min(Math.max(0, Math.floor(activeIndex)), Math.max(0, safeCount - 1));
+
+  return (
+    <div ref={ref} className={cn("flex items-center justify-center gap-1.5", className)} {...props}>
+      {Array.from({ length: safeCount }, (_, i) => (
+        <span
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed dot count; order is stable
+          key={i}
+          role="presentation"
+          className={cn(
+            "size-2 shrink-0 rounded-full",
+            i === safeActive ? "bg-content-primary" : "bg-neutral-alphas-200",
+          )}
+        />
+      ))}
+    </div>
+  );
+});
+ScreenHeaderDotIndicators.displayName = "ScreenHeaderDotIndicators";
+
+/**
+ * Full-width row for centered title + dots with edge chevrons (onboarding carousel).
+ */
+export const ScreenHeaderOnboardingRow = React.forwardRef<
+  HTMLDivElement,
+  ScreenHeaderOnboardingRowProps
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn("flex w-full min-w-0 flex-1 items-center justify-between px-4 py-3", className)}
+      {...props}
+    />
+  );
+});
+ScreenHeaderOnboardingRow.displayName = "ScreenHeaderOnboardingRow";

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,6 +312,19 @@ export { Loader } from "./components/Loader/Loader";
 export type { LogoColor, LogoProps, LogoVariant } from "./components/Logo/Logo";
 export { Logo } from "./components/Logo/Logo";
 export type {
+  MainContainerHeaderDevice,
+  MainContainerHeaderEndProps,
+  MainContainerHeaderProps,
+  MainContainerHeaderStartProps,
+  MainContainerHeaderTitleProps,
+} from "./components/MainContainerHeader/MainContainerHeader";
+export {
+  MainContainerHeader,
+  MainContainerHeaderEnd,
+  MainContainerHeaderStart,
+  MainContainerHeaderTitle,
+} from "./components/MainContainerHeader/MainContainerHeader";
+export type {
   MobileStepperPosition,
   MobileStepperProps,
   MobileStepperVariant,
@@ -344,6 +357,28 @@ export type { RadioProps } from "./components/Radio/Radio";
 export { Radio } from "./components/Radio/Radio";
 export type { RadioGroupProps } from "./components/RadioGroup/RadioGroup";
 export { RadioGroup } from "./components/RadioGroup/RadioGroup";
+export type {
+  ScreenHeaderActionsProps,
+  ScreenHeaderDevice,
+  ScreenHeaderDotIndicatorsProps,
+  ScreenHeaderGreetingProps,
+  ScreenHeaderOnboardingRowProps,
+  ScreenHeaderProps,
+  ScreenHeaderStepsProps,
+  ScreenHeaderSurface,
+  ScreenHeaderTitleProps,
+  ScreenHeaderToolbarProps,
+} from "./components/ScreenHeader/ScreenHeader";
+export {
+  ScreenHeader,
+  ScreenHeaderActions,
+  ScreenHeaderDotIndicators,
+  ScreenHeaderGreeting,
+  ScreenHeaderOnboardingRow,
+  ScreenHeaderSteps,
+  ScreenHeaderTitle,
+  ScreenHeaderToolbar,
+} from "./components/ScreenHeader/ScreenHeader";
 export type {
   SearchFieldProps,
   SearchFieldSize,


### PR DESCRIPTION
## Summary
- `MainContainerHeader` + `ScreenHeader` compound components using v2 design tokens (`DesignTokenMigration.mdx`)
- Stories, tests, `src/index.ts` exports
- App demos with preview shells + TOC entries

## Note
Direct push to `main` is blocked (protected branch); opening PR from `feat/main-container-screen-headers`.

Made with [Cursor](https://cursor.com)