### PR TITLE
feat: v2 input field redesign

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4395,7 +4395,7 @@ function DialogDemo() {
           <DialogContent>
             <DialogHeader>
               <DialogTitle className="sr-only">Search dialog</DialogTitle>
-              <SearchField size="32" placeholder="Search..." fullWidth />
+              <SearchField size="40" placeholder="Search..." fullWidth />
             </DialogHeader>
             <DialogBody>
               <DialogDescription>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -387,7 +387,6 @@ function TextFieldShowcase() {
       <h2 className="typography-header-heading-sm mb-4">Text Field</h2>
       <TextField label="Size 48" placeholder="Placeholder" size="48" autoComplete="off" />
       <TextField label="Size 40" placeholder="Placeholder" size="40" autoComplete="off" />
-      <TextField label="Size 32" placeholder="Placeholder" size="32" autoComplete="off" />
       <TextField
         label="With helper"
         placeholder="Placeholder"
@@ -466,7 +465,6 @@ function PasswordFieldShowcase() {
       <h2 className="typography-header-heading-sm mb-4">Password Field</h2>
       <PasswordField label="Size 48" placeholder="Enter password" size="48" autoComplete="off" />
       <PasswordField label="Size 40" placeholder="Enter password" size="40" autoComplete="off" />
-      <PasswordField label="Size 32" placeholder="Enter password" size="32" autoComplete="off" />
       <PasswordField
         label="With helper"
         placeholder="Enter password"
@@ -520,7 +518,6 @@ function TextAreaShowcase() {
       <div className="flex max-w-2xl flex-col gap-4">
         <TextArea label="Size 48" placeholder="Enter description..." size="48" />
         <TextArea label="Size 40" placeholder="Enter description..." size="40" />
-        <TextArea label="Size 32" placeholder="Enter description..." size="32" />
         <TextArea
           label="With helper"
           placeholder="Enter description..."
@@ -718,7 +715,6 @@ function SearchFieldShowcase() {
       <h2 className="typography-header-heading-sm mb-4">Search Field</h2>
       <SearchField label="Size 48" placeholder="Search..." size="48" autoComplete="off" />
       <SearchField label="Size 40" placeholder="Search..." size="40" autoComplete="off" />
-      <SearchField label="Size 32" placeholder="Search..." size="32" autoComplete="off" />
       <SearchField
         label="With helper"
         placeholder="Search..."

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -165,7 +165,7 @@ export const AllStatesV2: Story = {
             <DialogContent>
               <DialogHeader>
                 <DialogTitle className="sr-only">Search dialog</DialogTitle>
-                <SearchField size="32" placeholder="Search..." fullWidth />
+                <SearchField size="40" placeholder="Search..." fullWidth />
               </DialogHeader>
               <DialogBody>
                 <DialogDescription>

--- a/src/components/PasswordField/PasswordField.stories.tsx
+++ b/src/components/PasswordField/PasswordField.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof PasswordField> = {
   argTypes: {
     size: {
       control: "select",
-      options: ["48", "40", "32"],
+      options: ["48", "40"],
     },
     label: {
       control: "text",
@@ -74,14 +74,6 @@ export const Size40: Story = {
   args: {
     size: "40",
     label: "Size 40",
-    placeholder: "Password",
-  },
-};
-
-export const Size32: Story = {
-  args: {
-    size: "32",
-    label: "Size 32",
     placeholder: "Password",
   },
 };
@@ -228,8 +220,8 @@ export const TextOverflow: Story = {
         defaultValue="averylongpasswordthatshoulddefinitelynotoverflowthecontainerboundary"
       />
       <PasswordField
-        label="Size 32"
-        size="32"
+        label="Size 40"
+        size="40"
         defaultValue="averylongpasswordthatshoulddefinitelynotoverflowthecontainerboundary"
       />
     </div>
@@ -242,7 +234,6 @@ export const AllSizeVariants: Story = {
     <div className="flex w-[375px] flex-col gap-4">
       <PasswordField size="48" label="Size 48" placeholder="Password" />
       <PasswordField size="40" label="Size 40" placeholder="Password" />
-      <PasswordField size="32" label="Size 32" placeholder="Password" />
     </div>
   ),
 };

--- a/src/components/PasswordField/PasswordField.test.tsx
+++ b/src/components/PasswordField/PasswordField.test.tsx
@@ -56,9 +56,9 @@ describe("PasswordField", () => {
       expect(inputContainer).toBeInTheDocument();
     });
 
-    it("applies size 32 when specified", () => {
-      const { container } = render(<PasswordField size="32" />);
-      const inputContainer = container.querySelector('[class*="h-8"]');
+    it("applies size 40 when specified", () => {
+      const { container } = render(<PasswordField size="40" />);
+      const inputContainer = container.querySelector('[class*="h-10"]');
       expect(inputContainer).toBeInTheDocument();
     });
   });
@@ -144,7 +144,7 @@ describe("PasswordField", () => {
   describe("error state", () => {
     it("applies error state styling", () => {
       const { container } = render(<PasswordField error />);
-      const inputContainer = container.querySelector('div[class*="border-error-content"]');
+      const inputContainer = container.querySelector('div[class*="border-border-error"]');
       expect(inputContainer).toBeInTheDocument();
     });
 

--- a/src/components/PasswordField/PasswordField.tsx
+++ b/src/components/PasswordField/PasswordField.tsx
@@ -3,7 +3,7 @@ import { EyeIcon } from "../Icons/EyeIcon";
 import { EyeSlashIcon } from "../Icons/EyeSlashIcon";
 import { TextField, type TextFieldProps } from "../TextField/TextField";
 
-export type PasswordFieldSize = "48" | "40" | "32";
+export type PasswordFieldSize = "48" | "40";
 
 export interface PasswordFieldProps extends Omit<TextFieldProps, "type" | "rightIcon"> {
   /** Size variant of the password field */

--- a/src/components/SearchField/SearchField.stories.tsx
+++ b/src/components/SearchField/SearchField.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   argTypes: {
     size: {
       control: "select",
-      options: ["48", "40", "32"],
+      options: ["48", "40"],
     },
   },
 } satisfies Meta<typeof SearchField>;
@@ -68,13 +68,6 @@ export const Size40: Story = {
   },
 };
 
-export const Size32: Story = {
-  args: {
-    size: "32",
-    placeholder: "Size 32",
-  },
-};
-
 export const Disabled: Story = {
   args: {
     label: "Search",
@@ -113,7 +106,7 @@ export const TextOverflow: Story = {
       <SearchField
         label="With label"
         placeholder="Search..."
-        size="32"
+        size="40"
         defaultValue="https://www.example.com/very/long/url/that/should/not/overflow/the/container/boundary"
       />
     </div>

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -4,7 +4,7 @@ import { CloseIcon } from "../Icons/CloseIcon";
 import { SearchIcon } from "../Icons/SearchIcon";
 import { TextField, type TextFieldProps } from "../TextField/TextField";
 
-export type SearchFieldSize = "48" | "40" | "32";
+export type SearchFieldSize = "48" | "40";
 
 export interface SearchFieldProps extends Omit<TextFieldProps, "type" | "leftIcon"> {
   /** Size variant of the search field. @default "48" */

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof TextArea> = {
   argTypes: {
     size: {
       control: "select",
-      options: ["48", "40", "32"],
+      options: ["48", "40"],
     },
     label: {
       control: "text",
@@ -93,14 +93,6 @@ export const Size40: Story = {
   args: {
     size: "40",
     label: "Size 40",
-    placeholder: "Text Area",
-  },
-};
-
-export const Size32: Story = {
-  args: {
-    size: "32",
-    label: "Size 32",
     placeholder: "Text Area",
   },
 };
@@ -305,8 +297,8 @@ export const TextOverflow: Story = {
         defaultValue="https://www.example.com/very/long/url/that/should/not/overflow/the/container/boundary"
       />
       <TextArea
-        label="Size 32"
-        size="32"
+        label="Size 40"
+        size="40"
         defaultValue="https://www.example.com/very/long/url/that/should/not/overflow/the/container/boundary"
       />
     </div>
@@ -319,7 +311,6 @@ export const AllSizeVariants: Story = {
     <div className="flex w-[375px] flex-col gap-4">
       <TextArea size="48" label="Size 48" placeholder="Default size" />
       <TextArea size="40" label="Size 40" placeholder="Medium size" />
-      <TextArea size="32" label="Size 32" placeholder="Compact size" />
     </div>
   ),
 };

--- a/src/components/TextArea/TextArea.test.tsx
+++ b/src/components/TextArea/TextArea.test.tsx
@@ -172,8 +172,8 @@ describe("TextArea", () => {
       expect(textarea).toHaveClass("py-2");
     });
 
-    it('applies correct classes for size="32"', () => {
-      render(<TextArea label="Test" size="32" />);
+    it('applies correct classes for size="40" (duplicate check)', () => {
+      render(<TextArea label="Test" size="40" />);
       const textarea = screen.getByRole("textbox");
       expect(textarea).toHaveClass("py-2");
     });
@@ -228,11 +228,11 @@ describe("TextArea", () => {
       expect(textarea).toHaveAttribute("style", "max-height: 208px;");
     });
 
-    it("calculates maxHeight correctly for size 32", () => {
-      render(<TextArea label="Test" maxRows={6} size="32" />);
+    it("calculates maxHeight correctly for size 40 (alt rows)", () => {
+      render(<TextArea label="Test" maxRows={6} size="40" />);
       const textarea = screen.getByRole("textbox");
-      // size 32: line-height 20px * 6 rows + padding 8px * 2 = 136px
-      expect(textarea).toHaveAttribute("style", "max-height: 136px;");
+      // size 40: line-height 24px * 6 rows + padding 8px * 2 = 160px
+      expect(textarea).toHaveAttribute("style", "max-height: 160px;");
     });
 
     it("does not apply style when maxRows is not provided", () => {

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -5,7 +5,7 @@ import { CheckOutlineIcon } from "../Icons/CheckOutlineIcon";
 import { CloseIcon } from "../Icons/CloseIcon";
 
 /** Text area height in pixels. */
-export type TextAreaSize = "48" | "40" | "32";
+export type TextAreaSize = "48" | "40";
 
 export interface TextAreaProps
   extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "size"> {
@@ -38,31 +38,16 @@ export interface TextAreaProps
 const CONTAINER_MIN_HEIGHT: Record<TextAreaSize, string> = {
   "48": "min-h-12",
   "40": "min-h-10",
-  "32": "min-h-8",
 };
 
 const TEXTAREA_SIZE_CLASSES: Record<TextAreaSize, string> = {
   "48": "py-3 typography-body-default-16px-regular autofill-body-lg",
   "40": "py-2 typography-body-default-16px-regular autofill-body-lg",
-  "32": "py-2 typography-body-small-14px-regular autofill-body-md",
-};
-
-const PADDING_HORIZONTAL: Record<TextAreaSize, string> = {
-  "48": "px-4",
-  "40": "px-4",
-  "32": "px-3",
-};
-
-const PADDING_RIGHT_WITH_CLEAR: Record<TextAreaSize, string> = {
-  "48": "pr-11",
-  "40": "pr-11",
-  "32": "pr-10",
 };
 
 const CLEAR_BUTTON_RIGHT: Record<TextAreaSize, string> = {
   "48": "right-4 top-3",
   "40": "right-4 top-2",
-  "32": "right-3 top-2",
 };
 
 function getContainerClassName(size: TextAreaSize, error: boolean, disabled?: boolean) {
@@ -86,8 +71,7 @@ function getTextareaClassName(
     resizable ? "resize-y" : "resize-none",
     !hasMinRows && "min-h-[80px]",
     TEXTAREA_SIZE_CLASSES[size],
-    PADDING_HORIZONTAL[size],
-    hasClearButton ? PADDING_RIGHT_WITH_CLEAR[size] : "",
+    hasClearButton ? "px-4 pr-11" : "px-4",
   );
 }
 
@@ -127,9 +111,9 @@ function calculateMaxHeight(size: TextAreaSize, maxRows?: number): string | unde
   if (!maxRows) return undefined;
 
   // Line height is 24px for body-1 (sizes 48 and 40) and 20px for body-2 (size 32)
-  const lineHeight = size === "32" ? 20 : 24;
+  const lineHeight = 24;
   // py-2 = 8px, py-3 = 12px
-  const verticalPadding = size === "32" ? 8 : size === "40" ? 8 : 12;
+  const verticalPadding = size === "40" ? 8 : 12;
 
   return `${lineHeight * maxRows + verticalPadding * 2}px`;
 }

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -13,14 +13,14 @@ const meta: Meta<typeof TextField> = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=4262-17626&m=dev",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16633-69732&m=dev",
     },
   },
   tags: ["autodocs"],
   argTypes: {
     size: {
       control: "select",
-      options: ["48", "40", "32"],
+      options: ["48", "40"],
     },
     label: {
       control: "text",
@@ -85,14 +85,6 @@ export const Size40: Story = {
   args: {
     size: "40",
     label: "Size 40",
-    placeholder: "Placeholder Text",
-  },
-};
-
-export const Size32: Story = {
-  args: {
-    size: "32",
-    label: "Size 32",
     placeholder: "Placeholder Text",
   },
 };
@@ -280,8 +272,8 @@ export const TextOverflow: Story = {
         defaultValue="https://www.example.com/very/long/url/that/should/not/overflow/the/container/boundary"
       />
       <TextField
-        label="Size 32"
-        size="32"
+        label="Size 40"
+        size="40"
         defaultValue="https://www.example.com/very/long/url/that/should/not/overflow/the/container/boundary"
       />
     </div>
@@ -294,7 +286,6 @@ export const AllSizeVariants: Story = {
     <div className="flex w-[375px] flex-col gap-4">
       <TextField size="48" label="Size 48" placeholder="Default size" />
       <TextField size="40" label="Size 40" placeholder="Medium size" />
-      <TextField size="32" label="Size 32" placeholder="Compact size" />
     </div>
   ),
 };

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -58,12 +58,6 @@ describe("TextField", () => {
       const inputContainer = container.querySelector('[class*="h-10"]');
       expect(inputContainer).toBeInTheDocument();
     });
-
-    it("applies size 32 when specified", () => {
-      const { container } = render(<TextField aria-label="Test" size="32" />);
-      const inputContainer = container.querySelector('[class*="h-8"]');
-      expect(inputContainer).toBeInTheDocument();
-    });
   });
 
   describe("label and helper text", () => {
@@ -104,7 +98,7 @@ describe("TextField", () => {
   describe("error state", () => {
     it("applies error state styling", () => {
       const { container } = render(<TextField aria-label="Test" error />);
-      const inputContainer = container.querySelector('[class*="border-error-content"]');
+      const inputContainer = container.querySelector('[class*="border-border-error"]');
       expect(inputContainer).toBeInTheDocument();
     });
 
@@ -238,15 +232,15 @@ describe("TextField", () => {
       const inputContainer = container.querySelector('[class*="border"]');
       expect(inputContainer).toBeInTheDocument();
       expect(inputContainer).toHaveClass("border");
-      expect(inputContainer).toHaveClass("border-transparent");
+      expect(inputContainer).toHaveClass("border-border-primary");
     });
 
-    it("renders border-error-content instead of border-transparent when error", () => {
+    it("renders border-border-error instead of border-border-primary when error", () => {
       const { container } = render(<TextField aria-label="Test" error />);
-      const inputContainer = container.querySelector('[class*="border-error-content"]');
+      const inputContainer = container.querySelector('[class*="border-border-error"]');
       expect(inputContainer).toBeInTheDocument();
       expect(inputContainer).toHaveClass("border");
-      expect(inputContainer).not.toHaveClass("border-transparent");
+      expect(inputContainer).not.toHaveClass("border-border-primary");
     });
 
     it("renders focus ring class on input container", () => {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -160,7 +160,10 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         data-error={error ? "" : undefined}
       >
         {label && (
-          <label htmlFor={inputId} className="typography-description-12px-semibold text-content-primary">
+          <label
+            htmlFor={inputId}
+            className="typography-description-12px-semibold text-content-primary"
+          >
             {label}
           </label>
         )}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -3,7 +3,7 @@ import { CheckOutlineIcon } from "@/index";
 import { cn } from "../../utils/cn";
 
 /** Text field height in pixels. */
-export type TextFieldSize = "48" | "40" | "32";
+export type TextFieldSize = "48" | "40";
 
 export interface TextFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size" | "prefix"> {
@@ -30,46 +30,48 @@ export interface TextFieldProps
 const CONTAINER_HEIGHT: Record<TextFieldSize, string> = {
   "48": "h-12",
   "40": "h-10",
-  "32": "h-8",
 };
 
 const INPUT_SIZE_CLASSES: Record<TextFieldSize, string> = {
   "48": "py-3 typography-body-default-16px-regular autofill-body-lg",
   "40": "py-2 typography-body-default-16px-regular autofill-body-lg",
-  "32": "py-2 typography-body-small-14px-regular autofill-body-md",
 };
 
 const INPUT_PL: Record<TextFieldSize, { default: string; withIcon: string }> = {
-  "48": { default: "pl-4", withIcon: "pl-10" },
+  "48": { default: "pl-4", withIcon: "pl-12" },
   "40": { default: "pl-4", withIcon: "pl-10" },
-  "32": { default: "pl-3", withIcon: "pl-9" },
 };
 
 const INPUT_PR: Record<TextFieldSize, { default: string; withIcon: string }> = {
-  "48": { default: "pr-4", withIcon: "pr-10" },
+  "48": { default: "pr-4", withIcon: "pr-12" },
   "40": { default: "pr-4", withIcon: "pr-10" },
-  "32": { default: "pr-3", withIcon: "pr-9" },
 };
 
 const ICON_INSET: Record<TextFieldSize, string> = {
   "48": "px-4",
   "40": "px-4",
-  "32": "px-3",
+};
+
+const ICON_SIZE: Record<TextFieldSize, string> = {
+  "48": "size-6",
+  "40": "size-4",
 };
 
 function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative overflow-hidden rounded-sm border bg-neutral-alphas-50 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
-    error ? "border-error-content" : "border-transparent",
-    !disabled && !error && "hover:border-neutral-alphas-400",
+    "relative overflow-hidden rounded-sm border bg-surface-inputs has-focus-visible:outline-none motion-safe:transition-colors",
+    disabled
+      ? "border-transparent bg-surface-inputs-off"
+      : error
+        ? "border-border-error"
+        : "border-border-primary hover:border-interaction-focus has-focus-visible:border-border-selected",
     CONTAINER_HEIGHT[size],
-    disabled && "opacity-50",
   );
 }
 
 function getInputClassName(size: TextFieldSize, hasLeftIcon: boolean, hasRightIcon: boolean) {
   return cn(
-    "h-full w-full rounded-sm bg-transparent text-content-primary no-underline placeholder:text-content-secondary focus:outline-none disabled:cursor-not-allowed",
+    "h-full w-full rounded-sm bg-transparent text-content-primary no-underline placeholder:text-content-tertiary focus:outline-none disabled:cursor-not-allowed disabled:text-content-disabled",
     INPUT_SIZE_CLASSES[size],
     hasLeftIcon ? INPUT_PL[size].withIcon : INPUT_PL[size].default,
     hasRightIcon ? INPUT_PR[size].withIcon : INPUT_PR[size].default,
@@ -89,8 +91,8 @@ function TextFieldHelperText({
     <p
       id={id}
       className={cn(
-        "typography-description-12px-regular px-2 pt-2 pb-0.5",
-        error ? "text-error-content" : "text-content-secondary",
+        "typography-description-12px-regular",
+        error ? "text-error-content" : "text-content-tertiary",
       )}
     >
       {children}
@@ -147,20 +149,18 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     const inputId = id || generatedId;
     const helperTextId = `${inputId}-helper`;
     const bottomText = error && errorMessage ? errorMessage : helperText;
+    const iconColor = disabled ? "text-content-disabled" : "text-content-secondary";
 
     warnMissingAccessibleName(label, props["aria-label"], props["aria-labelledby"]);
 
     return (
       <div
-        className={cn("flex flex-col", fullWidth && "w-full", className)}
+        className={cn("flex flex-col gap-2", fullWidth && "w-full", className)}
         data-disabled={disabled ? "" : undefined}
         data-error={error ? "" : undefined}
       >
         {label && (
-          <label
-            htmlFor={inputId}
-            className="typography-description-12px-semibold px-1 pt-1 pb-2 text-content-primary"
-          >
+          <label htmlFor={inputId} className="typography-description-12px-semibold text-content-primary">
             {label}
           </label>
         )}
@@ -182,26 +182,37 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           {leftIcon && (
             <div
               className={cn(
-                "pointer-events-none absolute inset-y-0 left-0 flex items-center text-content-secondary",
+                "pointer-events-none absolute inset-y-0 left-0 flex items-center",
+                iconColor,
                 ICON_INSET[size],
               )}
             >
-              <div className="flex size-4 shrink-0 items-center justify-center">{leftIcon}</div>
+              <div className={cn("flex shrink-0 items-center justify-center", ICON_SIZE[size])}>
+                {leftIcon}
+              </div>
             </div>
           )}
 
           {(rightIcon || validated) && (
             <div
               className={cn(
-                "absolute inset-y-0 right-0 flex items-center gap-2 text-content-secondary",
+                "absolute inset-y-0 right-0 flex items-center gap-2",
+                iconColor,
                 ICON_INSET[size],
               )}
             >
               {rightIcon && (
-                <div className="flex size-4 shrink-0 items-center justify-center">{rightIcon}</div>
+                <div className={cn("flex shrink-0 items-center justify-center", ICON_SIZE[size])}>
+                  {rightIcon}
+                </div>
               )}
               {validated && (
-                <div className="pointer-events-none flex size-4 shrink-0 items-center justify-center">
+                <div
+                  className={cn(
+                    "pointer-events-none flex shrink-0 items-center justify-center",
+                    ICON_SIZE[size],
+                  )}
+                >
                   <CheckOutlineIcon className="text-success-content" />
                 </div>
               )}

--- a/src/styles/styleTokens.json
+++ b/src/styles/styleTokens.json
@@ -1213,11 +1213,6 @@
                 "exportKey": "variables"
               }
             }
-          },
-          "disabled": {
-            "description": "Disabled input text and icon color",
-            "type": "color",
-            "value": "{primitives.light.color.gray.450}"
           }
         },
         "success": {
@@ -4859,11 +4854,6 @@
                 "exportKey": "variables"
               }
             }
-          },
-          "disabled": {
-            "description": "Disabled input text and icon color",
-            "type": "color",
-            "value": "{primitives.dark.color.gray.600}"
           }
         },
         "success": {

--- a/src/styles/styleTokens.json
+++ b/src/styles/styleTokens.json
@@ -1213,6 +1213,11 @@
                 "exportKey": "variables"
               }
             }
+          },
+          "disabled": {
+            "description": "Disabled input text and icon color",
+            "type": "color",
+            "value": "{primitives.light.color.gray.450}"
           }
         },
         "success": {
@@ -4854,6 +4859,11 @@
                 "exportKey": "variables"
               }
             }
+          },
+          "disabled": {
+            "description": "Disabled input text and icon color",
+            "type": "color",
+            "value": "{primitives.dark.color.gray.600}"
           }
         },
         "success": {


### PR DESCRIPTION
## Summary
- Add `border-selected` and `content-disabled` semantic tokens to `styleTokens.json` and regenerate `theme.css` via `buildStyles.js`
- Redesign TextField, TextArea, SearchField, and PasswordField to match v2 Figma spec (remove size 32, update focus/hover/disabled states)
- Remove size 32 showcase entries from App.tsx

## Test plan
- [ ] Verify all input components render correctly at sizes 48 and 40
- [ ] Verify focus, hover, error, disabled, and validated states match Figma
- [ ] Verify dark mode token values are correct
- [ ] Run existing tests (`pnpm test`)
- [ ] Check Chromatic for visual regressions


Made with [Cursor](https://cursor.com)