### PR TITLE
feat(creator-cover): add CreatorCover component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ import {
   CompassIcon,
   CopyIcon,
   Count,
+  CreatorCover,
   CrossIcon,
   CrownIcon,
   Dialog,
@@ -1779,6 +1780,45 @@ function EmptyStateDemo() {
           primaryAction="Primary action"
           secondaryAction="Secondary action"
         />
+      </div>
+    </div>
+  );
+}
+
+function CreatorCoverDemo() {
+  const sampleImage =
+    "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=600&h=900&fit=crop";
+
+  return (
+    <div id="creator-cover" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-bold-heading-sm mb-4">Creator Cover</h2>
+      <p className="typography-regular-body-md text-content-secondary max-w-xl">
+        Profile hero with a blurred backdrop, central cover image, status pill, name, tagline, and
+        primary CTA. Pass strings for the simple API or nodes for full control.
+      </p>
+      <div className="flex flex-wrap items-start gap-8">
+        <div className="w-[393px]">
+          <CreatorCover
+            imageSrc={sampleImage}
+            imageAlt="Jane Doe"
+            name="JANE DOE"
+            tagline="GLOBAL POPSTAR"
+            tag="New Joiner"
+            action="Join for free for 7 days"
+          />
+        </div>
+        <div className="w-[393px]">
+          <CreatorCover
+            imageSrc={sampleImage}
+            imageAlt="Jane Doe"
+            name="JANE DOE"
+            action={
+              <Button variant="brand" size="48" fullWidth>
+                Subscribe
+              </Button>
+            }
+          />
+        </div>
       </div>
     </div>
   );
@@ -4300,6 +4340,7 @@ function App() {
     { id: "checkbox", label: "Checkbox" },
     { id: "chip", label: "Chip" },
     { id: "count", label: "Count" },
+    { id: "creator-cover", label: "Creator Cover" },
     { id: "datepicker", label: "Date Picker" },
     { id: "dialog", label: "Dialog" },
     { id: "divider", label: "Divider" },
@@ -4454,6 +4495,9 @@ function App() {
 
             {/* Empty State */}
             <EmptyStateDemo />
+
+            {/* Creator Cover */}
+            <CreatorCoverDemo />
 
             {/* Button */}
             <ButtonDemo />

--- a/src/components/CreatorCover/CreatorCover.stories.tsx
+++ b/src/components/CreatorCover/CreatorCover.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../Button/Button";
+import { CreatorCover } from "./CreatorCover";
+
+const meta = {
+  title: "Components/CreatorCover",
+  component: CreatorCover,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-75729&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof CreatorCover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleImage =
+  "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=600&h=900&fit=crop";
+
+const wrapperDecorator = (Story: () => React.ReactElement) => (
+  <div className="w-[393px]">
+    <Story />
+  </div>
+);
+
+const defaultArgs = {
+  imageSrc: sampleImage,
+  imageAlt: "Jane Doe",
+  name: "JANE DOE",
+  tagline: "GLOBAL POPSTAR",
+  tag: "New Joiner",
+  action: "Join for free for 7 days",
+};
+
+export const Default: Story = {
+  args: defaultArgs,
+  decorators: [wrapperDecorator],
+};
+
+export const WithoutTag: Story = {
+  args: {
+    ...defaultArgs,
+    tag: undefined,
+  },
+  decorators: [wrapperDecorator],
+};
+
+export const WithoutTagline: Story = {
+  args: {
+    ...defaultArgs,
+    tagline: undefined,
+  },
+  decorators: [wrapperDecorator],
+};
+
+export const NameOnly: Story = {
+  args: {
+    imageSrc: sampleImage,
+    imageAlt: "Jane Doe",
+    name: "JANE DOE",
+  },
+  decorators: [wrapperDecorator],
+};
+
+export const SeparateBackground: Story = {
+  args: {
+    ...defaultArgs,
+    backgroundSrc:
+      "https://images.unsplash.com/photo-1517457373958-b7bdd4587205?w=600&h=900&fit=crop",
+  },
+  decorators: [wrapperDecorator],
+};
+
+export const CustomActionNode: Story = {
+  args: {
+    ...defaultArgs,
+    action: (
+      <Button variant="brand" size="48" fullWidth>
+        Subscribe
+      </Button>
+    ),
+  },
+  decorators: [wrapperDecorator],
+};

--- a/src/components/CreatorCover/CreatorCover.stories.tsx
+++ b/src/components/CreatorCover/CreatorCover.stories.tsx
@@ -11,6 +11,12 @@ const meta = {
       type: "figma",
       url: "https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-75729&m=dev",
     },
+    chromatic: {
+      modes: {
+        light: { theme: "light" },
+        dark: { theme: "dark" },
+      },
+    },
   },
   tags: ["autodocs"],
 } satisfies Meta<typeof CreatorCover>;
@@ -22,7 +28,7 @@ const sampleImage =
   "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=600&h=900&fit=crop";
 
 const wrapperDecorator = (Story: () => React.ReactElement) => (
-  <div className="w-[393px]">
+  <div className="w-98.25">
     <Story />
   </div>
 );

--- a/src/components/CreatorCover/CreatorCover.stories.tsx
+++ b/src/components/CreatorCover/CreatorCover.stories.tsx
@@ -28,7 +28,7 @@ const sampleImage =
   "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=600&h=900&fit=crop";
 
 const wrapperDecorator = (Story: () => React.ReactElement) => (
-  <div className="w-98.25">
+  <div className="w-120">
     <Story />
   </div>
 );
@@ -91,4 +91,27 @@ export const CustomActionNode: Story = {
     ),
   },
   decorators: [wrapperDecorator],
+};
+
+export const FadeBottom: Story = {
+  args: {
+    ...defaultArgs,
+    fadeBottom: true,
+    square: true,
+  },
+  parameters: {
+    chromatic: {
+      modes: {
+        light: { theme: "light" },
+        dark: { theme: "dark" },
+      },
+    },
+  },
+  decorators: [
+    (Story: () => React.ReactElement) => (
+      <div className="w-200">
+        <Story />
+      </div>
+    ),
+  ],
 };

