### PR TITLE
fix(BottomNavigation): shrink indicator glow on narrow items

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -88,8 +88,8 @@ export const BottomNavigation = React.forwardRef<HTMLElement, BottomNavigationPr
                   }}
                 >
                   <div className="h-px w-full bg-linear-to-r from-transparent via-(--color-special-bottom-nav-highlight) to-transparent" />
-                  <div className="h-20 w-full overflow-hidden">
-                    <div className="mx-auto aspect-square w-[70%] max-w-[70px] -translate-y-1/2 rounded-full bg-(--color-special-bottom-nav-highlight) opacity-30 blur-[min(20px,2vw)] dark:opacity-15" />
+                  <div className="@container h-20 w-full overflow-hidden">
+                    <div className="mx-auto aspect-square w-[70%] max-w-[70px] -translate-y-1/2 rounded-full bg-(--color-special-bottom-nav-highlight) opacity-30 blur-[min(20px,2vw)] @max-[80px]:w-[calc(70%-10px)] dark:opacity-15" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- When a `hasInformationArchitectureNav` item is ~70–80px wide (many items in a narrow viewport), the blurred spotlight halo extends past the item's clipping box and shows a visible cut on the edges.
- Makes the inner 80px-tall wrapper a container query context and subtracts 10px from the circle width once the item container is ≤80px, keeping the halo fully inside the clip at narrow widths. Wider items are unchanged (still `w-[70%]` up to the 70px cap).

## Test plan
- [ ] Storybook: resize `BottomNavigation` IA story until each item is ~70–80px — confirm the active-item glow no longer clips at the left/right edges.
- [ ] Verify wider layouts (4–5 items on desktop widths) still render the same spotlight size.
- [ ] Dark mode still reads correctly (opacity-15 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)