### PR TITLE
Add empty state textSize and imageSize options

### DIFF
--- a/src/components/EmptyState/EmptyState.stories.tsx
+++ b/src/components/EmptyState/EmptyState.stories.tsx
@@ -20,16 +20,9 @@ const meta = {
     },
     titleSize: {
       control: "select",
-      options: [
-        "typography-bold-heading-xl",
-        "typography-bold-heading-lg",
-        "typography-bold-heading-md",
-        "typography-bold-heading-sm",
-        "typography-bold-heading-xs",
-      ],
-      description:
-        "Typography token applied to the title. Defaults to `typography-bold-heading-lg`.",
-      table: { defaultValue: { summary: "typography-bold-heading-lg" } },
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description: "Size of the title heading — xs through xl, mapping to bold heading tokens.",
+      table: { defaultValue: { summary: "lg" } },
     },
     mediaSize: {
       control: "select",
@@ -65,7 +58,7 @@ const defaultArgs = {
 export const Default: Story = {
   args: {
     variant: "default",
-    titleSize: "typography-bold-heading-lg",
+    titleSize: "lg",
     mediaSize: "lg",
     ...defaultArgs,
   },
@@ -90,7 +83,7 @@ export const SmallTitleSize: Story = {
   args: {
     variant: "default",
     ...defaultArgs,
-    titleSize: "typography-bold-heading-sm",
+    titleSize: "sm",
   },
 };
 

--- a/src/components/EmptyState/EmptyState.stories.tsx
+++ b/src/components/EmptyState/EmptyState.stories.tsx
@@ -18,6 +18,26 @@ const meta = {
       control: "select",
       options: ["default", "centered"],
     },
+    titleSize: {
+      control: "select",
+      options: [
+        "typography-bold-heading-xl",
+        "typography-bold-heading-lg",
+        "typography-bold-heading-md",
+        "typography-bold-heading-sm",
+        "typography-bold-heading-xs",
+      ],
+      description:
+        "Typography token applied to the title. Defaults to `typography-bold-heading-lg`.",
+      table: { defaultValue: { summary: "typography-bold-heading-lg" } },
+    },
+    mediaSize: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description:
+        "Height of the media container — xs: 80px, sm: 160px, md: 200px, lg: 280px, xl: 360px.",
+      table: { defaultValue: { summary: "lg" } },
+    },
   },
 } satisfies Meta<typeof EmptyState>;
 
@@ -45,6 +65,8 @@ const defaultArgs = {
 export const Default: Story = {
   args: {
     variant: "default",
+    titleSize: "typography-bold-heading-lg",
+    mediaSize: "lg",
     ...defaultArgs,
   },
 };
@@ -61,5 +83,29 @@ export const WithSecondaryAction: Story = {
     variant: "default",
     ...defaultArgs,
     secondaryAction: <Button variant="secondary">Learn more</Button>,
+  },
+};
+
+export const SmallTitleSize: Story = {
+  args: {
+    variant: "default",
+    ...defaultArgs,
+    titleSize: "typography-bold-heading-sm",
+  },
+};
+
+export const SmallMedia: Story = {
+  args: {
+    variant: "default",
+    ...defaultArgs,
+    mediaSize: "sm",
+  },
+};
+
+export const ExtraSmallMedia: Story = {
+  args: {
+    variant: "default",
+    ...defaultArgs,
+    mediaSize: "xs",
   },
 };

--- a/src/components/EmptyState/EmptyState.test.tsx
+++ b/src/components/EmptyState/EmptyState.test.tsx
@@ -47,15 +47,13 @@ describe("EmptyState", () => {
   });
 
   it("applies the titleSize token class to the heading", () => {
-    const { container } = render(
-      <EmptyState title="No media yet" titleSize="typography-bold-heading-sm" />,
-    );
+    const { container } = render(<EmptyState title="No media yet" titleSize="sm" />);
     const heading = container.querySelector("h2");
     expect(heading).toHaveClass("typography-bold-heading-sm");
     expect(heading).not.toHaveClass("typography-bold-heading-lg");
   });
 