--- a/src/components/CreatorCover/CreatorCover.stories.tsx
+++ b/src/components/CreatorCover/CreatorCover.stories.tsx
@@ -97,7 +97,6 @@ export const FadeBottom: Story = {
   args: {
     ...defaultArgs,
     fadeBottom: true,
-    square: true,
   },
   parameters: {
     chromatic: {

--- a/src/components/CreatorCover/CreatorCover.test.tsx
+++ b/src/components/CreatorCover/CreatorCover.test.tsx
@@ -28,6 +28,7 @@ describe("CreatorCover", () => {
       render(<CreatorCover {...baseProps} />);
       const cover = screen.getByAltText("Jane Doe");
       expect(cover).toHaveAttribute("src", baseProps.imageSrc);
+      expect(cover).toHaveAttribute("loading", "lazy");
     });
 
     it("falls back to imageSrc for the blurred background when backgroundSrc is omitted", () => {
@@ -54,7 +55,8 @@ describe("CreatorCover", () => {
 
     it("renders a string tag as a pill", () => {
       render(<CreatorCover {...baseProps} tag="New Joiner" />);
-      const tag = screen.getByText("New Joiner");
+      const tag = screen.getByTestId("pill");
+      expect(tag).toHaveTextContent("New Joiner");
       expect(tag).toHaveClass("bg-brand-primary-default");
       expect(tag).toHaveClass("rounded-full");
     });

--- a/src/components/CreatorCover/CreatorCover.test.tsx
+++ b/src/components/CreatorCover/CreatorCover.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Button } from "../Button/Button";
+import { CreatorCover } from "./CreatorCover";
+
+const baseProps = {
+  imageSrc: "https://example.com/creator.jpg",
+  imageAlt: "Jane Doe",
+  name: "JANE DOE",
+};
+
+describe("CreatorCover", () => {
+  describe("API", () => {
+    it("renders a region labelled by the heading", () => {
+      render(<CreatorCover {...baseProps} />);
+      const region = screen.getByRole("region", { name: "JANE DOE" });
+      expect(region).toBeInTheDocument();
+      expect(region).toHaveAttribute("data-testid", "creator-cover");
+    });
+
+    it("renders the name as a level-2 heading", () => {
+      render(<CreatorCover {...baseProps} />);
+      expect(screen.getByRole("heading", { level: 2, name: "JANE DOE" })).toBeInTheDocument();
+    });
+
+    it("uses the imageSrc for the cover image with the provided alt text", () => {
+      render(<CreatorCover {...baseProps} />);
+      const cover = screen.getByAltText("Jane Doe");
+      expect(cover).toHaveAttribute("src", baseProps.imageSrc);
+    });
+
+    it("falls back to imageSrc for the blurred background when backgroundSrc is omitted", () => {
+      const { container } = render(<CreatorCover {...baseProps} />);
+      const images = container.querySelectorAll("img");
+      expect(images).toHaveLength(2);
+      expect(images[0]).toHaveAttribute("src", baseProps.imageSrc);
+    });
+
+    it("uses backgroundSrc for the blurred background when provided", () => {
+      const { container } = render(
+        <CreatorCover {...baseProps} backgroundSrc="https://example.com/bg.jpg" />,
+      );
+      const backgroundImg = container.querySelector("img[alt='']");
+      expect(backgroundImg).toHaveAttribute("src", "https://example.com/bg.jpg");
+    });
+
+    it("renders the tagline in uppercase styling", () => {
+      render(<CreatorCover {...baseProps} tagline="Global Popstar" />);
+      const tagline = screen.getByText("Global Popstar");
+      expect(tagline).toHaveClass("uppercase");
+      expect(tagline).toHaveClass("text-brand-primary-default");
+    });
+
+    it("renders a string tag as a pill", () => {
+      render(<CreatorCover {...baseProps} tag="New Joiner" />);
+      const tag = screen.getByText("New Joiner");
+      expect(tag).toHaveClass("bg-brand-primary-default");
+      expect(tag).toHaveClass("rounded-full");
+    });
+
+    it("renders a node tag as-is", () => {
+      render(<CreatorCover {...baseProps} tag={<span data-testid="custom-tag">Trending</span>} />);
+      expect(screen.getByTestId("custom-tag")).toBeInTheDocument();
+    });
+
+    it("renders a string action as a full-width button", () => {
+      render(<CreatorCover {...baseProps} action="Join for free for 7 days" />);
+      const button = screen.getByRole("button", { name: "Join for free for 7 days" });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveClass("w-full");
+    });
+
+    it("renders a node action as-is", () => {
+      render(<CreatorCover {...baseProps} action={<Button variant="brand">Subscribe</Button>} />);
+      expect(screen.getByRole("button", { name: "Subscribe" })).toBeInTheDocument();
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(<CreatorCover {...baseProps} className="custom-class" />);
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("forwards additional HTML attributes", () => {
+      render(<CreatorCover {...baseProps} id="hero" />);
+      expect(screen.getByRole("region")).toHaveAttribute("id", "hero");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no axe violations with all slots", async () => {
+      const { container } = render(
+        <CreatorCover
+          {...baseProps}
+          tagline="Global Popstar"
+          tag="New Joiner"
+          action="Join for free for 7 days"
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no axe violations with minimal props", async () => {
+      const { container } = render(<CreatorCover {...baseProps} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/CreatorCover/CreatorCover.tsx
+++ b/src/components/CreatorCover/CreatorCover.tsx
@@ -1,0 +1,127 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { Button } from "../Button/Button";
+
+/** Slot that accepts a string (rendered as default styling) or a node for full control. */
+export type CreatorCoverSlot = string | React.ReactNode;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export interface CreatorCoverProps extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
+  /** URL of the creator image displayed in the centre card. Also used as the blurred backdrop unless `backgroundSrc` is provided. */
+  imageSrc: string;
+  /** Alt text for the centre cover image. @default "" */
+  imageAlt?: string;
+  /** Override URL used for the blurred background image. @default `imageSrc` */
+  backgroundSrc?: string;
+  /** Creator's name, rendered as the heading. */
+  name: string;
+  /** Smaller subtitle below the name (e.g. "GLOBAL POPSTAR"). Rendered uppercase in the brand colour. */
+  tagline?: string;
+  /**
+   * Status label rendered as a pill overlapping the bottom of the cover image (e.g. "New Joiner").
+   * Strings render with default green pill styling; pass a node for custom markup.
+   */
+  tag?: CreatorCoverSlot;
+  /**
+   * Primary call to action displayed below the title.
+   * A string renders a full-width white {@link Button} with that label; pass a node for links, loading, etc.
+   */
+  action?: CreatorCoverSlot;
+}
+
+/**
+ * A creator profile hero with a stylised blurred backdrop, central cover image,
+ * status pill, name, tagline, and primary call to action.
+ *
+ * @example
+ * ```tsx
+ * <CreatorCover
+ *   imageSrc="/creator.jpg"
+ *   imageAlt="Jane Doe"
+ *   name="JANE DOE"
+ *   tagline="GLOBAL POPSTAR"
+ *   tag="New Joiner"
+ *   action="Join for free for 7 days"
+ * />
+ * ```
+ */
+export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
+  (
+    { className, imageSrc, imageAlt = "", backgroundSrc, name, tagline, tag, action, ...props },
+    ref,
+  ) => {
+    const headingId = React.useId();
+
+    const renderedTag = isNonEmptyString(tag) ? (
+      <span className="typography-semibold-body-sm inline-flex items-center justify-center whitespace-nowrap rounded-full bg-brand-primary-default px-3 py-2 text-content-primary">
+        {tag}
+      </span>
+    ) : (
+      tag
+    );
+
+    const renderedAction = isNonEmptyString(action) ? (
+      <Button variant="white" size="48" fullWidth>
+        {action}
+      </Button>
+    ) : (
+      action
+    );
+
+    return (
+      <section
+        ref={ref}
+        aria-labelledby={headingId}
+        data-testid="creator-cover"
+        className={cn(
+          "relative isolate w-full overflow-hidden rounded-xl bg-surface-primary-inverted",
+          className,
+        )}
+        {...props}
+      >
+        <div aria-hidden="true" className="absolute inset-0 -z-10">
+          <img
+            src={backgroundSrc ?? imageSrc}
+            alt=""
+            decoding="async"
+            className="size-full scale-110 object-cover blur-3xl"
+          />
+          <div className="absolute inset-0 bg-linear-to-b from-black/30 to-black/15" />
+        </div>
+
+        <div className="flex flex-col items-center gap-4 px-4 pt-17 pb-4">
+          <div className="relative">
+            <img
+              src={imageSrc}
+              alt={imageAlt}
+              decoding="async"
+              className="block h-55 w-37.5 rounded-lg object-cover"
+            />
+            {renderedTag ? (
+              <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2">
+                {renderedTag}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col items-center gap-1 pt-4 text-center">
+            <h2 id={headingId} className="typography-bold-heading-md m-0 text-white">
+              {name}
+            </h2>
+            {tagline ? (
+              <p className="typography-semibold-badge m-0 text-brand-primary-default uppercase">
+                {tagline}
+              </p>
+            ) : null}
+          </div>
+          {renderedAction ? <div className="w-full pt-2">{renderedAction}</div> : null}
+        </div>
+      </section>
+    );
+  },
+);
+
+CreatorCover.displayName = "CreatorCover";

--- a/src/components/CreatorCover/CreatorCover.tsx
+++ b/src/components/CreatorCover/CreatorCover.tsx
@@ -30,8 +30,6 @@ export interface CreatorCoverProps extends Omit<React.HTMLAttributes<HTMLElement
    * A string renders a full-width white {@link Button} with that label; pass a node for links, loading, etc.
    */
   action?: CreatorCoverSlot;
-  /** When `true`, removes the `rounded-xl` border radius from the container. @default false */
-  square?: boolean;
   /** When `true`, fades the bottom of the component to transparent and increases bottom padding to 64px. @default false */
   fadeBottom?: boolean;
 }
@@ -54,19 +52,7 @@ export interface CreatorCoverProps extends Omit<React.HTMLAttributes<HTMLElement
  */
 export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
   (
-    {
-      className,
-      imageSrc,
-      imageAlt = "",
-      backgroundSrc,
-      name,
-      tagline,
-      tag,
-      action,
-      square = false,
-      fadeBottom = false,
-      ...props
-    },
+    { className, imageSrc, imageAlt = "", backgroundSrc, name, tagline, tag, action, ...props },
     ref,
   ) => {
     const headingId = React.useId();
@@ -94,7 +80,6 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
         data-testid="creator-cover"
         className={cn(
           "relative isolate w-full overflow-hidden bg-white dark:bg-bg-primary",
-          !square && "rounded-xl",
           className,
         )}
         {...props}
@@ -107,16 +92,9 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
             className="size-full scale-110 object-cover blur-3xl"
           />
           <div className="absolute inset-0 bg-linear-to-b from-white/30 to-white/15 dark:from-bg-primary/30 dark:to-bg-primary/15" />
-          {fadeBottom && (
-            <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-b from-transparent to-white dark:to-bg-primary" />
-          )}
+          <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-b from-transparent to-white dark:to-bg-primary" />
         </div>
-        <div
-          className={cn(
-            "mx-auto flex max-w-90 flex-col items-center gap-4 px-4 pt-17",
-            fadeBottom ? "pb-16" : "pb-4",
-          )}
-        >
+        <div className={cn("mx-auto flex max-w-90 flex-col items-center gap-4 px-4 pt-17 pb-16")}>
           <div className="relative">
             <img
               src={imageSrc}

--- a/src/components/CreatorCover/CreatorCover.tsx
+++ b/src/components/CreatorCover/CreatorCover.tsx
@@ -106,7 +106,7 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
             decoding="async"
             className="size-full scale-110 object-cover blur-3xl"
           />
-          <div className="absolute inset-0 bg-linear-to-b from-white/30 dark:from-bg-primary/30 to-white/15 dark:to-bg-primary/15" />
+          <div className="absolute inset-0 bg-linear-to-b from-white/30 to-white/15 dark:from-bg-primary/30 dark:to-bg-primary/15" />
           {fadeBottom && (
             <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-b from-transparent to-white dark:to-bg-primary" />
           )}

--- a/src/components/CreatorCover/CreatorCover.tsx
+++ b/src/components/CreatorCover/CreatorCover.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
 import { Button } from "../Button/Button";
+import { Pill } from "../Pill/Pill";
 
 /** Slot that accepts a string (rendered as default styling) or a node for full control. */
 export type CreatorCoverSlot = string | React.ReactNode;
@@ -57,13 +58,7 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
   ) => {
     const headingId = React.useId();
 
-    const renderedTag = isNonEmptyString(tag) ? (
-      <span className="typography-semibold-body-sm inline-flex items-center justify-center whitespace-nowrap rounded-full bg-brand-primary-default px-3 py-2 text-content-on-brand">
-        {tag}
-      </span>
-    ) : (
-      tag
-    );
+    const renderedTag = isNonEmptyString(tag) ? <Pill variant="brand">{tag}</Pill> : tag;
 
     const renderedAction = isNonEmptyString(action) ? (
       <Button variant="white" size="48" fullWidth>
@@ -84,11 +79,11 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
         )}
         {...props}
       >
-        <div aria-hidden="true" className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 -z-10">
           <img
             src={backgroundSrc ?? imageSrc}
             alt=""
-            decoding="async"
+            loading="lazy"
             className="size-full scale-110 object-cover blur-3xl"
           />
           <div className="absolute inset-0 bg-linear-to-b from-white/30 to-white/15 dark:from-bg-primary/30 dark:to-bg-primary/15" />
@@ -99,7 +94,7 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
             <img
               src={imageSrc}
               alt={imageAlt}
-              decoding="async"
+              loading="lazy"
               className="block h-55 w-37.5 rounded-lg object-cover"
             />
             {renderedTag ? (

--- a/src/components/CreatorCover/CreatorCover.tsx
+++ b/src/components/CreatorCover/CreatorCover.tsx
@@ -30,6 +30,10 @@ export interface CreatorCoverProps extends Omit<React.HTMLAttributes<HTMLElement
    * A string renders a full-width white {@link Button} with that label; pass a node for links, loading, etc.
    */
   action?: CreatorCoverSlot;
+  /** When `true`, removes the `rounded-xl` border radius from the container. @default false */
+  square?: boolean;
+  /** When `true`, fades the bottom of the component to transparent and increases bottom padding to 64px. @default false */
+  fadeBottom?: boolean;
 }
 
 /**
@@ -50,7 +54,19 @@ export interface CreatorCoverProps extends Omit<React.HTMLAttributes<HTMLElement
  */
 export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
   (
-    { className, imageSrc, imageAlt = "", backgroundSrc, name, tagline, tag, action, ...props },
+    {
+      className,
+      imageSrc,
+      imageAlt = "",
+      backgroundSrc,
+      name,
+      tagline,
+      tag,
+      action,
+      square = false,
+      fadeBottom = false,
+      ...props
+    },
     ref,
   ) => {
     const headingId = React.useId();
@@ -77,7 +93,8 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
         aria-labelledby={headingId}
         data-testid="creator-cover"
         className={cn(
-          "relative isolate w-full overflow-hidden rounded-xl bg-surface-primary",
+          "relative isolate w-full overflow-hidden bg-white dark:bg-bg-primary",
+          !square && "rounded-xl",
           className,
         )}
         {...props}
@@ -89,9 +106,17 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
             decoding="async"
             className="size-full scale-110 object-cover blur-3xl"
           />
-          <div className="absolute inset-0 bg-linear-to-b from-black/30 to-black/15" />
+          <div className="absolute inset-0 bg-linear-to-b from-white/30 dark:from-bg-primary/30 to-white/15 dark:to-bg-primary/15" />
+          {fadeBottom && (
+            <div className="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-b from-transparent to-white dark:to-bg-primary" />
+          )}
         </div>
-        <div className="flex flex-col items-center gap-4 px-4 pt-17 pb-4">
+        <div
+          className={cn(
+            "mx-auto flex max-w-90 flex-col items-center gap-4 px-4 pt-17",
+            fadeBottom ? "pb-16" : "pb-4",
+          )}
+        >
           <div className="relative">
             <img
               src={imageSrc}

--- a/src/components/CreatorCover/CreatorCover.tsx
+++ b/src/components/CreatorCover/CreatorCover.tsx
@@ -56,7 +56,7 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
     const headingId = React.useId();
 
     const renderedTag = isNonEmptyString(tag) ? (
-      <span className="typography-semibold-body-sm inline-flex items-center justify-center whitespace-nowrap rounded-full bg-brand-primary-default px-3 py-2 text-content-primary">
+      <span className="typography-semibold-body-sm inline-flex items-center justify-center whitespace-nowrap rounded-full bg-brand-primary-default px-3 py-2 text-content-on-brand">
         {tag}
       </span>
     ) : (
@@ -77,7 +77,7 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
         aria-labelledby={headingId}
         data-testid="creator-cover"
         className={cn(
-          "relative isolate w-full overflow-hidden rounded-xl bg-surface-primary-inverted",
+          "relative isolate w-full overflow-hidden rounded-xl bg-surface-primary",
           className,
         )}
         {...props}
@@ -91,7 +91,6 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
           />
           <div className="absolute inset-0 bg-linear-to-b from-black/30 to-black/15" />
         </div>
-
         <div className="flex flex-col items-center gap-4 px-4 pt-17 pb-4">
           <div className="relative">
             <img
@@ -106,7 +105,6 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
               </div>
             ) : null}
           </div>
-
           <div className="flex flex-col items-center gap-1 pt-4 text-center">
             <h2 id={headingId} className="typography-bold-heading-md m-0 text-white">
               {name}

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,11 @@ export type {
 } from "./components/Count/Count";
 export { Count } from "./components/Count/Count";
 export type {
+  CreatorCoverProps,
+  CreatorCoverSlot,
+} from "./components/CreatorCover/CreatorCover";
+export { CreatorCover } from "./components/CreatorCover/CreatorCover";
+export type {
   DialogBodyProps,
   DialogCloseProps,
   DialogContentProps,


### PR DESCRIPTION
## Summary

Adds a new `CreatorCover` component — a creator profile hero with a stylised blurred backdrop, central cover image, status pill, name, tagline, and primary call to action. Implementation matches the [Figma exploration design](https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-75729&m=dev) and follows the library's standard component patterns (`forwardRef`, `cn()`, string-or-node slots, Tailwind tokens, JSDoc'd public API).

## Changes

- `src/components/CreatorCover/CreatorCover.tsx` — component implementation with props `imageSrc`, `imageAlt`, `backgroundSrc`, `name`, `tagline`, `tag`, `action`, `square`, `fadeBottom`. Strings render with default styling (green pill, full-width white `Button`); pass nodes for full control.
- `src/components/CreatorCover/CreatorCover.test.tsx` — 14 unit tests covering API contracts (region labelling, heading level, image sources, slot rendering, className, attribute forwarding) and axe accessibility.
- `src/components/CreatorCover/CreatorCover.stories.tsx` — 7 stories (Default, WithoutTag, WithoutTagline, NameOnly, SeparateBackground, CustomActionNode, FadeBottom) with Figma `design` parameter and Chromatic light/dark modes.
- `src/index.ts` — exports `CreatorCover` plus `CreatorCoverProps` and `CreatorCoverSlot` types.
- `src/App.tsx` — adds a Creator Cover demo section to the showcase app.

## Checklist

- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] New/updated components have stories
- [x] New/updated components have accessibility tests
- [x] New/updated components have forwardRef unit tests
- [x] New/updated components have className chaining unit tests
- [x] Exported in `src/index.ts` (if consumable by vendors)
- [x] Figma link added to story `design` parameter (if applicable)
- [x] Does not have barrel file `src/YourComponent/index.ts`
## Screenshots / Storybook

<img width="800" height="546" alt="Screenshot 2026-05-04 at 15 48 33" src="https://github.com/user-attachments/assets/5bb209a2-0b8b-404f-a5d1-755c47c364a2" /> <img width="804" height="546" alt="Screenshot 2026-05-04 at 15 48 16" src="https://github.com/user-attachments/assets/1ec6c8f3-0041-4e6b-ad37-dd850c432fa1" />

Stories: [Default](https://fanvue.github.io/fanv-ui/pr-456/?path=/story/components-creatorcover--default) · [WithoutTag](https://fanvue.github.io/fanv-ui/pr-456/?path=/story/components-creatorcover--without-tag) · [WithoutTagline](https://fanvue.github.io/fanv-ui/pr-456/?path=/story/components-creatorcover--without-tagline) · [NameOnly](https://fanvue.github.io/fanv-ui/pr-456/?path=/story/components-creatorcover--name-only) · [SeparateBackground](https://fanvue.github.io/fanv-ui/pr-456/?path=/story/components-creatorcover--separate-background) · [CustomActionNode](https://fanvue.github.io/fanv-ui/pr-456/?path=/story/components-creatorcover--custom-action-node) · [FadeBottom](https://fanvue.github.io/fanv-ui/pr-456/?path=/story/components-creatorcover--fade-bottom)

Co-authored-by: Copilot <copilot@github.com>
