### PR TITLE
feat(CyclingText): add component for cycling strings with slide animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ import {
   Count,
   CrossIcon,
   CrownIcon,
+  CyclingText,
   Dialog,
   DialogBody,
   DialogClose,
@@ -1397,7 +1398,7 @@ function AvatarDemo() {
           <div className="relative h-28 w-56 shrink-0 overflow-visible rounded-lg border border-neutral-300">
             <div className="absolute inset-x-0 top-0 h-1/2 bg-[repeating-linear-gradient(135deg,#fca5a5_0_6px,#fde047_6px_12px)]" />
             <div className="absolute inset-x-0 bottom-0 h-1/2 bg-[repeating-linear-gradient(-45deg,#93c5fd_0_6px,#86efac_6px_12px)]" />
-            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
               <Avatar
                 size={64}
                 src="https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?w=128&h=128&fit=crop"
@@ -1409,7 +1410,7 @@ function AvatarDemo() {
           <div className="relative h-28 w-56 shrink-0 overflow-visible rounded-lg border border-neutral-300">
             <div className="absolute inset-x-0 top-0 h-1/2 bg-[repeating-linear-gradient(135deg,#fca5a5_0_6px,#fde047_6px_12px)]" />
             <div className="absolute inset-x-0 bottom-0 h-1/2 bg-[repeating-linear-gradient(-45deg,#93c5fd_0_6px,#86efac_6px_12px)]" />
-            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
               <Avatar size={64} fallback="AB" />
             </div>
           </div>
@@ -1715,9 +1716,9 @@ function BannerDemo() {
 function EmptyStateDemo() {
   const artwork = (
     <div className="relative h-full w-full bg-surface-secondary">
-      <div className="absolute left-3 top-10 size-20 rounded-full bg-surface-primary" />
-      <div className="absolute left-20 top-6 size-36 rounded-full bg-surface-tertiary" />
-      <div className="absolute left-48 top-24 size-24 rounded-full bg-surface-primary" />
+      <div className="absolute top-10 left-3 size-20 rounded-full bg-surface-primary" />
+      <div className="absolute top-6 left-20 size-36 rounded-full bg-surface-tertiary" />
+      <div className="absolute top-24 left-48 size-24 rounded-full bg-surface-primary" />
     </div>
   );
 
@@ -1731,7 +1732,7 @@ function EmptyStateDemo() {
       <h3 className="typography-bold-heading-xs text-content-secondary">
         ReactNode slots (previous pattern)
       </h3>
-      <p className="typography-regular-body-md text-content-secondary max-w-xl">
+      <p className="typography-regular-body-md max-w-xl text-content-secondary">
         Pass elements for <code className="typography-regular-body-md">media</code>,{" "}
         <code className="typography-regular-body-md">title</code>,{" "}
         <code className="typography-regular-body-md">description</code>, and actions—for example
@@ -1765,8 +1766,8 @@ function EmptyStateDemo() {
           secondaryAction={<Button variant="secondary">Learn more</Button>}
         />
       </div>
-      <h3 className="typography-bold-heading-xs text-content-secondary mt-6">String slots</h3>
-      <p className="typography-regular-body-md text-content-secondary max-w-xl">
+      <h3 className="typography-bold-heading-xs mt-6 text-content-secondary">String slots</h3>
+      <p className="typography-regular-body-md max-w-xl text-content-secondary">
         Title, description, media URL, and action labels as strings: typography and buttons are
         applied inside <code className="typography-regular-body-md">EmptyState</code>.
       </p>
@@ -2413,6 +2414,80 @@ function CountDemo() {
       <div className="flex flex-wrap items-center gap-4">
         <Count value={150} max={99} />
         <Count value={1000} max={999} />
+      </div>
+    </div>
+  );
+}
+
+const CYCLING_TEXT_STAGES = [
+  "Thinking",
+  "Reading messages",
+  "Drafting reply",
+  "Connecting the dots",
+  "Almost there",
+];
+
+const CYCLING_TEXT_PLACEHOLDERS = [
+  "Search creators…",
+  "Find a fan…",
+  "Look up a transaction…",
+  "Browse posts…",
+];
+
+function CyclingTextFakePlaceholder() {
+  const [value, setValue] = useState("");
+  const [focused, setFocused] = useState(false);
+  const showPlaceholder = !focused && value.length === 0;
+
+  return (
+    <div className="relative w-80">
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        className="w-full rounded-md border border-border-default bg-bg-primary px-3 py-2 text-content-primary outline-none"
+      />
+      {showPlaceholder && (
+        <CyclingText
+          items={CYCLING_TEXT_PLACEHOLDERS}
+          className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-content-tertiary"
+        />
+      )}
+    </div>
+  );
+}
+
+function CyclingTextDemo() {
+  return (
+    <div id="cycling-text" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-bold-heading-sm mb-4">Cycling Text</h2>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="typography-bold-heading-xs text-content-secondary">Standalone</h3>
+        <CyclingText items={CYCLING_TEXT_STAGES} />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="typography-bold-heading-xs text-content-secondary">In a status row</h3>
+        <div className="inline-flex items-center gap-2 text-content-tertiary">
+          <SpinnerIcon className="size-4 animate-spin" />
+          <CyclingText items={CYCLING_TEXT_STAGES} />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="typography-bold-heading-xs text-content-secondary">Sized to current</h3>
+        <div className="inline-flex items-center gap-2 text-content-tertiary">
+          <SpinnerIcon className="size-4 animate-spin" />
+          <CyclingText items={CYCLING_TEXT_STAGES} sizing="current" />
+          <SpinnerIcon className="size-4 animate-spin" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="typography-bold-heading-xs text-content-secondary">Fake placeholder</h3>
+        <CyclingTextFakePlaceholder />
       </div>
     </div>
   );
@@ -4300,6 +4375,7 @@ function App() {
     { id: "checkbox", label: "Checkbox" },
     { id: "chip", label: "Chip" },
     { id: "count", label: "Count" },
+    { id: "cycling-text", label: "Cycling Text" },
     { id: "datepicker", label: "Date Picker" },
     { id: "dialog", label: "Dialog" },
     { id: "divider", label: "Divider" },
@@ -4496,6 +4572,9 @@ function App() {
 
             {/* Count */}
             <CountDemo />
+
+            {/* Cycling Text */}
+            <CyclingTextDemo />
 
             {/* Chip */}
             <ChipDemo />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2435,25 +2435,9 @@ const CYCLING_TEXT_PLACEHOLDERS = [
 ];
 
 function CyclingTextFakePlaceholder() {
-  const [value, setValue] = useState("");
-  const [focused, setFocused] = useState(false);
-  const showPlaceholder = !focused && value.length === 0;
-
   return (
-    <div className="relative w-80">
-      <input
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-        className="w-full rounded-md border border-border-default bg-bg-primary px-3 py-2 text-content-primary outline-none"
-      />
-      {showPlaceholder && (
-        <CyclingText
-          items={CYCLING_TEXT_PLACEHOLDERS}
-          className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-content-tertiary"
-        />
-      )}
+    <div className="w-80 rounded-md border border-border-default bg-bg-primary px-3 py-2 text-content-tertiary">
+      <CyclingText items={CYCLING_TEXT_PLACEHOLDERS} />
     </div>
   );
 }
@@ -2463,29 +2447,29 @@ function CyclingTextDemo() {
     <div id="cycling-text" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-bold-heading-sm mb-4">Cycling Text</h2>
 
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
         <h3 className="typography-bold-heading-xs text-content-secondary">Standalone</h3>
         <CyclingText items={CYCLING_TEXT_STAGES} />
       </div>
 
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
         <h3 className="typography-bold-heading-xs text-content-secondary">In a status row</h3>
         <div className="inline-flex items-center gap-2 text-content-tertiary">
-          <SpinnerIcon className="size-4 animate-spin" />
+          <SpinnerIcon className="size-6 animate-spin" />
           <CyclingText items={CYCLING_TEXT_STAGES} />
         </div>
       </div>
 
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
         <h3 className="typography-bold-heading-xs text-content-secondary">Sized to current</h3>
         <div className="inline-flex items-center gap-2 text-content-tertiary">
-          <SpinnerIcon className="size-4 animate-spin" />
+          <SpinnerIcon className="size-6 animate-spin" />
           <CyclingText items={CYCLING_TEXT_STAGES} sizing="current" />
-          <SpinnerIcon className="size-4 animate-spin" />
+          <SpinnerIcon className="size-6 animate-spin" />
         </div>
       </div>
 
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
         <h3 className="typography-bold-heading-xs text-content-secondary">Fake placeholder</h3>
         <CyclingTextFakePlaceholder />
       </div>

--- a/src/components/CyclingText/CyclingText.stories.tsx
+++ b/src/components/CyclingText/CyclingText.stories.tsx
@@ -55,7 +55,7 @@ export const InsideAButton: Story = {
 
 export const InsideAStatusRow: Story = {
   render: (args) => (
-    <div className="text-content-tertiary inline-flex items-center gap-2">
+    <div className="inline-flex items-center gap-2 text-content-tertiary">
       <SpinnerIcon className="size-4 animate-spin" />
       <CyclingText {...args} />
     </div>
@@ -99,23 +99,18 @@ export const FakePlaceholder: Story = {
           onChange={(e) => setValue(e.target.value)}
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
-          className="border-border-default bg-bg-primary text-content-primary w-full rounded-md border px-3 py-2 outline-none"
+          className="w-full rounded-md border border-border-default bg-bg-primary px-3 py-2 text-content-primary outline-none"
         />
         {showPlaceholder && (
           <CyclingText
             {...args}
-            className="text-content-tertiary pointer-events-none absolute inset-y-0 left-3 flex items-center"
+            className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-content-tertiary"
           />
         )}
       </div>
     );
   },
   args: {
-    items: [
-      "Search creators…",
-      "Find a fan…",
-      "Look up a transaction…",
-      "Browse posts…",
-    ],
+    items: ["Search creators…", "Find a fan…", "Look up a transaction…", "Browse posts…"],
   },
 };

--- a/src/components/CyclingText/CyclingText.stories.tsx
+++ b/src/components/CyclingText/CyclingText.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "../Button/Button";
+import { SpinnerIcon } from "../Icons/SpinnerIcon";
+import { CyclingText } from "./CyclingText";
+
+const meta = {
+  title: "Components/CyclingText",
+  component: CyclingText,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    direction: { control: "radio", options: ["up", "down"] },
+    sizing: { control: "radio", options: ["longest", "current"] },
+    intervalMs: { control: { type: "number", min: 200, step: 100 } },
+    transitionMs: { control: { type: "number", min: 0, step: 20 } },
+    paused: { control: "boolean" },
+  },
+} satisfies Meta<typeof CyclingText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const STAGES = [
+  "Thinking",
+  "Reading messages",
+  "Drafting reply",
+  "Connecting the dots",
+  "Almost there",
+];
+
+export const Default: Story = {
+  args: {
+    items: STAGES,
+    intervalMs: 1800,
+    transitionMs: 380,
+    direction: "up",
+    sizing: "longest",
+  },
+};
+
+export const InsideAButton: Story = {
+  render: (args) => (
+    <Button variant="secondary">
+      <SpinnerIcon className="mr-2 size-4 animate-spin" />
+      <CyclingText {...args} />
+    </Button>
+  ),
+  args: {
+    items: STAGES,
+  },
+};
+
+export const InsideAStatusRow: Story = {
+  render: (args) => (
+    <div className="text-content-tertiary inline-flex items-center gap-2">
+      <SpinnerIcon className="size-4 animate-spin" />
+      <CyclingText {...args} />
+    </div>
+  ),
+  args: {
+    items: STAGES,
+  },
+};
+
+export const SizedToCurrent: Story = {
+  args: {
+    items: STAGES,
+    sizing: "current",
+  },
+};
+
+export const ShortItems: Story = {
+  args: {
+    items: ["One", "Two", "Three"],
+    intervalMs: 900,
+  },
+};
+
+export const Paused: Story = {
+  args: {
+    items: STAGES,
+    paused: true,
+  },
+};
+
+export const FakePlaceholder: Story = {
+  render: (args) => {
+    const [value, setValue] = useState("");
+    const [focused, setFocused] = useState(false);
+    const showPlaceholder = !focused && value.length === 0;
+
+    return (
+      <div className="relative w-80">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          className="border-border-default bg-bg-primary text-content-primary w-full rounded-md border px-3 py-2 outline-none"
+        />
+        {showPlaceholder && (
+          <CyclingText
+            {...args}
+            className="text-content-tertiary pointer-events-none absolute inset-y-0 left-3 flex items-center"
+          />
+        )}
+      </div>
+    );
+  },
+  args: {
+    items: [
+      "Search creators…",
+      "Find a fan…",
+      "Look up a transaction…",
+      "Browse posts…",
+    ],
+  },
+};

--- a/src/components/CyclingText/CyclingText.stories.tsx
+++ b/src/components/CyclingText/CyclingText.stories.tsx
@@ -9,6 +9,10 @@ const meta = {
   component: CyclingText,
   parameters: {
     layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18117-70537&t=aDs0f0yBBCb6keGl-1",
+    },
   },
   tags: ["autodocs"],
   argTypes: {

--- a/src/components/CyclingText/CyclingText.stories.tsx
+++ b/src/components/CyclingText/CyclingText.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState } from "react";
 import { Button } from "../Button/Button";
 import { SpinnerIcon } from "../Icons/SpinnerIcon";
 import { CyclingText } from "./CyclingText";
@@ -21,6 +20,7 @@ const meta = {
     intervalMs: { control: { type: "number", min: 200, step: 100 } },
     transitionMs: { control: { type: "number", min: 0, step: 20 } },
     paused: { control: "boolean" },
+    announceChanges: { control: "boolean" },
   },
 } satisfies Meta<typeof CyclingText>;
 
@@ -91,29 +91,11 @@ export const Paused: Story = {
 };
 
 export const FakePlaceholder: Story = {
-  render: (args) => {
-    const [value, setValue] = useState("");
-    const [focused, setFocused] = useState(false);
-    const showPlaceholder = !focused && value.length === 0;
-
-    return (
-      <div className="relative w-80">
-        <input
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onFocus={() => setFocused(true)}
-          onBlur={() => setFocused(false)}
-          className="w-full rounded-md border border-border-default bg-bg-primary px-3 py-2 text-content-primary outline-none"
-        />
-        {showPlaceholder && (
-          <CyclingText
-            {...args}
-            className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-content-tertiary"
-          />
-        )}
-      </div>
-    );
-  },
+  render: (args) => (
+    <div className="w-80 rounded-md border border-border-default bg-bg-primary px-3 py-2 text-content-tertiary">
+      <CyclingText {...args} />
+    </div>
+  ),
   args: {
     items: ["Search creators…", "Find a fan…", "Look up a transaction…", "Browse posts…"],
   },

--- a/src/components/CyclingText/CyclingText.test.tsx
+++ b/src/components/CyclingText/CyclingText.test.tsx
@@ -1,0 +1,175 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { CyclingText } from "./CyclingText";
+
+const ITEMS = ["Alpha", "Beta", "Gamma"];
+
+const installMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: () =>
+      ({
+        matches,
+        media: "(prefers-reduced-motion: reduce)",
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+      }) as unknown as MediaQueryList,
+  });
+};
+
+const getVisibleLabel = () => {
+  const root = screen.getByTestId("cycling-text");
+  const live = root.querySelector('[aria-live="polite"]');
+  if (!live) throw new Error("No visible label found");
+  return live;
+};
+
+const getSizingLabel = () => {
+  const root = screen.getByTestId("cycling-text");
+  const sizing = root.querySelector('[aria-hidden="true"]');
+  if (!sizing) throw new Error("No sizing label found");
+  return sizing;
+};
+
+const getIncomingLabel = () => {
+  const root = screen.getByTestId("cycling-text");
+  // Two aria-hidden spans during a transition — the second is the incoming layer.
+  const hidden = root.querySelectorAll('[aria-hidden="true"]');
+  return hidden.length > 1 ? hidden[1] : null;
+};
+
+describe("CyclingText", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("API", () => {
+    it("renders the first item initially in the live layer", () => {
+      render(<CyclingText items={ITEMS} />);
+      expect(getVisibleLabel().textContent).toBe("Alpha");
+    });
+
+    it("returns null when items is empty", () => {
+      const { container } = render(<CyclingText items={[]} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("applies custom className to the wrapper", () => {
+      render(<CyclingText items={ITEMS} className="custom-class" />);
+      const root = screen.getByTestId("cycling-text");
+      expect(root).toHaveClass("custom-class");
+    });
+
+    it("applies labelClassName to the visible layer", () => {
+      render(<CyclingText items={ITEMS} labelClassName="shimmer" />);
+      expect(getVisibleLabel()).toHaveClass("shimmer");
+    });
+
+    it("uses the longest item to size the wrapper by default", () => {
+      render(<CyclingText items={["Hi", "Hello there", "Yo"]} />);
+      expect(getSizingLabel().textContent).toBe("Hello there");
+    });
+  });
+
+  describe("cycling", () => {
+    it("advances to the next item across an interval + transition", () => {
+      render(<CyclingText items={ITEMS} intervalMs={1000} transitionMs={200} />);
+
+      expect(getVisibleLabel().textContent).toBe("Alpha");
+
+      // Tick: incoming is mounted with the next item; current is still the old one.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(getIncomingLabel()?.textContent).toBe("Beta");
+
+      // Finish the slide — incoming becomes current.
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(getVisibleLabel().textContent).toBe("Beta");
+      expect(getIncomingLabel()).toBeNull();
+    });
+
+    it("wraps back to the first item after the last", () => {
+      render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={100} />);
+
+      // Alpha -> Beta
+      act(() => vi.advanceTimersByTime(600));
+      expect(getVisibleLabel().textContent).toBe("Beta");
+
+      // Beta -> Gamma
+      act(() => vi.advanceTimersByTime(600));
+      expect(getVisibleLabel().textContent).toBe("Gamma");
+
+      // Gamma -> Alpha (wrap)
+      act(() => vi.advanceTimersByTime(600));
+      expect(getVisibleLabel().textContent).toBe("Alpha");
+    });
+
+    it("does not cycle when paused", () => {
+      render(<CyclingText items={ITEMS} intervalMs={500} paused />);
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(getVisibleLabel().textContent).toBe("Alpha");
+    });
+
+    it("does not cycle with a single item", () => {
+      render(<CyclingText items={["Solo"]} intervalMs={300} />);
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(getVisibleLabel().textContent).toBe("Solo");
+    });
+
+    it("cleans up timers on unmount", () => {
+      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+      const { unmount } = render(<CyclingText items={ITEMS} intervalMs={500} />);
+      unmount();
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      clearIntervalSpy.mockRestore();
+    });
+  });
+
+  describe("reduced motion", () => {
+    it("hard-swaps items with no incoming layer when prefers-reduced-motion is set", () => {
+      installMatchMedia(true);
+      render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={200} />);
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(getVisibleLabel().textContent).toBe("Beta");
+      expect(getIncomingLabel()).toBeNull();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(<CyclingText items={ITEMS} />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("marks the sizing layer as aria-hidden and the visible layer as aria-live", () => {
+      render(<CyclingText items={ITEMS} />);
+      expect(getSizingLabel()).toHaveAttribute("aria-hidden", "true");
+      expect(getVisibleLabel()).toHaveAttribute("aria-live", "polite");
+    });
+  });
+});

--- a/src/components/CyclingText/CyclingText.test.tsx
+++ b/src/components/CyclingText/CyclingText.test.tsx
@@ -160,6 +160,10 @@ describe("CyclingText", () => {
   });
 
   describe("accessibility", () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
+
     it("has no accessibility violations", async () => {
       const { container } = render(<CyclingText items={ITEMS} />);
       const results = await axe(container);

--- a/src/components/CyclingText/CyclingText.test.tsx
+++ b/src/components/CyclingText/CyclingText.test.tsx
@@ -5,29 +5,11 @@ import { CyclingText } from "./CyclingText";
 
 const ITEMS = ["Alpha", "Beta", "Gamma"];
 
-const installMatchMedia = (matches: boolean) => {
-  Object.defineProperty(window, "matchMedia", {
-    writable: true,
-    configurable: true,
-    value: () =>
-      ({
-        matches,
-        media: "(prefers-reduced-motion: reduce)",
-        onchange: null,
-        addEventListener: () => undefined,
-        removeEventListener: () => undefined,
-        dispatchEvent: () => false,
-        addListener: () => undefined,
-        removeListener: () => undefined,
-      }) as unknown as MediaQueryList,
-  });
-};
-
 const getVisibleLabel = () => {
   const root = screen.getByTestId("cycling-text");
-  const live = root.querySelector('[aria-live="polite"]');
-  if (!live) throw new Error("No visible label found");
-  return live;
+  const layer = root.querySelector('[data-layer="current"]');
+  if (!layer) throw new Error("No visible label found");
+  return layer;
 };
 
 const getSizingLabel = () => {
@@ -39,15 +21,13 @@ const getSizingLabel = () => {
 
 const getIncomingLabel = () => {
   const root = screen.getByTestId("cycling-text");
-  // Two aria-hidden spans during a transition — the second is the incoming layer.
-  const hidden = root.querySelectorAll('[aria-hidden="true"]');
-  return hidden.length > 1 ? hidden[1] : null;
+  const incoming = root.querySelector('[data-layer="incoming"]');
+  return incoming;
 };
 
 describe("CyclingText", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    installMatchMedia(false);
   });
 
   afterEach(() => {
@@ -55,7 +35,7 @@ describe("CyclingText", () => {
   });
 
   describe("API", () => {
-    it("renders the first item initially in the live layer", () => {
+    it("renders the first item initially in the current layer", () => {
       render(<CyclingText items={ITEMS} />);
       expect(getVisibleLabel().textContent).toBe("Alpha");
     });
@@ -88,7 +68,6 @@ describe("CyclingText", () => {
 
       expect(getVisibleLabel().textContent).toBe("Alpha");
 
-      // Tick: incoming is mounted with the next item; current is still the old one.
       act(() => {
         vi.advanceTimersByTime(1000);
       });
@@ -104,13 +83,16 @@ describe("CyclingText", () => {
     it("wraps back to the first item after the last", () => {
       render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={100} />);
 
-      act(() => vi.advanceTimersByTime(600));
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(100));
       expect(getVisibleLabel().textContent).toBe("Beta");
 
-      act(() => vi.advanceTimersByTime(600));
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(100));
       expect(getVisibleLabel().textContent).toBe("Gamma");
 
-      act(() => vi.advanceTimersByTime(600));
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(100));
       expect(getVisibleLabel().textContent).toBe("Alpha");
     });
 
@@ -133,23 +115,32 @@ describe("CyclingText", () => {
     });
 
     it("cleans up timers on unmount", () => {
-      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
       const { unmount } = render(<CyclingText items={ITEMS} intervalMs={500} />);
       unmount();
-      expect(clearIntervalSpy).toHaveBeenCalled();
-      clearIntervalSpy.mockRestore();
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      clearTimeoutSpy.mockRestore();
     });
-  });
 
-  describe("reduced motion", () => {
-    it("hard-swaps items with no incoming layer when prefers-reduced-motion is set", () => {
-      installMatchMedia(true);
+    it("completes a transition step without relying on matchMedia", () => {
       render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={200} />);
 
-      act(() => {
-        vi.advanceTimersByTime(500);
-      });
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(200));
+      expect(getVisibleLabel().textContent).toBe("Beta");
+      expect(getIncomingLabel()).toBeNull();
+    });
 
+    it("does not queue a second tick while a long transition is still running", () => {
+      render(<CyclingText items={ITEMS} intervalMs={1000} transitionMs={4000} />);
+
+      act(() => vi.advanceTimersByTime(1000));
+      expect(getIncomingLabel()?.textContent).toBe("Beta");
+
+      act(() => vi.advanceTimersByTime(1000));
+      expect(getIncomingLabel()?.textContent).toBe("Beta");
+
+      act(() => vi.advanceTimersByTime(3000));
       expect(getVisibleLabel().textContent).toBe("Beta");
       expect(getIncomingLabel()).toBeNull();
     });
@@ -166,9 +157,18 @@ describe("CyclingText", () => {
       expect(results).toHaveNoViolations();
     });
 
-    it("marks the sizing layer as aria-hidden and the visible layer as aria-live", () => {
+    it("marks the sizing layer as aria-hidden", () => {
       render(<CyclingText items={ITEMS} />);
       expect(getSizingLabel()).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("does not set aria-live by default", () => {
+      render(<CyclingText items={ITEMS} />);
+      expect(getVisibleLabel()).not.toHaveAttribute("aria-live");
+    });
+
+    it("sets aria-live polite when announceChanges is true", () => {
+      render(<CyclingText items={ITEMS} announceChanges />);
       expect(getVisibleLabel()).toHaveAttribute("aria-live", "polite");
     });
   });

--- a/src/components/CyclingText/CyclingText.test.tsx
+++ b/src/components/CyclingText/CyclingText.test.tsx
@@ -94,7 +94,6 @@ describe("CyclingText", () => {
       });
       expect(getIncomingLabel()?.textContent).toBe("Beta");
 
-      // Finish the slide — incoming becomes current.
       act(() => {
         vi.advanceTimersByTime(200);
       });
@@ -105,15 +104,12 @@ describe("CyclingText", () => {
     it("wraps back to the first item after the last", () => {
       render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={100} />);
 
-      // Alpha -> Beta
       act(() => vi.advanceTimersByTime(600));
       expect(getVisibleLabel().textContent).toBe("Beta");
 
-      // Beta -> Gamma
       act(() => vi.advanceTimersByTime(600));
       expect(getVisibleLabel().textContent).toBe("Gamma");
 
-      // Gamma -> Alpha (wrap)
       act(() => vi.advanceTimersByTime(600));
       expect(getVisibleLabel().textContent).toBe("Alpha");
     });

--- a/src/components/CyclingText/CyclingText.tsx
+++ b/src/components/CyclingText/CyclingText.tsx
@@ -1,0 +1,336 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+const DEFAULT_INTERVAL_MS = 2100;
+const DEFAULT_TRANSITION_MS = 380;
+
+/** How the wrapper should be sized to accommodate variable-length items. */
+export type CyclingTextSizing = "longest" | "current";
+
+export interface CyclingTextProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** Strings to cycle through, in order. Cycles back to the first after the last. */
+  items: readonly string[];
+  /** Time each item is fully visible before the next transition starts. @default 2100 */
+  intervalMs?: number;
+  /** Slide animation duration. @default 380 */
+  transitionMs?: number;
+  /** Direction the outgoing item slides. @default "up" */
+  direction?: "up" | "down";
+  /** When true, freezes on the current item — no further cycling until cleared. @default false */
+  paused?: boolean;
+  /**
+   * How the wrapper sizes itself horizontally.
+   * - `longest` reserves space for the longest item — no width jitter as items cycle.
+   * - `current` shrinks/grows with each item, animating width between cycles.
+   * @default "longest"
+   */
+  sizing?: CyclingTextSizing;
+  /**
+   * Class applied to each visible label span (current + incoming). Use this for
+   * effects that have to sit on the text element itself, e.g. `background-clip: text`.
+   */
+  labelClassName?: string;
+}
+
+const useReducedMotion = () => {
+  const [reduced, setReduced] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return reduced;
+};
+
+const useDocumentVisible = () => {
+  const [visible, setVisible] = React.useState(true);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const update = () => setVisible(!document.hidden);
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, []);
+
+  return visible;
+};
+
+/**
+ * Cycles through a list of strings with a slide-in/slide-out animation. Lives
+ * inline so it can sit inside divs, spans, buttons, or as a fake placeholder
+ * overlay.
+ *
+ * @example
+ * ```tsx
+ * <CyclingText items={["Thinking", "Reading messages", "Drafting reply"]} />
+ * ```
+ */
+export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
+  (
+    {
+      items,
+      intervalMs = DEFAULT_INTERVAL_MS,
+      transitionMs = DEFAULT_TRANSITION_MS,
+      direction = "up",
+      paused = false,
+      sizing = "longest",
+      className,
+      labelClassName,
+      ...rest
+    },
+    ref,
+  ) => {
+    const reducedMotion = useReducedMotion();
+    const docVisible = useDocumentVisible();
+
+    const [currentIndex, setCurrentIndex] = React.useState(0);
+    const [incomingIndex, setIncomingIndex] = React.useState<number | null>(null);
+    const [incomingEntered, setIncomingEntered] = React.useState(false);
+    const [transitioning, setTransitioning] = React.useState(false);
+
+    const currentIndexRef = React.useRef(0);
+    const intervalIdRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
+    const swapTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const enterFrameRef = React.useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
+    const widthFrameRef = React.useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
+
+    const sizingLabelRef = React.useRef<HTMLSpanElement | null>(null);
+    const [trackWidth, setTrackWidth] = React.useState<number | null>(null);
+
+    const itemCount = items.length;
+    const safeCurrentIndex = itemCount === 0 ? 0 : currentIndex % itemCount;
+    const safeIncomingIndex =
+      incomingIndex === null || itemCount === 0 ? null : incomingIndex % itemCount;
+
+    const currentLabel = itemCount === 0 ? "" : items[safeCurrentIndex] ?? "";
+    const incomingLabel =
+      safeIncomingIndex === null ? null : items[safeIncomingIndex] ?? "";
+
+    // For sizing="longest", the sizing label is whichever string is longest by length.
+    // For sizing="current", track the visible/incoming item to animate width.
+    const longestItem = React.useMemo(() => {
+      if (itemCount === 0) return "";
+      let longest = items[0] ?? "";
+      for (const item of items) {
+        if (item.length > longest.length) longest = item;
+      }
+      return longest;
+    }, [items]);
+
+    const sizingLabel =
+      sizing === "longest"
+        ? longestItem
+        : incomingLabel && incomingLabel.length > currentLabel.length
+          ? incomingLabel
+          : currentLabel;
+
+    // Reset to a valid index if items shrink underneath us.
+    React.useEffect(() => {
+      if (itemCount === 0) return;
+      if (currentIndexRef.current >= itemCount) {
+        currentIndexRef.current = 0;
+        setCurrentIndex(0);
+        setIncomingIndex(null);
+        setIncomingEntered(false);
+        setTransitioning(false);
+      }
+    }, [itemCount]);
+
+    const clearTimers = React.useCallback(() => {
+      if (intervalIdRef.current !== null) {
+        clearInterval(intervalIdRef.current);
+        intervalIdRef.current = null;
+      }
+      if (swapTimeoutRef.current !== null) {
+        clearTimeout(swapTimeoutRef.current);
+        swapTimeoutRef.current = null;
+      }
+      if (enterFrameRef.current !== null) {
+        cancelAnimationFrame(enterFrameRef.current);
+        enterFrameRef.current = null;
+      }
+    }, []);
+
+    const shouldCycle = !paused && docVisible && itemCount > 1;
+
+    React.useEffect(() => {
+      if (!shouldCycle) {
+        return;
+      }
+
+      intervalIdRef.current = setInterval(() => {
+        const next = (currentIndexRef.current + 1) % itemCount;
+        setIncomingIndex(next);
+        setIncomingEntered(false);
+        setTransitioning(true);
+
+        if (reducedMotion) {
+          // Hard swap — no slide.
+          currentIndexRef.current = next;
+          setCurrentIndex(next);
+          setTransitioning(false);
+          setIncomingIndex(null);
+          setIncomingEntered(false);
+          return;
+        }
+
+        if (enterFrameRef.current !== null) {
+          cancelAnimationFrame(enterFrameRef.current);
+        }
+        enterFrameRef.current = requestAnimationFrame(() => {
+          setIncomingEntered(true);
+          enterFrameRef.current = null;
+        });
+
+        if (swapTimeoutRef.current !== null) {
+          clearTimeout(swapTimeoutRef.current);
+        }
+        swapTimeoutRef.current = setTimeout(() => {
+          currentIndexRef.current = next;
+          setCurrentIndex(next);
+          setTransitioning(false);
+          setIncomingEntered(false);
+          setIncomingIndex(null);
+          swapTimeoutRef.current = null;
+        }, transitionMs);
+      }, intervalMs);
+
+      return clearTimers;
+    }, [shouldCycle, itemCount, intervalMs, transitionMs, reducedMotion, clearTimers]);
+
+    // Cancel any in-flight transition when paused mid-animation.
+    React.useEffect(() => {
+      if (paused) {
+        clearTimers();
+        setIncomingIndex(null);
+        setIncomingEntered(false);
+        setTransitioning(false);
+      }
+    }, [paused, clearTimers]);
+
+    React.useEffect(() => clearTimers, [clearTimers]);
+
+    // Width tracking via ResizeObserver — handles font load + parent resize.
+    React.useEffect(() => {
+      const node = sizingLabelRef.current;
+      if (!node) return;
+
+      const measure = () => {
+        const next = Math.ceil(node.getBoundingClientRect().width);
+        if (!next) return;
+        if (widthFrameRef.current !== null) {
+          cancelAnimationFrame(widthFrameRef.current);
+        }
+        widthFrameRef.current = requestAnimationFrame(() => {
+          setTrackWidth(next);
+          widthFrameRef.current = null;
+        });
+      };
+
+      measure();
+
+      if (typeof ResizeObserver === "undefined") return;
+      const observer = new ResizeObserver(measure);
+      observer.observe(node);
+
+      return () => {
+        observer.disconnect();
+        if (widthFrameRef.current !== null) {
+          cancelAnimationFrame(widthFrameRef.current);
+          widthFrameRef.current = null;
+        }
+      };
+    }, [sizingLabel]);
+
+    if (itemCount === 0) {
+      return null;
+    }
+
+    const outgoingTranslate = direction === "up" ? "-translate-y-[105%]" : "translate-y-[105%]";
+    const incomingStartTranslate =
+      direction === "up" ? "translate-y-[105%]" : "-translate-y-[105%]";
+
+    // Static Tailwind classes only — duration is applied via inline style so
+    // arbitrary transitionMs values don't have to be pre-emitted by the JIT.
+    const motionClasses = reducedMotion
+      ? ""
+      : "transition-transform ease-[cubic-bezier(0.22,1,0.36,1)]";
+
+    const labelStyle: React.CSSProperties = reducedMotion
+      ? {}
+      : { transitionDuration: transitioning ? `${transitionMs}ms` : "0ms" };
+
+    const incomingStyle: React.CSSProperties = reducedMotion
+      ? {}
+      : { transitionDuration: `${transitionMs}ms` };
+
+    const wrapperStyle: React.CSSProperties = trackWidth !== null ? { width: `${trackWidth}px` } : {};
+
+    return (
+      <span
+        ref={ref}
+        data-testid="cycling-text"
+        data-paused={paused ? "true" : undefined}
+        className={cn(
+          "relative inline-block overflow-hidden transition-[width] duration-300 ease-out",
+          className,
+        )}
+        style={wrapperStyle}
+        {...rest}
+      >
+        {/* Sizing layer — invisible, sets natural width of the wrapper. */}
+        <span
+          ref={sizingLabelRef}
+          aria-hidden="true"
+          className="pointer-events-none invisible inline-block whitespace-nowrap select-none"
+        >
+          {sizingLabel}
+        </span>
+
+        {/* Current (visible) item — slides out when transitioning. */}
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className={cn(
+            "absolute inset-0 whitespace-nowrap",
+            motionClasses,
+            transitioning && !reducedMotion ? outgoingTranslate : "translate-y-0",
+            labelClassName,
+          )}
+          style={labelStyle}
+        >
+          {currentLabel}
+        </span>
+
+        {/* Incoming item — only mounted during the transition. */}
+        {incomingLabel !== null && !reducedMotion && (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute inset-0 whitespace-nowrap",
+              motionClasses,
+              incomingEntered ? "translate-y-0" : incomingStartTranslate,
+              labelClassName,
+            )}
+            style={incomingStyle}
+          >
+            {incomingLabel}
+          </span>
+        )}
+      </span>
+    );
+  },
+);
+
+CyclingText.displayName = "CyclingText";

--- a/src/components/CyclingText/CyclingText.tsx
+++ b/src/components/CyclingText/CyclingText.tsx
@@ -7,8 +7,7 @@ const DEFAULT_TRANSITION_MS = 380;
 /** How the wrapper should be sized to accommodate variable-length items. */
 export type CyclingTextSizing = "longest" | "current";
 
-export interface CyclingTextProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+export interface CyclingTextProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
   /** Strings to cycle through, in order. Cycles back to the first after the last. */
   items: readonly string[];
   /** Time each item is fully visible before the next transition starts. @default 2100 */
@@ -90,6 +89,7 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
       ...rest
     },
     ref,
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: coordinates timers, resize observation, and motion layers
   ) => {
     const reducedMotion = useReducedMotion();
     const docVisible = useDocumentVisible();
@@ -113,9 +113,8 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
     const safeIncomingIndex =
       incomingIndex === null || itemCount === 0 ? null : incomingIndex % itemCount;
 
-    const currentLabel = itemCount === 0 ? "" : items[safeCurrentIndex] ?? "";
-    const incomingLabel =
-      safeIncomingIndex === null ? null : items[safeIncomingIndex] ?? "";
+    const currentLabel = itemCount === 0 ? "" : (items[safeCurrentIndex] ?? "");
+    const incomingLabel = safeIncomingIndex === null ? null : (items[safeIncomingIndex] ?? "");
 
     // For sizing="longest", the sizing label is whichever string is longest by length.
     // For sizing="current", track the visible/incoming item to animate width.
@@ -126,7 +125,7 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
         if (item.length > longest.length) longest = item;
       }
       return longest;
-    }, [items]);
+    }, [items, itemCount]);
 
     const sizingLabel =
       sizing === "longest"
@@ -251,7 +250,7 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
           widthFrameRef.current = null;
         }
       };
-    }, [sizingLabel]);
+    }, []);
 
     if (itemCount === 0) {
       return null;
@@ -275,7 +274,8 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
       ? {}
       : { transitionDuration: `${transitionMs}ms` };
 
-    const wrapperStyle: React.CSSProperties = trackWidth !== null ? { width: `${trackWidth}px` } : {};
+    const wrapperStyle: React.CSSProperties =
+      trackWidth !== null ? { width: `${trackWidth}px` } : {};
 
     return (
       <span
@@ -293,7 +293,7 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
         <span
           ref={sizingLabelRef}
           aria-hidden="true"
-          className="pointer-events-none invisible inline-block whitespace-nowrap select-none"
+          className="pointer-events-none invisible inline-block select-none whitespace-nowrap"
         >
           {sizingLabel}
         </span>

--- a/src/components/CyclingText/CyclingText.tsx
+++ b/src/components/CyclingText/CyclingText.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 import { cn } from "../../utils/cn";
 
 const DEFAULT_INTERVAL_MS = 2100;
-const DEFAULT_TRANSITION_MS = 380;
+const DEFAULT_TRANSITION_MS = 200;
+
+const SLIDE_OFFSET = "1.15em";
 
 /** How the wrapper should be sized to accommodate variable-length items. */
 export type CyclingTextSizing = "longest" | "current";
@@ -12,7 +14,7 @@ export interface CyclingTextProps extends Omit<React.HTMLAttributes<HTMLSpanElem
   items: readonly string[];
   /** Time each item is fully visible before the next transition starts. @default 2100 */
   intervalMs?: number;
-  /** Slide animation duration. @default 380 */
+  /** Slide and cross-fade duration in milliseconds. @default 200 */
   transitionMs?: number;
   /** Direction the outgoing item slides. @default "up" */
   direction?: "up" | "down";
@@ -256,23 +258,44 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
       return null;
     }
 
-    const outgoingTranslate = direction === "up" ? "-translate-y-[105%]" : "translate-y-[105%]";
-    const incomingStartTranslate =
-      direction === "up" ? "translate-y-[105%]" : "-translate-y-[105%]";
+    const incomingOpacityEase = "cubic-bezier(0.72, 0, 0.92, 1)";
+    const incomingTransformEase = "cubic-bezier(0.42, 0, 0.58, 1)";
+    const outgoingOpacityEase = "cubic-bezier(0.42, 0, 1, 1)";
+    const outgoingTransformEase = "cubic-bezier(0.22, 1, 0.36, 1)";
 
-    // Static Tailwind classes only — duration is applied via inline style so
-    // arbitrary transitionMs values don't have to be pre-emitted by the JIT.
-    const motionClasses = reducedMotion
-      ? ""
-      : "transition-transform ease-[cubic-bezier(0.22,1,0.36,1)]";
+    const outgoingMotionStyle: React.CSSProperties = {
+      opacity: transitioning ? 0 : 1,
+      transform:
+        direction === "up"
+          ? transitioning
+            ? `translateY(-${SLIDE_OFFSET})`
+            : "translateY(0)"
+          : transitioning
+            ? `translateY(${SLIDE_OFFSET})`
+            : "translateY(0)",
+      transitionProperty: "opacity, transform",
+      transitionDuration: transitioning ? `${transitionMs}ms, ${transitionMs}ms` : "0ms, 0ms",
+      transitionTimingFunction: transitioning
+        ? `${outgoingOpacityEase}, ${outgoingTransformEase}`
+        : "linear, linear",
+    };
 
-    const labelStyle: React.CSSProperties = reducedMotion
-      ? {}
-      : { transitionDuration: transitioning ? `${transitionMs}ms` : "0ms" };
-
-    const incomingStyle: React.CSSProperties = reducedMotion
-      ? {}
-      : { transitionDuration: `${transitionMs}ms` };
+    const incomingMotionStyle: React.CSSProperties = {
+      opacity: incomingEntered ? 1 : 0,
+      transform:
+        direction === "up"
+          ? incomingEntered
+            ? "translateY(0)"
+            : `translateY(${SLIDE_OFFSET})`
+          : incomingEntered
+            ? "translateY(0)"
+            : `translateY(-${SLIDE_OFFSET})`,
+      transitionProperty: "opacity, transform",
+      transitionDuration: incomingEntered ? `${transitionMs}ms, ${transitionMs}ms` : "0ms, 0ms",
+      transitionTimingFunction: incomingEntered
+        ? `${incomingOpacityEase}, ${incomingTransformEase}`
+        : "linear, linear",
+    };
 
     const wrapperStyle: React.CSSProperties =
       trackWidth !== null ? { width: `${trackWidth}px` } : {};
@@ -298,32 +321,26 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
           {sizingLabel}
         </span>
 
-        {/* Current (visible) item — slides out when transitioning. */}
+        {/* Current (visible) item — slides up and fades out when transitioning. */}
         <span
           aria-live="polite"
           aria-atomic="true"
           className={cn(
             "absolute inset-0 whitespace-nowrap",
-            motionClasses,
-            transitioning && !reducedMotion ? outgoingTranslate : "translate-y-0",
+            reducedMotion && "translate-y-0 opacity-100",
             labelClassName,
           )}
-          style={labelStyle}
+          style={reducedMotion ? undefined : outgoingMotionStyle}
         >
           {currentLabel}
         </span>
 
-        {/* Incoming item — only mounted during the transition. */}
+        {/* Incoming item — slides up from below and fades in. */}
         {incomingLabel !== null && !reducedMotion && (
           <span
             aria-hidden="true"
-            className={cn(
-              "absolute inset-0 whitespace-nowrap",
-              motionClasses,
-              incomingEntered ? "translate-y-0" : incomingStartTranslate,
-              labelClassName,
-            )}
-            style={incomingStyle}
+            className={cn("absolute inset-0 whitespace-nowrap", labelClassName)}
+            style={incomingMotionStyle}
           >
             {incomingLabel}
           </span>

--- a/src/components/CyclingText/CyclingText.tsx
+++ b/src/components/CyclingText/CyclingText.tsx
@@ -1,10 +1,14 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { useCyclingCycle } from "./useCyclingCycle";
+import { useCyclingTextTrackWidth } from "./useCyclingTextTrackWidth";
+import { usePageVisibility } from "./usePageVisibility";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
 
 const DEFAULT_INTERVAL_MS = 2100;
 const DEFAULT_TRANSITION_MS = 200;
 
-const SLIDE_OFFSET = "1.15em";
+const SLIDE_OFFSET_PX = 18;
 
 /** How the wrapper should be sized to accommodate variable-length items. */
 export type CyclingTextSizing = "longest" | "current";
@@ -12,7 +16,10 @@ export type CyclingTextSizing = "longest" | "current";
 export interface CyclingTextProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
   /** Strings to cycle through, in order. Cycles back to the first after the last. */
   items: readonly string[];
-  /** Time each item is fully visible before the next transition starts. @default 2100 */
+  /**
+   * Milliseconds to wait after the previous transition finishes before starting the next one.
+   * @default 2100
+   */
   intervalMs?: number;
   /** Slide and cross-fade duration in milliseconds. @default 200 */
   transitionMs?: number;
@@ -28,44 +35,17 @@ export interface CyclingTextProps extends Omit<React.HTMLAttributes<HTMLSpanElem
    */
   sizing?: CyclingTextSizing;
   /**
+   * When `true`, updates are exposed to assistive technologies via `aria-live="polite"`.
+   * Leave `false` for decorative or frequently changing copy so screen readers are not interrupted on every cycle.
+   * @default false
+   */
+  announceChanges?: boolean;
+  /**
    * Class applied to each visible label span (current + incoming). Use this for
    * effects that have to sit on the text element itself, e.g. `background-clip: text`.
    */
   labelClassName?: string;
 }
-
-const useReducedMotion = () => {
-  const [reduced, setReduced] = React.useState(false);
-
-  React.useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
-    }
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduced(mq.matches);
-    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
-
-  return reduced;
-};
-
-const useDocumentVisible = () => {
-  const [visible, setVisible] = React.useState(true);
-
-  React.useEffect(() => {
-    if (typeof document === "undefined") {
-      return;
-    }
-    const update = () => setVisible(!document.hidden);
-    update();
-    document.addEventListener("visibilitychange", update);
-    return () => document.removeEventListener("visibilitychange", update);
-  }, []);
-
-  return visible;
-};
 
 /**
  * Cycles through a list of strings with a slide-in/slide-out animation. Lives
@@ -88,217 +68,57 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
       sizing = "longest",
       className,
       labelClassName,
+      announceChanges = false,
       ...rest
     },
     ref,
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: coordinates timers, resize observation, and motion layers
   ) => {
-    const reducedMotion = useReducedMotion();
-    const docVisible = useDocumentVisible();
-
-    const [currentIndex, setCurrentIndex] = React.useState(0);
-    const [incomingIndex, setIncomingIndex] = React.useState<number | null>(null);
-    const [incomingEntered, setIncomingEntered] = React.useState(false);
-    const [transitioning, setTransitioning] = React.useState(false);
-
-    const currentIndexRef = React.useRef(0);
-    const intervalIdRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
-    const swapTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-    const enterFrameRef = React.useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
-    const widthFrameRef = React.useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
-
-    const sizingLabelRef = React.useRef<HTMLSpanElement | null>(null);
-    const [trackWidth, setTrackWidth] = React.useState<number | null>(null);
+    const docVisible = usePageVisibility();
+    const reducedMotion = usePrefersReducedMotion();
+    const { sizingLabelRef, trackWidth } = useCyclingTextTrackWidth();
+    const { cycle, currentLabel, incomingLabel, sizingLabel, onOutgoingTransitionEnd } =
+      useCyclingCycle(items, sizing, intervalMs, paused, docVisible, transitionMs);
 
     const itemCount = items.length;
-    const safeCurrentIndex = itemCount === 0 ? 0 : currentIndex % itemCount;
-    const safeIncomingIndex =
-      incomingIndex === null || itemCount === 0 ? null : incomingIndex % itemCount;
 
-    const currentLabel = itemCount === 0 ? "" : (items[safeCurrentIndex] ?? "");
-    const incomingLabel = safeIncomingIndex === null ? null : (items[safeIncomingIndex] ?? "");
-
-    // For sizing="longest", the sizing label is whichever string is longest by length.
-    // For sizing="current", track the visible/incoming item to animate width.
-    const longestItem = React.useMemo(() => {
-      if (itemCount === 0) return "";
-      let longest = items[0] ?? "";
-      for (const item of items) {
-        if (item.length > longest.length) longest = item;
-      }
-      return longest;
-    }, [items, itemCount]);
-
-    const sizingLabel =
-      sizing === "longest"
-        ? longestItem
-        : incomingLabel && incomingLabel.length > currentLabel.length
-          ? incomingLabel
-          : currentLabel;
-
-    // Reset to a valid index if items shrink underneath us.
-    React.useEffect(() => {
-      if (itemCount === 0) return;
-      if (currentIndexRef.current >= itemCount) {
-        currentIndexRef.current = 0;
-        setCurrentIndex(0);
-        setIncomingIndex(null);
-        setIncomingEntered(false);
-        setTransitioning(false);
-      }
-    }, [itemCount]);
-
-    const clearTimers = React.useCallback(() => {
-      if (intervalIdRef.current !== null) {
-        clearInterval(intervalIdRef.current);
-        intervalIdRef.current = null;
-      }
-      if (swapTimeoutRef.current !== null) {
-        clearTimeout(swapTimeoutRef.current);
-        swapTimeoutRef.current = null;
-      }
-      if (enterFrameRef.current !== null) {
-        cancelAnimationFrame(enterFrameRef.current);
-        enterFrameRef.current = null;
-      }
-    }, []);
-
-    const shouldCycle = !paused && docVisible && itemCount > 1;
-
-    React.useEffect(() => {
-      if (!shouldCycle) {
-        return;
-      }
-
-      intervalIdRef.current = setInterval(() => {
-        const next = (currentIndexRef.current + 1) % itemCount;
-        setIncomingIndex(next);
-        setIncomingEntered(false);
-        setTransitioning(true);
-
-        if (reducedMotion) {
-          // Hard swap — no slide.
-          currentIndexRef.current = next;
-          setCurrentIndex(next);
-          setTransitioning(false);
-          setIncomingIndex(null);
-          setIncomingEntered(false);
-          return;
-        }
-
-        if (enterFrameRef.current !== null) {
-          cancelAnimationFrame(enterFrameRef.current);
-        }
-        enterFrameRef.current = requestAnimationFrame(() => {
-          setIncomingEntered(true);
-          enterFrameRef.current = null;
-        });
-
-        if (swapTimeoutRef.current !== null) {
-          clearTimeout(swapTimeoutRef.current);
-        }
-        swapTimeoutRef.current = setTimeout(() => {
-          currentIndexRef.current = next;
-          setCurrentIndex(next);
-          setTransitioning(false);
-          setIncomingEntered(false);
-          setIncomingIndex(null);
-          swapTimeoutRef.current = null;
-        }, transitionMs);
-      }, intervalMs);
-
-      return clearTimers;
-    }, [shouldCycle, itemCount, intervalMs, transitionMs, reducedMotion, clearTimers]);
-
-    // Cancel any in-flight transition when paused mid-animation.
-    React.useEffect(() => {
-      if (paused) {
-        clearTimers();
-        setIncomingIndex(null);
-        setIncomingEntered(false);
-        setTransitioning(false);
-      }
-    }, [paused, clearTimers]);
-
-    React.useEffect(() => clearTimers, [clearTimers]);
-
-    // Width tracking via ResizeObserver — handles font load + parent resize.
-    React.useEffect(() => {
-      const node = sizingLabelRef.current;
-      if (!node) return;
-
-      const measure = () => {
-        const next = Math.ceil(node.getBoundingClientRect().width);
-        if (!next) return;
-        if (widthFrameRef.current !== null) {
-          cancelAnimationFrame(widthFrameRef.current);
-        }
-        widthFrameRef.current = requestAnimationFrame(() => {
-          setTrackWidth(next);
-          widthFrameRef.current = null;
-        });
+    const outgoingMotionStyle = React.useMemo((): React.CSSProperties => {
+      const durMs = reducedMotion ? 0 : transitionMs;
+      const exiting = cycle.transitioning;
+      const yExit = direction === "up" ? -SLIDE_OFFSET_PX : SLIDE_OFFSET_PX;
+      return {
+        opacity: exiting ? 0 : 1,
+        transform: exiting ? `translate3d(0, ${yExit}px, 0)` : "translate3d(0, 0, 0)",
+        transition:
+          exiting && durMs > 0
+            ? `opacity ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1), transform ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1)`
+            : "none",
       };
+    }, [cycle.transitioning, direction, transitionMs, reducedMotion]);
 
-      measure();
-
-      if (typeof ResizeObserver === "undefined") return;
-      const observer = new ResizeObserver(measure);
-      observer.observe(node);
-
-      return () => {
-        observer.disconnect();
-        if (widthFrameRef.current !== null) {
-          cancelAnimationFrame(widthFrameRef.current);
-          widthFrameRef.current = null;
-        }
+    const incomingMotionStyle = React.useMemo((): React.CSSProperties => {
+      const durMs = reducedMotion ? 0 : transitionMs;
+      const entered = cycle.incomingEntered;
+      const yEnter = direction === "up" ? SLIDE_OFFSET_PX : -SLIDE_OFFSET_PX;
+      return {
+        opacity: entered ? 1 : 0,
+        transform: entered ? "translate3d(0, 0, 0)" : `translate3d(0, ${yEnter}px, 0)`,
+        transition:
+          durMs > 0
+            ? `opacity ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1), transform ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1)`
+            : "none",
       };
-    }, []);
+    }, [cycle.incomingEntered, direction, transitionMs, reducedMotion]);
 
     if (itemCount === 0) {
       return null;
     }
 
-    const incomingOpacityEase = "cubic-bezier(0.72, 0, 0.92, 1)";
-    const incomingTransformEase = "cubic-bezier(0.42, 0, 0.58, 1)";
-    const outgoingOpacityEase = "cubic-bezier(0.42, 0, 1, 1)";
-    const outgoingTransformEase = "cubic-bezier(0.22, 1, 0.36, 1)";
+    const wrapperStyle = {
+      ...(trackWidth !== null ? { width: `${trackWidth}px` } : {}),
+      // paddingTop: SLIDE_OFFSET_PX,
+    } as React.CSSProperties;
 
-    const outgoingMotionStyle: React.CSSProperties = {
-      opacity: transitioning ? 0 : 1,
-      transform:
-        direction === "up"
-          ? transitioning
-            ? `translateY(-${SLIDE_OFFSET})`
-            : "translateY(0)"
-          : transitioning
-            ? `translateY(${SLIDE_OFFSET})`
-            : "translateY(0)",
-      transitionProperty: "opacity, transform",
-      transitionDuration: transitioning ? `${transitionMs}ms, ${transitionMs}ms` : "0ms, 0ms",
-      transitionTimingFunction: transitioning
-        ? `${outgoingOpacityEase}, ${outgoingTransformEase}`
-        : "linear, linear",
-    };
-
-    const incomingMotionStyle: React.CSSProperties = {
-      opacity: incomingEntered ? 1 : 0,
-      transform:
-        direction === "up"
-          ? incomingEntered
-            ? "translateY(0)"
-            : `translateY(${SLIDE_OFFSET})`
-          : incomingEntered
-            ? "translateY(0)"
-            : `translateY(-${SLIDE_OFFSET})`,
-      transitionProperty: "opacity, transform",
-      transitionDuration: incomingEntered ? `${transitionMs}ms, ${transitionMs}ms` : "0ms, 0ms",
-      transitionTimingFunction: incomingEntered
-        ? `${incomingOpacityEase}, ${incomingTransformEase}`
-        : "linear, linear",
-    };
-
-    const wrapperStyle: React.CSSProperties =
-      trackWidth !== null ? { width: `${trackWidth}px` } : {};
+    const showIncoming = incomingLabel !== null && cycle.transitioning;
 
     return (
       <span
@@ -306,45 +126,50 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
         data-testid="cycling-text"
         data-paused={paused ? "true" : undefined}
         className={cn(
-          "relative inline-block overflow-hidden transition-[width] duration-300 ease-out",
+          "relative inline-flex items-center overflow-hidden align-middle leading-[inherit]",
+          "motion-safe:transition-[width] motion-safe:duration-300 motion-safe:ease-out",
           className,
         )}
         style={wrapperStyle}
         {...rest}
       >
-        {/* Sizing layer — invisible, sets natural width of the wrapper. */}
         <span
           ref={sizingLabelRef}
           aria-hidden="true"
-          className="pointer-events-none invisible inline-block select-none whitespace-nowrap"
+          className="pointer-events-none invisible inline-block select-none whitespace-nowrap leading-[inherit]"
         >
           {sizingLabel}
         </span>
 
-        {/* Current (visible) item — slides up and fades out when transitioning. */}
         <span
-          aria-live="polite"
-          aria-atomic="true"
+          data-layer="current"
+          aria-live={announceChanges ? "polite" : undefined}
+          aria-atomic={announceChanges ? true : undefined}
+          data-state={cycle.transitioning ? "exit" : "idle"}
+          onTransitionEnd={onOutgoingTransitionEnd}
           className={cn(
-            "absolute inset-0 whitespace-nowrap",
-            reducedMotion && "translate-y-0 opacity-100",
+            "absolute inset-0 flex items-center whitespace-nowrap leading-[inherit]",
             labelClassName,
           )}
-          style={reducedMotion ? undefined : outgoingMotionStyle}
+          style={outgoingMotionStyle}
         >
           {currentLabel}
         </span>
 
-        {/* Incoming item — slides up from below and fades in. */}
-        {incomingLabel !== null && !reducedMotion && (
+        {showIncoming ? (
           <span
             aria-hidden="true"
-            className={cn("absolute inset-0 whitespace-nowrap", labelClassName)}
+            data-layer="incoming"
+            data-state={cycle.incomingEntered ? "idle" : "enter"}
+            className={cn(
+              "absolute inset-0 flex items-center whitespace-nowrap leading-[inherit]",
+              labelClassName,
+            )}
             style={incomingMotionStyle}
           >
             {incomingLabel}
           </span>
-        )}
+        ) : null}
       </span>
     );
   },

--- a/src/components/CyclingText/useCyclingCycle.ts
+++ b/src/components/CyclingText/useCyclingCycle.ts
@@ -1,0 +1,246 @@
+import * as React from "react";
+
+type CyclingTextSizingOption = "longest" | "current";
+
+type CycleState = {
+  currentIndex: number;
+  incomingIndex: number | null;
+  incomingEntered: boolean;
+  transitioning: boolean;
+};
+
+type CycleAction =
+  | { type: "tick"; itemCount: number }
+  | { type: "incoming_entered" }
+  | { type: "transition_complete" }
+  | { type: "pause_clear" }
+  | { type: "clamp_after_items_change"; itemCount: number };
+
+const initialCycleState: CycleState = {
+  currentIndex: 0,
+  incomingIndex: null,
+  incomingEntered: false,
+  transitioning: false,
+};
+
+function cycleReducer(state: CycleState, action: CycleAction): CycleState {
+  switch (action.type) {
+    case "tick": {
+      if (action.itemCount <= 1) return state;
+      const next = (state.currentIndex + 1) % action.itemCount;
+      return {
+        ...state,
+        incomingIndex: next,
+        incomingEntered: false,
+        transitioning: true,
+      };
+    }
+    case "incoming_entered":
+      return { ...state, incomingEntered: true };
+    case "transition_complete": {
+      if (!state.transitioning || state.incomingIndex === null) return state;
+      return {
+        currentIndex: state.incomingIndex,
+        incomingIndex: null,
+        incomingEntered: false,
+        transitioning: false,
+      };
+    }
+    case "pause_clear":
+      return {
+        ...state,
+        incomingIndex: null,
+        incomingEntered: false,
+        transitioning: false,
+      };
+    case "clamp_after_items_change": {
+      if (action.itemCount === 0) return state;
+      const idx = state.currentIndex >= action.itemCount ? 0 : state.currentIndex;
+      return {
+        currentIndex: idx,
+        incomingIndex: null,
+        incomingEntered: false,
+        transitioning: false,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export function useCyclingCycle(
+  items: readonly string[],
+  sizing: CyclingTextSizingOption,
+  intervalMs: number,
+  paused: boolean,
+  docVisible: boolean,
+  transitionMs: number,
+) {
+  const [cycle, dispatch] = React.useReducer(cycleReducer, initialCycleState);
+
+  const enterOuterFrameRef = React.useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
+  const enterInnerFrameRef = React.useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
+  const fallbackTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cycleTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearCycleTimeout = React.useCallback(() => {
+    if (cycleTimeoutRef.current !== null) {
+      clearTimeout(cycleTimeoutRef.current);
+      cycleTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearAnimationArtifacts = React.useCallback(() => {
+    if (enterOuterFrameRef.current !== null) {
+      cancelAnimationFrame(enterOuterFrameRef.current);
+      enterOuterFrameRef.current = null;
+    }
+    if (enterInnerFrameRef.current !== null) {
+      cancelAnimationFrame(enterInnerFrameRef.current);
+      enterInnerFrameRef.current = null;
+    }
+    if (fallbackTimerRef.current !== null) {
+      clearTimeout(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
+    }
+    clearCycleTimeout();
+  }, [clearCycleTimeout]);
+
+  const itemCount = items.length;
+
+  React.useEffect(() => {
+    if (itemCount === 0) return;
+    dispatch({ type: "clamp_after_items_change", itemCount });
+  }, [itemCount]);
+
+  const safeCurrentIndex = itemCount === 0 ? 0 : cycle.currentIndex % itemCount;
+  const safeIncomingIndex =
+    cycle.incomingIndex === null || itemCount === 0 ? null : cycle.incomingIndex % itemCount;
+
+  const currentLabel = itemCount === 0 ? "" : (items[safeCurrentIndex] ?? "");
+  const incomingLabel = safeIncomingIndex === null ? null : (items[safeIncomingIndex] ?? "");
+
+  const longestItem = React.useMemo(() => {
+    if (itemCount === 0) return "";
+    let longest = items[0] ?? "";
+    for (const item of items) {
+      if (item.length > longest.length) longest = item;
+    }
+    return longest;
+  }, [items, itemCount]);
+
+  const sizingLabel =
+    sizing === "longest"
+      ? longestItem
+      : incomingLabel && incomingLabel.length > currentLabel.length
+        ? incomingLabel
+        : currentLabel;
+
+  const shouldCycle = !paused && docVisible && itemCount > 1;
+
+  React.useEffect(() => {
+    if (!shouldCycle || itemCount <= 1) {
+      clearCycleTimeout();
+      return;
+    }
+
+    if (cycle.transitioning) {
+      return;
+    }
+
+    cycleTimeoutRef.current = setTimeout(() => {
+      cycleTimeoutRef.current = null;
+      dispatch({ type: "tick", itemCount });
+    }, intervalMs);
+
+    return () => {
+      clearCycleTimeout();
+    };
+  }, [shouldCycle, itemCount, intervalMs, cycle.transitioning, clearCycleTimeout]);
+
+  React.useEffect(() => {
+    if (paused) {
+      clearAnimationArtifacts();
+      dispatch({ type: "pause_clear" });
+    }
+  }, [paused, clearAnimationArtifacts]);
+
+  React.useEffect(() => {
+    return () => {
+      clearAnimationArtifacts();
+    };
+  }, [clearAnimationArtifacts]);
+
+  React.useEffect(() => {
+    if (!cycle.transitioning || cycle.incomingIndex === null || cycle.incomingEntered) {
+      return;
+    }
+
+    if (enterOuterFrameRef.current !== null) {
+      cancelAnimationFrame(enterOuterFrameRef.current);
+    }
+    if (enterInnerFrameRef.current !== null) {
+      cancelAnimationFrame(enterInnerFrameRef.current);
+    }
+
+    enterOuterFrameRef.current = requestAnimationFrame(() => {
+      enterOuterFrameRef.current = null;
+      enterInnerFrameRef.current = requestAnimationFrame(() => {
+        enterInnerFrameRef.current = null;
+        dispatch({ type: "incoming_entered" });
+      });
+    });
+
+    return () => {
+      if (enterOuterFrameRef.current !== null) {
+        cancelAnimationFrame(enterOuterFrameRef.current);
+        enterOuterFrameRef.current = null;
+      }
+      if (enterInnerFrameRef.current !== null) {
+        cancelAnimationFrame(enterInnerFrameRef.current);
+        enterInnerFrameRef.current = null;
+      }
+    };
+  }, [cycle.transitioning, cycle.incomingIndex, cycle.incomingEntered]);
+
+  React.useEffect(() => {
+    if (!cycle.transitioning) {
+      return;
+    }
+    if (fallbackTimerRef.current !== null) {
+      clearTimeout(fallbackTimerRef.current);
+    }
+    fallbackTimerRef.current = setTimeout(() => {
+      dispatch({ type: "transition_complete" });
+      fallbackTimerRef.current = null;
+    }, transitionMs);
+
+    return () => {
+      if (fallbackTimerRef.current !== null) {
+        clearTimeout(fallbackTimerRef.current);
+        fallbackTimerRef.current = null;
+      }
+    };
+  }, [cycle.transitioning, transitionMs]);
+
+  const onOutgoingTransitionEnd = React.useCallback(
+    (event: React.TransitionEvent<HTMLSpanElement>) => {
+      if (!cycle.transitioning) return;
+      if (event.propertyName !== "opacity") return;
+      if (fallbackTimerRef.current !== null) {
+        clearTimeout(fallbackTimerRef.current);
+        fallbackTimerRef.current = null;
+      }
+      dispatch({ type: "transition_complete" });
+    },
+    [cycle.transitioning],
+  );
+
+  return {
+    cycle,
+    currentLabel,
+    incomingLabel,
+    sizingLabel,
+    onOutgoingTransitionEnd,
+  };
+}

--- a/src/components/CyclingText/useCyclingTextTrackWidth.ts
+++ b/src/components/CyclingText/useCyclingTextTrackWidth.ts
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+/**
+ * Observes the measured label node and stores its width so the wrapper can animate width
+ * without layout thrash when fonts load or the parent resizes.
+ */
+export function useCyclingTextTrackWidth() {
+  const sizingLabelRef = React.useRef<HTMLSpanElement | null>(null);
+  const [trackWidth, setTrackWidth] = React.useState<number | null>(null);
+  const widthFrameRef = React.useRef<ReturnType<typeof requestAnimationFrame> | null>(null);
+
+  React.useEffect(() => {
+    const node = sizingLabelRef.current;
+    if (!node) return;
+
+    const measure = () => {
+      const next = Math.ceil(node.getBoundingClientRect().width);
+      if (!next) return;
+      if (widthFrameRef.current !== null) {
+        cancelAnimationFrame(widthFrameRef.current);
+      }
+      widthFrameRef.current = requestAnimationFrame(() => {
+        setTrackWidth(next);
+        widthFrameRef.current = null;
+      });
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+      if (widthFrameRef.current !== null) {
+        cancelAnimationFrame(widthFrameRef.current);
+        widthFrameRef.current = null;
+      }
+    };
+  }, []);
+
+  return { sizingLabelRef, trackWidth };
+}

--- a/src/components/CyclingText/usePageVisibility.ts
+++ b/src/components/CyclingText/usePageVisibility.ts
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+/**
+ * Tracks whether the browser tab is visible (`document.visibilityState === "visible"`).
+ * Cycling animations use this to pause while the document is hidden so timers do not queue
+ * many swaps while the user is away.
+ */
+export function usePageVisibility(): boolean {
+  const [visible, setVisible] = React.useState(true);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const update = () => {
+      setVisible(document.visibilityState === "visible");
+    };
+    update();
+    document.addEventListener("visibilitychange", update);
+    return () => document.removeEventListener("visibilitychange", update);
+  }, []);
+
+  return visible;
+}

--- a/src/components/CyclingText/usePrefersReducedMotion.ts
+++ b/src/components/CyclingText/usePrefersReducedMotion.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => {
+      setReduced(mq.matches);
+    };
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+
+  return reduced;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,11 @@ export type {
 } from "./components/Count/Count";
 export { Count } from "./components/Count/Count";
 export type {
+  CyclingTextProps,
+  CyclingTextSizing,
+} from "./components/CyclingText/CyclingText";
+export { CyclingText } from "./components/CyclingText/CyclingText";
+export type {
   DialogBodyProps,
   DialogCloseProps,
   DialogContentProps,


### PR DESCRIPTION
## Summary

A rotating text animation. Sits inside divs, spans, buttons, or fake input placeholders. Takes an array of strings and a cycle delay; on tick, the visible item slides out while the next slides in.

- prefers-reduced-motion hard-swap fallback
- pause when document is hidden, so the cycle doesn't catch up after a tab switch
- ResizeObserver-driven width measurement so font-load and parent resize stay in sync
- aria-live="polite" on the visible label, aria-hidden on the sizing and incoming layers
- paused prop for external control (focus, off-screen, etc.)

Sizing has two modes: "longest" (default) reserves space for the longest item to avoid width jitter; "current" animates the wrapper width between items.

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<img width="276" height="87" alt="image" src="https://github.com/user-attachments/assets/06b1ea20-b6c9-4c02-9361-dafe0e198eb4" />

https://github.com/user-attachments/assets/eb90d5a4-924e-41b3-8796-0be51d4e5cf0



