### PR TITLE
refactor(empty-state): accept string or ReactNode for slots

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1688,6 +1688,10 @@ function EmptyStateDemo() {
     </div>
   );
 
+  const stringSlotMediaSrc = `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="280" viewBox="0 0 400 280"><rect width="400" height="280" fill="%23e5e7eb"/><circle cx="200" cy="140" r="40" fill="%239ca3af"/></svg>',
+  )}`;
+
   return (
     <div id="empty-state" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-bold-heading-sm mb-4">Empty State</h2>
@@ -1706,6 +1710,21 @@ function EmptyStateDemo() {
           description="Add your photos to the Vault to start sharing your creations and earning."
           primaryAction={<Button variant="brand">Add Media to Vault</Button>}
           secondaryAction={<Button variant="secondary">Learn more</Button>}
+        />
+      </div>
+      <h3 className="typography-bold-heading-xs text-content-secondary">String slots</h3>
+      <p className="typography-regular-body-md text-content-secondary max-w-xl">
+        Title, description, media URL, and action labels as strings: typography and buttons are
+        applied inside <code className="typography-regular-body-md">EmptyState</code>.
+      </p>
+      <div className="flex flex-wrap items-start gap-8">
+        <EmptyState
+          variant="default"
+          media={stringSlotMediaSrc}
+          title="All strings"
+          description="Media is a URL string (inline SVG). Primary and secondary actions are label strings."
+          primaryAction="Primary action"
+          secondaryAction="Secondary action"
         />
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1695,13 +1695,33 @@ function EmptyStateDemo() {
   return (
     <div id="empty-state" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-bold-heading-sm mb-4">Empty State</h2>
+      <h3 className="typography-bold-heading-xs text-content-secondary">
+        ReactNode slots (previous pattern)
+      </h3>
+      <p className="typography-regular-body-md text-content-secondary max-w-xl">
+        Pass elements for <code className="typography-regular-body-md">media</code>,{" "}
+        <code className="typography-regular-body-md">title</code>,{" "}
+        <code className="typography-regular-body-md">description</code>, and actions—for example
+        custom layout around an image and explicit{" "}
+        <code className="typography-regular-body-md">Button</code> components (including{" "}
+        <code className="typography-regular-body-md">asChild</code> links).
+      </p>
       <div className="flex flex-wrap items-start gap-8">
         <EmptyState
           variant="default"
           media={artwork}
-          title="Empty Vault, Full Potential!"
-          description="Add your photos to the Vault to start sharing your creations and earning."
-          primaryAction={<Button variant="brand">Add Media to Vault</Button>}
+          title={<span className="whitespace-pre-line">{"Empty Vault\nFull Potential!"}</span>}
+          description={
+            <span className="text-content-tertiary">
+              Title and description as custom nodes (e.g. i18n with line breaks or{" "}
+              <code className="typography-regular-body-md">Trans</code>).
+            </span>
+          }
+          primaryAction={
+            <Button variant="primary" asChild>
+              <a href="#empty-state">Discover as link CTA</a>
+            </Button>
+          }
         />
         <EmptyState
           variant="centered"
@@ -1712,7 +1732,7 @@ function EmptyStateDemo() {
           secondaryAction={<Button variant="secondary">Learn more</Button>}
         />
       </div>
-      <h3 className="typography-bold-heading-xs text-content-secondary">String slots</h3>
+      <h3 className="typography-bold-heading-xs text-content-secondary mt-6">String slots</h3>
       <p className="typography-regular-body-md text-content-secondary max-w-xl">
         Title, description, media URL, and action labels as strings: typography and buttons are
         applied inside <code className="typography-regular-body-md">EmptyState</code>.

--- a/src/components/EmptyState/EmptyState.stories.tsx
+++ b/src/components/EmptyState/EmptyState.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
     layout: "padded",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=14487-61248&m=dev",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=14487-61260&m=dev",
     },
   },
   tags: ["autodocs"],

--- a/src/components/EmptyState/EmptyState.test.tsx
+++ b/src/components/EmptyState/EmptyState.test.tsx
@@ -25,6 +25,27 @@ describe("EmptyState", () => {
     expect(screen.getByRole("button", { name: "Read guide" })).toBeInTheDocument();
   });
 
+  it("renders string actions as full-width buttons", () => {
+    render(<EmptyState title="Title" primaryAction="Primary" secondaryAction="Secondary" />);
+
+    expect(screen.getByRole("button", { name: "Primary" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Secondary" })).toBeInTheDocument();
+  });
+
+  it("renders string media as an image", () => {
+    const { container } = render(<EmptyState title="T" media="https://example.com/empty.png" />);
+
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img).toHaveAttribute("src", "https://example.com/empty.png");
+  });
+
+  it("uses a heading for string titles", () => {
+    render(<EmptyState title="No media yet" />);
+
+    expect(screen.getByRole("heading", { level: 2, name: "No media yet" })).toBeInTheDocument();
+  });
+
   it("has no serious axe violations", async () => {
     const { container } = render(
       <EmptyState

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,7 +1,25 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { Button } from "../Button/Button";
 
 export type EmptyStateVariant = "default" | "centered";
+
+/** Slot that can be plain copy (styled by `EmptyState`) or custom markup. */
+export type EmptyStateSlot = string | React.ReactNode;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function hasSlotContent(value: EmptyStateSlot | undefined): boolean {
+  if (value === undefined || value === null || value === false) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.length > 0;
+  }
+  return true;
+}
 
 export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
   /**
@@ -9,16 +27,25 @@ export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLElement>,
    * @default "default"
    */
   variant?: EmptyStateVariant;
-  /** Main heading. */
-  title?: React.ReactNode;
-  /** Supporting body copy. */
-  description?: React.ReactNode;
-  /** Top visual/illustration slot. */
-  media?: React.ReactNode;
-  /** Primary call-to-action node. */
-  primaryAction?: React.ReactNode;
-  /** Optional secondary action rendered below primary. */
-  secondaryAction?: React.ReactNode;
+  /** Main heading. Strings use library heading styles; pass a node for full control. */
+  title?: EmptyStateSlot;
+  /** Supporting body copy. Strings use library body styles; pass a node for rich text. */
+  description?: EmptyStateSlot;
+  /**
+   * Top visual / illustration slot.
+   * A string is treated as an image URL (`<img src={…}>`); pass a node for custom layout.
+   */
+  media?: EmptyStateSlot;
+  /**
+   * Primary call to action.
+   * A string renders a brand `Button` with that label; pass a node for links, loading, etc.
+   */
+  primaryAction?: EmptyStateSlot;
+  /**
+   * Secondary action below the primary.
+   * A string renders a secondary `Button` with that label; pass a node when you need more control.
+   */
+  secondaryAction?: EmptyStateSlot;
 }
 
 export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
@@ -37,8 +64,78 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
   ) => {
     const isCentered = variant === "centered";
     const titleId = React.useId();
-    const regionLabelledBy =
-      title !== undefined && title !== null && title !== false ? titleId : undefined;
+    const regionLabelledBy = hasSlotContent(title) ? titleId : undefined;
+
+    const renderedPrimary =
+      primaryAction === undefined ||
+      primaryAction === null ||
+      primaryAction === false ||
+      primaryAction === "" ? null : isNonEmptyString(primaryAction) ? (
+        <Button variant="brand" fullWidth>
+          {primaryAction}
+        </Button>
+      ) : (
+        primaryAction
+      );
+
+    const renderedSecondary =
+      secondaryAction === undefined ||
+      secondaryAction === null ||
+      secondaryAction === false ||
+      secondaryAction === "" ? null : isNonEmptyString(secondaryAction) ? (
+        <Button variant="secondary" fullWidth>
+          {secondaryAction}
+        </Button>
+      ) : (
+        secondaryAction
+      );
+
+    const renderedTitle =
+      title === undefined ||
+      title === null ||
+      title === false ||
+      title === "" ? null : isNonEmptyString(title) ? (
+        <h2 id={titleId} className="m-0 typography-bold-heading-lg text-content-primary">
+          {title}
+        </h2>
+      ) : (
+        <div
+          id={titleId}
+          className="typography-bold-heading-lg text-content-primary min-w-0 w-full"
+        >
+          {title}
+        </div>
+      );
+
+    const renderedDescription =
+      description === undefined ||
+      description === null ||
+      description === false ||
+      description === "" ? null : isNonEmptyString(description) ? (
+        <p className="m-0 typography-regular-body-lg text-content-secondary">{description}</p>
+      ) : (
+        <div className="typography-regular-body-lg text-content-secondary min-w-0 w-full">
+          {description}
+        </div>
+      );
+
+    const renderedMedia =
+      media === undefined ||
+      media === null ||
+      media === false ||
+      media === "" ? null : isNonEmptyString(media) ? (
+        <img
+          src={media}
+          alt=""
+          decoding="async"
+          className="block h-full w-full object-contain object-center"
+        />
+      ) : (
+        media
+      );
+
+    const showMedia = renderedMedia !== null;
+    const showActions = renderedPrimary !== null || renderedSecondary !== null;
 
     return (
       <section
@@ -52,8 +149,8 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
         )}
         {...props}
       >
-        {media !== undefined && media !== null && (
-          <div className="h-[280px] w-full overflow-hidden rounded-md">{media}</div>
+        {showMedia && (
+          <div className="h-[280px] w-full overflow-hidden rounded-md">{renderedMedia}</div>
         )}
 
         <div
@@ -65,21 +162,14 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
               isCentered ? "items-center" : "items-start",
             )}
           >
-            {title !== undefined && title !== null && title !== false && (
-              <div id={titleId} className="typography-bold-heading-lg text-content-primary">
-                {title}
-              </div>
-            )}
-            {description !== undefined && description !== null && description !== false && (
-              <p className="typography-regular-body-lg text-content-secondary">{description}</p>
-            )}
+            {renderedTitle}
+            {renderedDescription}
           </div>
 
-          {(primaryAction !== undefined && primaryAction !== null) ||
-          (secondaryAction !== undefined && secondaryAction !== null) ? (
+          {showActions ? (
             <div className={cn("flex flex-col gap-4", isCentered ? "items-center" : "items-start")}>
-              {primaryAction}
-              {secondaryAction}
+              {renderedPrimary}
+              {renderedSecondary}
             </div>
           ) : null}
         </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,11 @@ export {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./components/DropdownMenu/DropdownMenu";
-export type { EmptyStateProps, EmptyStateVariant } from "./components/EmptyState/EmptyState";
+export type {
+  EmptyStateProps,
+  EmptyStateSlot,
+  EmptyStateVariant,
+} from "./components/EmptyState/EmptyState";
 export { EmptyState } from "./components/EmptyState/EmptyState";
 export type {
   IconButtonProps,


### PR DESCRIPTION
## Summary

- `EmptyState` slots (`title`, `description`, `media`, `primaryAction`, `secondaryAction`) are typed as `EmptyStateSlot` (`string | React.ReactNode`).
- Non-empty strings use internal typography (`h2` / `p`), treat `media` as an image `src`, and render primary/secondary actions as full-width brand/secondary `Button`s.
- React nodes keep escape-hatch behaviour with the same layout wrappers as before for title and description.
- Export `EmptyStateSlot` from the package entry. Storybook Figma node updated. Tests and an App gallery demo cover string slots.

## Test plan

- [ ] `pnpm exec vitest run src/components/EmptyState/EmptyState.test.tsx`
- [ ] Spot-check Empty State section in the fanv-ui App gallery

Made with [Cursor](https://cursor.com)