### PR TITLE
fix(alert): top-align icon for multi-line body text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1556,7 +1556,8 @@ function AlertDemo() {
       <h2 className="typography-bold-heading-sm mb-4">Alert</h2>
       <div className="max-w-2xl space-y-4">
         <Alert variant="info" icon={<InfoCircleIcon />}>
-          This is an informational alert message.
+          This is an informational alert with enough text to wrap across multiple lines so the icon
+          stays aligned to the top of the message.
         </Alert>
         <Alert variant="success" icon={<CheckCircleIcon />}>
           Your changes have been saved successfully.

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -96,7 +96,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
         {...props}
       >
         {resolvedIcon && (
-          <span className="flex shrink-0 items-start" aria-hidden="true">
+          <span className="flex shrink-0 items-start h-full" aria-hidden="true">
             {resolvedIcon}
           </span>
         )}


### PR DESCRIPTION
## Summary
- Add `h-full` on the icon wrapper so it fills the grid row; the inner flex keeps `items-start` so the glyph stays top-aligned when body text wraps.
- Refresh the Alert demo with a wrapping info example.

## Notes
Body-only alerts use vertically centered grid items; without a full-height icon column the icon sat vertically centered next to wrapped text.

Made with [Cursor](https://cursor.com)