### PR TITLE
fix(BottomNavigation): fix label truncation for long locales

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.stories.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.stories.tsx
@@ -259,6 +259,57 @@ export const InformationArchitectureNavWithBadges: Story = {
   },
 };
 
+export const InformationArchitectureNavPortuguese: Story = {
+  name: "Information Architecture Nav – Portuguese",
+  render: () => {
+    const [value, setValue] = React.useState("notifications");
+    return (
+      <BottomNavigation
+        value={value}
+        onValueChange={setValue}
+        hasInformationArchitectureNav
+        aria-label="Main navigation"
+      >
+        <BottomNavigationAction value="home" icon={<HomeIcon />} label="Início" />
+        <BottomNavigationAction
+          value="notifications"
+          icon={<BellIcon />}
+          label="Notificações"
+          badge={
+            <Count
+              value={6}
+              max={99}
+              variant="default"
+              size="24"
+              className="ring-2 ring-bg-primary"
+            />
+          }
+        />
+        <BottomNavigationAction value="create" icon={<AddIcon />} label="Nova Publicação" />
+        <BottomNavigationAction
+          value="messages"
+          icon={<MessageIcon />}
+          label="Mensagens"
+          badge={
+            <Count
+              value={2}
+              max={99}
+              variant="default"
+              size="24"
+              className="ring-2 ring-bg-primary"
+            />
+          }
+        />
+        <BottomNavigationAction
+          value="profile"
+          icon={<Avatar size={32} alt="User" fallback="OH" />}
+          label="Perfil"
+        />
+      </BottomNavigation>
+    );
+  },
+};
+
 export const InformationArchitectureNavSelected: Story = {
   name: "Information Architecture Nav – Selected State",
   render: () => (

--- a/src/components/BottomNavigation/BottomNavigationAction.tsx
+++ b/src/components/BottomNavigation/BottomNavigationAction.tsx
@@ -63,7 +63,7 @@ export const BottomNavigationAction = React.forwardRef<
         {label && (
           <span
             className={cn(
-              "typography-medium-caption-xs truncate text-center motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
+              "typography-medium-caption-xs max-w-full truncate text-center motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
               isActive ? "text-content-primary" : "text-content-tertiary",
             )}
           >


### PR DESCRIPTION
## Summary
- Adds `max-w-full` to the label span in the information architecture nav variant so `truncate` actually works — previously labels like "Notificações" and "Nova Publicação" overflowed instead of truncating
- Adds a new story **"Information Architecture Nav – Portuguese"** with Portuguese labels and badges to catch this visually

## Test plan
- [ ] Open Storybook → Components/BottomNavigation → "Information Architecture Nav – Portuguese"
- [ ] Verify labels truncate correctly at narrow widths
- [ ] Verify existing English stories still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)