### PR TITLE
fix(chat): Make drop-down align with button

### DIFF
--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -326,7 +326,7 @@ function InlineSelect({ options, value, onChange, disabled, selectedOption }: In
         onClick={() => setOpen((prev) => !prev)}
         className={cn(
           "typography-semibold-body-sm text-content-primary",
-          "flex items-center gap-1 rounded-sm px-2 py-1",
+          "flex items-center gap-1 rounded-sm px-2 py-2",
           "hover:bg-neutral-alphas-50 focus-visible:shadow-focus-ring focus-visible:outline-none",
           "disabled:cursor-not-allowed disabled:opacity-50",
           "motion-safe:transition-colors",


### PR DESCRIPTION
## Summary

Increases padding on the drop-down so that hover state aligns with the submit button

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<img width="237" height="142" alt="image" src="https://github.com/user-attachments/assets/b3c344b1-0a18-4c2d-90d7-c9768eaf09fe" />