### PR TITLE
feat: export Slot/Slottable, move react-slot to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "publish:dry-run": "pnpm run build && pnpm publish --dry-run"
   },
   "peerDependencies": {
+    "@radix-ui/react-slot": "^1.2.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-day-picker": "^9.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
@@ -97,7 +98,6 @@
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-separator": "1.1.8",
     "@radix-ui/react-slider": "1.3.6",
-    "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-switch": "1.2.6",
     "@radix-ui/react-tabs": "1.1.13",
     "@radix-ui/react-toast": "1.2.15",
@@ -119,6 +119,7 @@
     "@storybook/addon-vitest": "10.2.3",
     "@storybook/react": "10.2.1",
     "@storybook/react-vite": "10.2.1",
+    "@radix-ui/react-slot": "1.2.4",
     "@tailwindcss/postcss": "4.1.18",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,6 @@ importers:
       '@radix-ui/react-slider':
         specifier: 1.3.6
         version: 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-slot':
-        specifier: 1.2.4
-        version: 1.2.4(@types/react@19.2.9)(react@19.2.3)
       '@radix-ui/react-switch':
         specifier: 1.2.6
         version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -89,6 +86,9 @@ importers:
       '@playwright/test':
         specifier: 1.58.1
         version: 1.58.1
+      '@radix-ui/react-slot':
+        specifier: 1.2.4
+        version: 1.2.4(@types/react@19.2.9)(react@19.2.3)
       '@size-limit/preset-small-lib':
         specifier: 12.0.0
         version: 12.0.0(size-limit@12.0.0(jiti@2.6.1))

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  * Avoid barrel files, re-exports of entire modules, or side effects in this entry point.
  */
 
+export { Slot, Slottable } from "@radix-ui/react-slot";
 export type { AccordionProps } from "./components/Accordion/Accordion";
 export { Accordion } from "./components/Accordion/Accordion";
 export type { AccordionContentProps } from "./components/Accordion/AccordionContent";


### PR DESCRIPTION
## Summary

- Moves `@radix-ui/react-slot` from `dependencies` to `peerDependencies` so consumers share a single copy
- Re-exports `Slot` and `Slottable` from the package entry point for convenience
- Adds `@radix-ui/react-slot` to `devDependencies` for local development

## Why

Consumers building `asChild`-capable components (e.g. `NavigationListItem` in `fanv-ui-internal`) import `Slot` and `Slottable` from `@radix-ui/react-slot`. When this package is a regular dependency, bundlers like Vite (particularly Storybook's pre-bundling) can create separate chunks for `@fanvue/ui`'s copy and the consumer's copy. Each chunk gets its own `Symbol("radix.slottable")`, which breaks the `Slot`/`Slottable` identity check at runtime (`React.Children.only expected to receive a single React element child`).

Making it a peer dependency ensures the package manager installs one copy at the top level, and re-exporting from `@fanvue/ui` gives consumers an import path guaranteed to resolve to the same module instance.

## Migration

Consumers using `@radix-ui/react-slot` directly should add it to their own `package.json`:

```sh
pnpm add @radix-ui/react-slot
```

Or import from `@fanvue/ui` instead:

```diff
-import { Slot, Slottable } from "@radix-ui/react-slot";
+import { Slot, Slottable } from "@fanvue/ui";
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 2370 tests pass
- [x] `pnpm build` — `Slot` and `Slottable` present in `dist/index.mjs`
- [x] `pnpm lint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)