### PR TITLE
feat(Tooltip): add placement prop for MUI-style positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3694,6 +3694,40 @@ function TooltipDemo() {
               <TooltipContent>More information about this feature</TooltipContent>
             </Tooltip>
           </div>
+          <div className="flex flex-wrap items-center gap-4">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="32">
+                  top-start
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent placement="top-start">placement="top-start"</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="32">
+                  top-end
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent placement="top-end">placement="top-end"</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="32">
+                  bottom-start
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent placement="bottom-start">placement="bottom-start"</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="secondary" size="32">
+                  bottom-end
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent placement="bottom-end">placement="bottom-end"</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       </TooltipProvider>
     </div>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -13,6 +13,25 @@ const meta: Meta<typeof TooltipContent> = {
     },
   },
   tags: ["autodocs"],
+  argTypes: {
+    placement: {
+      control: "select",
+      options: [
+        "top",
+        "top-start",
+        "top-end",
+        "bottom",
+        "bottom-start",
+        "bottom-end",
+        "left",
+        "left-start",
+        "left-end",
+        "right",
+        "right-start",
+        "right-end",
+      ],
+    },
+  },
   decorators: [
     (Story) => (
       <TooltipProvider delayDuration={0}>
@@ -46,7 +65,7 @@ export const Bottom: Story = {
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
-      <TooltipContent side="bottom">Tooltip</TooltipContent>
+      <TooltipContent placement="bottom">Tooltip</TooltipContent>
     </Tooltip>
   ),
 };
@@ -59,7 +78,7 @@ export const Left: Story = {
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
-      <TooltipContent side="left">Tooltip</TooltipContent>
+      <TooltipContent placement="left">Tooltip</TooltipContent>
     </Tooltip>
   ),
 };
@@ -72,7 +91,7 @@ export const Right: Story = {
           <InfoCircleIcon className="size-5" />
         </button>
       </TooltipTrigger>
-      <TooltipContent side="right">Tooltip</TooltipContent>
+      <TooltipContent placement="right">Tooltip</TooltipContent>
     </Tooltip>
   ),
 };
@@ -93,44 +112,45 @@ export const LongContent: Story = {
 };
 
 export const AllPlacements: Story = {
-  render: () => (
-    <div className="flex flex-col items-center gap-24 py-16">
-      <Tooltip defaultOpen>
-        <TooltipTrigger asChild>
-          <button type="button" className="text-content-secondary">
-            <InfoCircleIcon className="size-5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top">Top</TooltipContent>
-      </Tooltip>
-      <div className="flex gap-48">
-        <Tooltip defaultOpen>
-          <TooltipTrigger asChild>
-            <button type="button" className="text-content-secondary">
-              <InfoCircleIcon className="size-5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="left">Left</TooltipContent>
-        </Tooltip>
-        <Tooltip defaultOpen>
-          <TooltipTrigger asChild>
-            <button type="button" className="text-content-secondary">
-              <InfoCircleIcon className="size-5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">Right</TooltipContent>
-        </Tooltip>
+  render: () => {
+    const placements = [
+      "top-start",
+      "top",
+      "top-end",
+      "left-start",
+      "spacer-1",
+      "right-start",
+      "left",
+      "spacer-2",
+      "right",
+      "left-end",
+      "spacer-3",
+      "right-end",
+      "bottom-start",
+      "bottom",
+      "bottom-end",
+    ] as const;
+    return (
+      <div className="grid grid-cols-3 place-items-center gap-24 py-24">
+        {placements.map((slot) =>
+          slot.startsWith("spacer") ? (
+            <div key={slot} />
+          ) : (
+            <Tooltip key={slot} defaultOpen>
+              <TooltipTrigger asChild>
+                <button type="button" className="text-content-secondary">
+                  <InfoCircleIcon className="size-5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent placement={slot as Exclude<typeof slot, `spacer-${string}`>}>
+                {slot}
+              </TooltipContent>
+            </Tooltip>
+          ),
+        )}
       </div>
-      <Tooltip defaultOpen>
-        <TooltipTrigger asChild>
-          <button type="button" className="text-content-secondary">
-            <InfoCircleIcon className="size-5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Bottom</TooltipContent>
-      </Tooltip>
-    </div>
-  ),
+    );
+  },
   parameters: {
     layout: "padded",
   },

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -54,6 +54,27 @@ describe("Tooltip", () => {
       await screen.findByRole("tooltip");
       expect(ref.current).toBeInstanceOf(HTMLDivElement);
     });
+
+    it("renders with placement prop without errors", async () => {
+      const user = userEvent.setup();
+      renderTooltip({ placement: "bottom-start" });
+      await user.hover(screen.getByRole("button", { name: "Hover me" }));
+      expect(await screen.findByRole("tooltip")).toHaveTextContent("Tooltip text");
+    });
+
+    it("renders with a placement that has no alignment suffix", async () => {
+      const user = userEvent.setup();
+      renderTooltip({ placement: "right" });
+      await user.hover(screen.getByRole("button", { name: "Hover me" }));
+      expect(await screen.findByRole("tooltip")).toHaveTextContent("Tooltip text");
+    });
+
+    it("still accepts side and align directly when placement is not provided", async () => {
+      const user = userEvent.setup();
+      renderTooltip({ side: "left", align: "end" });
+      await user.hover(screen.getByRole("button", { name: "Hover me" }));
+      expect(await screen.findByRole("tooltip")).toHaveTextContent("Tooltip text");
+    });
   });
 
   describe("accessibility", () => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -24,16 +24,51 @@ export type TooltipTriggerProps = React.ComponentPropsWithoutRef<typeof TooltipP
 /** The element that triggers the tooltip on hover/focus. */
 export const TooltipTrigger = TooltipPrimitive.Trigger;
 
-export type TooltipContentProps = React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>;
+/** Position of the tooltip relative to its trigger, combining side and alignment (MUI-style). */
+export type TooltipPlacement =
+  | "top"
+  | "top-start"
+  | "top-end"
+  | "bottom"
+  | "bottom-start"
+  | "bottom-end"
+  | "left"
+  | "left-start"
+  | "left-end"
+  | "right"
+  | "right-start"
+  | "right-end";
+
+export interface TooltipContentProps
+  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
+  /**
+   * Position of the tooltip relative to the trigger. Takes precedence over `side` and `align`.
+   * @default "top"
+   */
+  placement?: TooltipPlacement;
+}
 
 export const TooltipContent = React.forwardRef<
   React.ComponentRef<typeof TooltipPrimitive.Content>,
   TooltipContentProps
