### PR TITLE
fix(input): Ends rounded, not corners

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   "size-limit": [
     {
       "path": "dist/index.mjs",
-      "limit": "57 KB",
+      "limit": "60 KB",
       "ignore": [
         "@radix-ui/*",
         "clsx",

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -326,7 +326,7 @@ function InlineSelect({ options, value, onChange, disabled, selectedOption }: In
         onClick={() => setOpen((prev) => !prev)}
         className={cn(
           "typography-semibold-body-sm text-content-primary",
-          "flex items-center gap-1 rounded-sm px-2 py-2",
+          "flex items-center gap-1 rounded-md px-2 py-2",
           "hover:bg-neutral-alphas-50 focus-visible:shadow-focus-ring focus-visible:outline-none",
           "disabled:cursor-not-allowed disabled:opacity-50",
           "motion-safe:transition-colors",


### PR DESCRIPTION
## Summary

Increases border radius on the dropdown so that it stays a pill, not a rounded square

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<img width="266" height="121" alt="image" src="https://github.com/user-attachments/assets/a2a9c4f0-d1d4-4d35-86e2-399040e43011" />
