### PR TITLE
fix(BottomNavigation): prevent indicator glow clipping on narrow containers

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -89,7 +89,7 @@ export const BottomNavigation = React.forwardRef<HTMLElement, BottomNavigationPr
                 >
                   <div className="h-px w-full bg-linear-to-r from-transparent via-(--color-special-bottom-nav-highlight) to-transparent" />
                   <div className="h-20 w-full overflow-hidden">
-                    <div className="mx-auto aspect-square w-[70%] max-w-[70px] -translate-y-1/2 rounded-full bg-(--color-special-bottom-nav-highlight) opacity-30 blur-[20px] dark:opacity-15" />
+                    <div className="mx-auto aspect-square w-[70%] max-w-[70px] -translate-y-1/2 rounded-full bg-(--color-special-bottom-nav-highlight) opacity-30 blur-[min(20px,2vw)] dark:opacity-15" />
                   </div>
                 </div>
               </div>

--- a/src/components/BottomNavigation/BottomNavigationAction.tsx
+++ b/src/components/BottomNavigation/BottomNavigationAction.tsx
@@ -46,7 +46,7 @@ export const BottomNavigationAction = React.forwardRef<
         onClick={handleClick}
         {...props}
         className={cn(
-          "relative flex min-w-0 flex-1 cursor-pointer flex-col items-center justify-center gap-1 px-2",
+          "relative flex min-w-0 flex-1 cursor-pointer flex-col items-center justify-center gap-1",
           isActive ? "text-icons-primary" : "text-icons-tertiary",
           "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary",


### PR DESCRIPTION
## Summary
- Replace fixed `blur-[20px]` with dynamic `blur-[min(20px,2vw)]` on the IA nav indicator glow so it scales with viewport width and doesn't get hard-clipped by `overflow-hidden` on narrow containers
- Remove `px-2` horizontal padding from IA nav buttons to give labels more room

## Test plan
- [x] Open BottomNavigation storybook stories (Information Architecture Nav variants)
- [x] Resize viewport to narrow widths — glow should scale down smoothly instead of being clipped
- [x] Verify wider viewports still show the full 20px blur effect
- [x] Check non-IA nav stories are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)