-  it("defaults titleSize to typography-bold-heading-lg", () => {
+  it("defaults titleSize to lg (typography-bold-heading-lg)", () => {
     const { container } = render(<EmptyState title="No media yet" />);
     expect(container.querySelector("h2")).toHaveClass("typography-bold-heading-lg");
   });

--- a/src/components/EmptyState/EmptyState.test.tsx
+++ b/src/components/EmptyState/EmptyState.test.tsx
@@ -46,6 +46,34 @@ describe("EmptyState", () => {
     expect(screen.getByRole("heading", { level: 2, name: "No media yet" })).toBeInTheDocument();
   });
 
+  it("applies the titleSize token class to the heading", () => {
+    const { container } = render(
+      <EmptyState title="No media yet" titleSize="typography-bold-heading-sm" />,
+    );
+    const heading = container.querySelector("h2");
+    expect(heading).toHaveClass("typography-bold-heading-sm");
+    expect(heading).not.toHaveClass("typography-bold-heading-lg");
+  });
+
+  it("defaults titleSize to typography-bold-heading-lg", () => {
+    const { container } = render(<EmptyState title="No media yet" />);
+    expect(container.querySelector("h2")).toHaveClass("typography-bold-heading-lg");
+  });
+
+  it("applies the correct height class for mediaSize", () => {
+    const { container } = render(
+      <EmptyState title="T" media="https://example.com/img.png" mediaSize="sm" />,
+    );
+    const wrapper = container.querySelector("[data-testid='empty-state'] > div");
+    expect(wrapper).toHaveClass("h-[160px]");
+  });
+
+  it("defaults mediaSize to lg", () => {
+    const { container } = render(<EmptyState title="T" media="https://example.com/img.png" />);
+    const wrapper = container.querySelector("[data-testid='empty-state'] > div");
+    expect(wrapper).toHaveClass("h-[280px]");
+  });
+
   it("has no serious axe violations", async () => {
     const { container } = render(
       <EmptyState

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -4,6 +4,23 @@ import { Button } from "../Button/Button";
 
 export type EmptyStateVariant = "default" | "centered";
 
+export type EmptyStateTitleSize =
+  | "typography-bold-heading-xl"
+  | "typography-bold-heading-lg"
+  | "typography-bold-heading-md"
+  | "typography-bold-heading-sm"
+  | "typography-bold-heading-xs";
+
+export type EmptyStateMediaSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+const mediaSizeClass: Record<EmptyStateMediaSize, string> = {
+  xs: "h-[80px]",
+  sm: "h-[160px]",
+  md: "h-[200px]",
+  lg: "h-[280px]",
+  xl: "h-[360px]",
+};
+
 /** Slot that can be plain copy (styled by `EmptyState`) or custom markup. */
 export type EmptyStateSlot = string | React.ReactNode;
 
@@ -29,6 +46,11 @@ export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLElement>,
   variant?: EmptyStateVariant;
   /** Main heading. Strings use library heading styles; pass a node for full control. */
   title?: EmptyStateSlot;
+  /**
+   * Typography token applied to the title when it is a string or plain node.
+   * @default "typography-bold-heading-lg"
+   */
+  titleSize?: EmptyStateTitleSize;
   /** Supporting body copy. Strings use library body styles; pass a node for rich text. */
   description?: EmptyStateSlot;
   /**
@@ -36,6 +58,11 @@ export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLElement>,
    * A string is treated as an image URL (`<img src={…}>`); pass a node for custom layout.
    */
   media?: EmptyStateSlot;
+  /**
+   * Height of the media container.
+   * @default "lg"
+   */
+  mediaSize?: EmptyStateMediaSize;
   /**
    * Primary call to action.
    * A string renders a brand `Button` with that label; pass a node for links, loading, etc.
@@ -54,8 +81,10 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
       className,
       variant = "default",
       title,
+      titleSize = "typography-bold-heading-lg",
       description,
       media,
+      mediaSize = "lg",
       primaryAction,
       secondaryAction,
       ...props
@@ -95,14 +124,11 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
       title === null ||
       title === false ||
       title === "" ? null : isNonEmptyString(title) ? (
-        <h2 id={titleId} className="m-0 typography-bold-heading-lg text-content-primary">
+        <h2 id={titleId} className={cn("m-0 text-content-primary", titleSize)}>
           {title}
         </h2>
       ) : (
-        <div
-          id={titleId}
-          className="typography-bold-heading-lg text-content-primary min-w-0 w-full"
-        >
+        <div id={titleId} className={cn("text-content-primary min-w-0 w-full", titleSize)}>
           {title}
         </div>
       );
@@ -150,7 +176,9 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
         {...props}
       >
         {showMedia && (
-          <div className="h-[280px] w-full overflow-hidden rounded-md">{renderedMedia}</div>
+          <div className={cn("w-full overflow-hidden rounded-md", mediaSizeClass[mediaSize])}>
+            {renderedMedia}
+          </div>
         )}
 
         <div

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -4,12 +4,15 @@ import { Button } from "../Button/Button";
 
 export type EmptyStateVariant = "default" | "centered";
 
-export type EmptyStateTitleSize =
-  | "typography-bold-heading-xl"
-  | "typography-bold-heading-lg"
-  | "typography-bold-heading-md"
-  | "typography-bold-heading-sm"
-  | "typography-bold-heading-xs";
+export type EmptyStateTitleSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+const titleSizeClass: Record<EmptyStateTitleSize, string> = {
+  xs: "typography-bold-heading-xs",
+  sm: "typography-bold-heading-sm",
+  md: "typography-bold-heading-md",
+  lg: "typography-bold-heading-lg",
+  xl: "typography-bold-heading-xl",
+};
 
 export type EmptyStateMediaSize = "xs" | "sm" | "md" | "lg" | "xl";
 
@@ -47,8 +50,8 @@ export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLElement>,
   /** Main heading. Strings use library heading styles; pass a node for full control. */
   title?: EmptyStateSlot;
   /**
-   * Typography token applied to the title when it is a string or plain node.
-   * @default "typography-bold-heading-lg"
+   * Size of the title heading — mapped internally to bold heading typography tokens.
+   * @default "lg"
    */
   titleSize?: EmptyStateTitleSize;
   /** Supporting body copy. Strings use library body styles; pass a node for rich text. */
@@ -81,7 +84,7 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
       className,
       variant = "default",
       title,
-      titleSize = "typography-bold-heading-lg",
+      titleSize = "lg",
       description,
       media,
       mediaSize = "lg",
@@ -124,11 +127,14 @@ export const EmptyState = React.forwardRef<HTMLElement, EmptyStateProps>(
       title === null ||
       title === false ||
       title === "" ? null : isNonEmptyString(title) ? (
-        <h2 id={titleId} className={cn("m-0 text-content-primary", titleSize)}>
+        <h2 id={titleId} className={cn("m-0 text-content-primary", titleSizeClass[titleSize])}>
           {title}
         </h2>
       ) : (
-        <div id={titleId} className={cn("text-content-primary min-w-0 w-full", titleSize)}>
+        <div
+          id={titleId}
+          className={cn("text-content-primary min-w-0 w-full", titleSizeClass[titleSize])}
+        >
           {title}
         </div>
       );


### PR DESCRIPTION
## Summary

- Adding new props `textSize` and `imageSize` in order to achieve latest SWF homepage refresh UI https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2387-80159&m=dev

## Changes

- Adding `textSize` and `imageSize` props to Empty State for extending control

## Checklist

- [x] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [x] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<!-- Paste screenshots or a link to the Chromatic/Storybook build. -->
