### PR TITLE
fix(forms): add focus ring to Select, TextField, TextArea, Autocomplete

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -158,7 +158,7 @@ export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard interaction is handled by the inner combobox input */}
           <div
             className={cn(
-              "flex flex-wrap items-center overflow-hidden rounded-sm border bg-neutral-alphas-100 has-focus-visible:outline-none motion-safe:transition-colors",
+              "flex flex-wrap items-center overflow-hidden rounded-sm border bg-neutral-alphas-100 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
               error ? "border-error-content" : "border-transparent",
               !disabled && !error && "hover:border-neutral-alphas-400",
               ac.isOpen && !error && !disabled && "border-neutral-alphas-400",

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -140,7 +140,7 @@ export const Select = React.forwardRef<
               aria-describedby={bottomText ? helperTextId : undefined}
               aria-invalid={error || undefined}
               className={cn(
-                "flex w-full cursor-pointer items-center justify-between rounded-sm border bg-neutral-alphas-50 outline-none motion-safe:transition-colors",
+                "flex w-full cursor-pointer items-center justify-between rounded-sm border bg-neutral-alphas-50 outline-none motion-safe:transition-colors focus-visible:shadow-focus-ring",
                 TRIGGER_HEIGHT[size],
                 TRIGGER_PADDING_X[size],
                 TRIGGER_GAP[size],

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -67,7 +67,7 @@ const CLEAR_BUTTON_RIGHT: Record<TextAreaSize, string> = {
 
 function getContainerClassName(size: TextAreaSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative rounded-sm border bg-neutral-alphas-50 has-focus-visible:outline-none motion-safe:transition-colors",
+    "relative rounded-sm border bg-neutral-alphas-50 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
     error ? "border-error-content" : "border-transparent",
     !disabled && !error && "hover:border-neutral-alphas-400",
     CONTAINER_MIN_HEIGHT[size],

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -59,7 +59,7 @@ const ICON_INSET: Record<TextFieldSize, string> = {
 
 function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative overflow-hidden rounded-sm border bg-neutral-alphas-50 has-focus-visible:outline-none motion-safe:transition-colors",
+    "relative overflow-hidden rounded-sm border bg-neutral-alphas-50 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
     error ? "border-error-content" : "border-transparent",
     !disabled && !error && "hover:border-neutral-alphas-400",
     CONTAINER_HEIGHT[size],


### PR DESCRIPTION
## Summary

- Several form controls were missing a visible keyboard focus indicator, an a11y issue when navigating by Tab.
- **Select** trigger declared `outline-none` with no replacement focus style.
- **TextField**, **TextArea**, and **Autocomplete** containers declared `has-focus-visible:outline-none` but never applied a visible ring — the suppression was there, the indicator was not.
- Applied the canonical `shadow-focus-ring` token (already used by `Button`, `IconButton`, `Switch`, `Chip`, `Pagination`, `Breadcrumb`, etc.) to bring these in line with the rest of the system.

## Audit notes

Checked all interactive components in `src/components`:

| Component | Before | After |
|---|---|---|
| Select trigger | ❌ `outline-none`, no ring | ✅ `focus-visible:shadow-focus-ring` |
| TextField container | ❌ outline suppressed, no ring | ✅ `has-focus-visible:shadow-focus-ring` |
| TextArea container | ❌ outline suppressed, no ring | ✅ `has-focus-visible:shadow-focus-ring` |
| Autocomplete container | ❌ outline suppressed, no ring | ✅ `has-focus-visible:shadow-focus-ring` |
| Button, IconButton, Switch, SwitchToggle, Chip, Slider, Checkbox, Radio, Tabs, Accordion, BottomNavigation, Pagination, Breadcrumb | ✅ already had focus rings | unchanged |
| ChatInput | uses subtle border-color change on focus (intentional) | unchanged |
| DatePicker | uses brand-secondary outline (intentional) | unchanged |

`PasswordField` and `SearchField` extend `TextField`, so they inherit the fix automatically.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 320 affected tests pass (Select, TextField, TextArea, Autocomplete, PasswordField, SearchField; both unit and Storybook chromium)
- [x] Visual check via Playwright + Storybook: all four components render the expected `0 0 0 2px bg-primary, 0 0 0 4px interaction-focus` box-shadow on `:focus-visible`
- [x] Reviewer: tab through a form with these controls and confirm the ring is consistent with `Button`/`Switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)