->(({ className, sideOffset = 8, style, ...props }, ref) => {
+>(({ className, sideOffset = 8, style, placement, side, align, ...props }, ref) => {
+  let resolvedSide = side;
+  let resolvedAlign: "start" | "center" | "end" = align ?? "center";
+  if (placement) {
+    const [parsedSide, parsedAlign] = placement.split("-") as [
+      "top" | "right" | "bottom" | "left",
+      "start" | "end" | undefined,
+    ];
+    resolvedSide = parsedSide;
+    resolvedAlign = parsedAlign ?? "center";
+  }
+
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         ref={ref}
+        side={resolvedSide}
+        align={resolvedAlign}
         sideOffset={sideOffset}
         collisionPadding={8}
         style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
@@ -41,7 +76,6 @@ export const TooltipContent = React.forwardRef<
           "typography-semibold-body-sm max-w-[320px] rounded-sm bg-surface-primary-inverted px-4 py-2 text-content-primary-inverted shadow-[0px_1px_4px_0px_rgba(0,0,0,0.06),0px_1px_3px_0px_rgba(0,0,0,0.05)]",
           className,
         )}
-        align="center"
         {...props}
       />
     </TooltipPrimitive.Portal>

--- a/src/index.ts
+++ b/src/index.ts
@@ -504,6 +504,7 @@ export type {
 export { Toast, ToastProvider, ToastViewport } from "./components/Toast/Toast";
 export type {
   TooltipContentProps,
+  TooltipPlacement,
   TooltipProps,
   TooltipProviderProps,
   TooltipTriggerProps,


### PR DESCRIPTION
## Summary

Addresses Slack request for a `placement` prop on Tooltip — consumers migrating from MUI were reaching for `@mui/material`'s Tooltip because they didn't know Radix exposes `side`/`align` separately.

- Adds `TooltipPlacement` type and `placement` prop on `TooltipContent` accepting MUI-style values: `"top"`, `"top-start"`, `"top-end"`, `"bottom"`, `"bottom-start"`, `"bottom-end"`, `"left"`, `"left-start"`, `"left-end"`, `"right"`, `"right-start"`, `"right-end"`.
- Internally decomposes to Radix's `side` + `align`. When `placement` is set it takes precedence; otherwise `side`/`align` continue to work for Radix-native consumers.
- Exports `TooltipPlacement` from `src/index.ts`.
- Adds story (`argTypes` control, refreshed `AllPlacements` grid) and App.tsx demo row showcasing `-start` / `-end` variants.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm biome check` — no new warnings on touched files
- [x] `pnpm vitest run src/components/Tooltip` — 14/14 pass (unit + Chromium story tests)
- [x] `pnpm build` — library builds cleanly
- [ ] Verify tooltip visually in Storybook (`pnpm storybook` → Components/Tooltip → All Placements) once deployed via Chromatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)