### PR TITLE
feat(creator-card): Adding CreatorCard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ import {
   CompassIcon,
   CopyIcon,
   Count,
+  CreatorCard,
   CrossIcon,
   CrownIcon,
   Dialog,
@@ -4276,6 +4277,81 @@ function CardDemo() {
   );
 }
 
+function CreatorCardDemo() {
+  const imageSrc =
+    "https://images.unsplash.com/photo-1517841905240-472988babdf9?w=580&h=900&fit=crop";
+  const avatarSrc =
+    "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop";
+
+  return (
+    <div id="creator-card" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-bold-heading-xs mb-4">Creator Card</h2>
+
+      <h3 className="typography-semibold-body-lg">Button variants</h3>
+      <div className="flex flex-wrap items-start gap-6">
+        <CreatorCard
+          imageSrc={imageSrc}
+          name="Jane Doe"
+          description="MODEL & PODCASTER"
+          avatarSrc={avatarSrc}
+          avatarFallback="JD"
+          actions={
+            <>
+              <Button variant="brand" size="32" fullWidth>
+                Join for free for 3 days
+              </Button>
+              <Button variant="primary" size="32" fullWidth>
+                Follow for Free
+              </Button>
+            </>
+          }
+        />
+        <CreatorCard
+          imageSrc={imageSrc}
+          name="Jane Doe"
+          description="MODEL & PODCASTER"
+          avatarSrc={avatarSrc}
+          avatarFallback="JD"
+          actions={
+            <Button variant="brand" size="32" fullWidth>
+              Follow for Free
+            </Button>
+          }
+        />
+        <CreatorCard
+          imageSrc={imageSrc}
+          name="Jane Doe"
+          description="MODEL & PODCASTER"
+          avatarSrc={avatarSrc}
+          avatarFallback="JD"
+        />
+      </div>
+
+      <h3 className="typography-semibold-body-lg mt-4">Rounded sizes</h3>
+      <div className="flex flex-wrap items-start gap-6">
+        {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((rounded) => (
+          <div key={rounded} className="flex flex-col items-center gap-2">
+            <CreatorCard
+              imageSrc={imageSrc}
+              name="Jane Doe"
+              description="MODEL & PODCASTER"
+              avatarSrc={avatarSrc}
+              avatarFallback="JD"
+              rounded={rounded}
+              actions={
+                <Button variant="brand" size="32" fullWidth>
+                  Follow for Free
+                </Button>
+              }
+            />
+            <p className="typography-regular-body-sm text-content-secondary">{rounded}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function App() {
   const [dark, setDark] = useState(false);
   const [tocOpen, setTocOpen] = useState(false);
@@ -4300,6 +4376,7 @@ function App() {
     { id: "checkbox", label: "Checkbox" },
     { id: "chip", label: "Chip" },
     { id: "count", label: "Count" },
+    { id: "creator-card", label: "Creator Card" },
     { id: "datepicker", label: "Date Picker" },
     { id: "dialog", label: "Dialog" },
     { id: "divider", label: "Divider" },
@@ -4560,6 +4637,9 @@ function App() {
 
             {/* Card */}
             <CardDemo />
+
+            {/* Creator Card */}
+            <CreatorCardDemo />
 
             {/* Toast */}
             <ToastDemo />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4375,8 +4375,7 @@ function CreatorCardDemo() {
           imageSrc={imageSrc}
           name="Jane Doe"
           description="MODEL & PODCASTER"
-          avatarSrc={avatarSrc}
-          avatarFallback="JD"
+          avatar={{ src: avatarSrc, alt: "Jane Doe", fallback: "JD" }}
           actions={
             <>
               <Button variant="brand" size="32" fullWidth>
@@ -4392,8 +4391,7 @@ function CreatorCardDemo() {
           imageSrc={imageSrc}
           name="Jane Doe"
           description="MODEL & PODCASTER"
-          avatarSrc={avatarSrc}
-          avatarFallback="JD"
+          avatar={{ src: avatarSrc, alt: "Jane Doe", fallback: "JD" }}
           actions={
             <Button variant="brand" size="32" fullWidth>
               Follow for Free
@@ -4404,8 +4402,7 @@ function CreatorCardDemo() {
           imageSrc={imageSrc}
           name="Jane Doe"
           description="MODEL & PODCASTER"
-          avatarSrc={avatarSrc}
-          avatarFallback="JD"
+          avatar={{ src: avatarSrc, alt: "Jane Doe", fallback: "JD" }}
         />
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4409,7 +4409,6 @@ function CreatorCardDemo() {
   return (
     <div id="creator-card" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-bold-heading-xs mb-4">Creator Card</h2>
-
       <h3 className="typography-semibold-body-lg">Button variants</h3>
       <div className="flex flex-wrap items-start gap-6">
         <CreatorCard
@@ -4427,6 +4426,7 @@ function CreatorCardDemo() {
               </Button>
             </>
           }
+          className="w-72 rounded-md"
         />
         <CreatorCard
           imageSrc={imageSrc}
@@ -4438,12 +4438,14 @@ function CreatorCardDemo() {
               Follow for Free
             </Button>
           }
+          className="w-72 rounded-md"
         />
         <CreatorCard
           imageSrc={imageSrc}
           name="Jane Doe"
           description="MODEL & PODCASTER"
           avatar={{ src: avatarSrc, alt: "Jane Doe", fallback: "JD" }}
+          className="w-72 rounded-md"
         />
       </div>
     </div>
@@ -4786,7 +4788,7 @@ function App() {
 
             {/* Creator Card */}
             <CreatorCardDemo />
-            
+
             {/* Creator Tile */}
             <CreatorTileDemo />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4326,28 +4326,6 @@ function CreatorCardDemo() {
           avatarFallback="JD"
         />
       </div>
-
-      <h3 className="typography-semibold-body-lg mt-4">Rounded sizes</h3>
-      <div className="flex flex-wrap items-start gap-6">
-        {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((rounded) => (
-          <div key={rounded} className="flex flex-col items-center gap-2">
-            <CreatorCard
-              imageSrc={imageSrc}
-              name="Jane Doe"
-              description="MODEL & PODCASTER"
-              avatarSrc={avatarSrc}
-              avatarFallback="JD"
-              rounded={rounded}
-              actions={
-                <Button variant="brand" size="32" fullWidth>
-                  Follow for Free
-                </Button>
-              }
-            />
-            <p className="typography-regular-body-sm text-content-secondary">{rounded}</p>
-          </div>
-        ))}
-      </div>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1830,7 +1830,11 @@ function CreatorCoverDemo() {
             name="JANE DOE"
             tagline="GLOBAL POPSTAR"
             tag="New Joiner"
-            action="Join for free for 7 days"
+            action={
+              <Button variant="primary" size="48" fullWidth>
+                Join for free for 7 days
+              </Button>
+            }
           />
         </div>
         <div className="w-[393px]">

--- a/src/components/CreatorCard/CreatorCard.stories.tsx
+++ b/src/components/CreatorCard/CreatorCard.stories.tsx
@@ -22,8 +22,11 @@ const meta = {
     imageSrc: SAMPLE_IMAGE,
     name: "Jane Doe",
     description: "MODEL & PODCASTER",
-    avatarSrc: SAMPLE_AVATAR,
-    avatarFallback: "JD",
+    avatar: {
+      src: SAMPLE_AVATAR,
+      alt: "Jane Doe",
+      fallback: "JD",
+    },
   },
 } satisfies Meta<typeof CreatorCard>;
 
@@ -56,6 +59,23 @@ export const OneButton: Story = {
 };
 
 export const NoButtons: Story = {};
+
+export const AvatarOptions: Story = {
+  args: {
+    avatar: {
+      src: SAMPLE_AVATAR,
+      alt: "Jane Doe",
+      fallback: "JD",
+      onlineIndicator: true,
+      platinumShow: true,
+    },
+    actions: (
+      <Button variant="primary" size="32" fullWidth>
+        Follow for Free
+      </Button>
+    ),
+  },
+};
 
 export const ContainerScaling: Story = {
   args: {

--- a/src/components/CreatorCard/CreatorCard.stories.tsx
+++ b/src/components/CreatorCard/CreatorCard.stories.tsx
@@ -57,6 +57,33 @@ export const OneButton: Story = {
 
 export const NoButtons: Story = {};
 
+export const ContainerScaling: Story = {
+  args: {
+    actions: (
+      <Button variant="primary" size="32" fullWidth>
+        Follow for Free
+      </Button>
+    ),
+  },
+  render: (args) => (
+    <div className="flex flex-wrap items-start gap-6">
+      {[
+        { label: "160px", className: "w-40" },
+        { label: "240px", className: "w-60" },
+        { label: "320px", className: "w-80" },
+        { label: "420px max", className: "w-[420px] max-w-[calc(100vw-2rem)]" },
+      ].map((container) => (
+        <div key={container.label} className="flex flex-col gap-2">
+          <div className={container.className}>
+            <CreatorCard {...args} />
+          </div>
+          <p className="typography-regular-body-sm text-content-secondary">{container.label}</p>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
 export const WithoutDescription: Story = {
   args: {
     description: undefined,

--- a/src/components/CreatorCard/CreatorCard.stories.tsx
+++ b/src/components/CreatorCard/CreatorCard.stories.tsx
@@ -18,19 +18,12 @@ const meta = {
     },
   },
   tags: ["autodocs"],
-  argTypes: {
-    rounded: {
-      control: "select",
-      options: ["none", "xs", "sm", "md", "lg", "xl"],
-    },
-  },
   args: {
     imageSrc: SAMPLE_IMAGE,
     name: "Jane Doe",
     description: "MODEL & PODCASTER",
     avatarSrc: SAMPLE_AVATAR,
     avatarFallback: "JD",
-    rounded: "lg",
   },
 } satisfies Meta<typeof CreatorCard>;
 
@@ -63,26 +56,6 @@ export const OneButton: Story = {
 };
 
 export const NoButtons: Story = {};
-
-export const RoundedSizes: Story = {
-  render: (args) => (
-    <div className="flex flex-wrap items-start gap-6">
-      {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((rounded) => (
-        <div key={rounded} className="flex flex-col items-center gap-2">
-          <CreatorCard {...args} rounded={rounded} />
-          <p className="typography-regular-body-sm text-content-secondary">{rounded}</p>
-        </div>
-      ))}
-    </div>
-  ),
-  args: {
-    actions: (
-      <Button variant="primary" size="32" fullWidth>
-        Follow for Free
-      </Button>
-    ),
-  },
-};
 
 export const WithoutDescription: Story = {
   args: {

--- a/src/components/CreatorCard/CreatorCard.stories.tsx
+++ b/src/components/CreatorCard/CreatorCard.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../Button/Button";
+import { CreatorCard } from "./CreatorCard";
+
+const SAMPLE_IMAGE =
+  "https://images.unsplash.com/photo-1517841905240-472988babdf9?w=580&h=900&fit=crop";
+const SAMPLE_AVATAR =
+  "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop";
+
+const meta = {
+  title: "Components/CreatorCard",
+  component: CreatorCard,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-76229",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    rounded: {
+      control: "select",
+      options: ["none", "xs", "sm", "md", "lg", "xl"],
+    },
+  },
+  args: {
+    imageSrc: SAMPLE_IMAGE,
+    name: "Jane Doe",
+    description: "MODEL & PODCASTER",
+    avatarSrc: SAMPLE_AVATAR,
+    avatarFallback: "JD",
+    rounded: "lg",
+  },
+} satisfies Meta<typeof CreatorCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TwoButtons: Story = {
+  args: {
+    actions: (
+      <>
+        <Button variant="brand" size="32" fullWidth>
+          Join for free for 3 days
+        </Button>
+        <Button variant="primary" size="32" fullWidth>
+          Follow for Free
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const OneButton: Story = {
+  args: {
+    actions: (
+      <Button variant="primary" size="32" fullWidth>
+        Follow for Free
+      </Button>
+    ),
+  },
+};
+
+export const NoButtons: Story = {};
+
+export const RoundedSizes: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-start gap-6">
+      {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((rounded) => (
+        <div key={rounded} className="flex flex-col items-center gap-2">
+          <CreatorCard {...args} rounded={rounded} />
+          <p className="typography-regular-body-sm text-content-secondary">{rounded}</p>
+        </div>
+      ))}
+    </div>
+  ),
+  args: {
+    actions: (
+      <Button variant="primary" size="32" fullWidth>
+        Follow for Free
+      </Button>
+    ),
+  },
+};
+
+export const WithoutDescription: Story = {
+  args: {
+    description: undefined,
+    actions: (
+      <Button variant="primary" size="32" fullWidth>
+        Follow for Free
+      </Button>
+    ),
+  },
+};

--- a/src/components/CreatorCard/CreatorCard.test.tsx
+++ b/src/components/CreatorCard/CreatorCard.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Button } from "../Button/Button";
+import { CreatorCard } from "./CreatorCard";
+
+const baseProps = {
+  imageSrc: "https://images.unsplash.com/photo-abc?w=290&h=450&fit=crop",
+  name: "Jane Doe",
+};
+
+describe("CreatorCard", () => {
+  describe("API", () => {
+    it("renders the name and description", () => {
+      render(<CreatorCard {...baseProps} description="MODEL & PODCASTER" />);
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.getByText("MODEL & PODCASTER")).toBeInTheDocument();
+    });
+
+    it("renders the background image with empty alt by default", () => {
+      render(<CreatorCard {...baseProps} data-testid="card" />);
+      const image = screen.getByTestId("card").querySelector("img");
+      expect(image).toHaveAttribute("src", baseProps.imageSrc);
+      expect(image).toHaveAttribute("alt", "");
+    });
+
+    it("uses provided imageAlt when set", () => {
+      render(<CreatorCard {...baseProps} imageAlt="Creator portrait" data-testid="card" />);
+      const image = screen.getByTestId("card").querySelector("img");
+      expect(image).toHaveAttribute("alt", "Creator portrait");
+    });
+
+    it("renders avatar fallback content", async () => {
+      render(<CreatorCard {...baseProps} avatarFallback="JD" />);
+      expect(await screen.findByText("JD")).toBeInTheDocument();
+    });
+
+    it("forwards ref correctly", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<CreatorCard {...baseProps} ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("applies custom className", () => {
+      render(<CreatorCard {...baseProps} data-testid="card" className="custom" />);
+      expect(screen.getByTestId("card")).toHaveClass("custom");
+    });
+
+    it("spreads additional HTML attributes", () => {
+      render(<CreatorCard {...baseProps} data-custom="value" data-testid="card" />);
+      expect(screen.getByTestId("card")).toHaveAttribute("data-custom", "value");
+    });
+  });
+
+  describe("rounded prop", () => {
+    it.each([
+      ["none", "rounded-none"],
+      ["xs", "rounded-xs"],
+      ["sm", "rounded-sm"],
+      ["md", "rounded-md"],
+      ["lg", "rounded-lg"],
+      ["xl", "rounded-xl"],
+    ] as const)("applies %s rounded class", (rounded, expectedClass) => {
+      render(<CreatorCard {...baseProps} data-testid="card" rounded={rounded} />);
+      expect(screen.getByTestId("card")).toHaveClass(expectedClass);
+    });
+
+    it("defaults to lg rounded", () => {
+      render(<CreatorCard {...baseProps} data-testid="card" />);
+      expect(screen.getByTestId("card")).toHaveClass("rounded-lg");
+    });
+  });
+
+  describe("actions", () => {
+    it("renders no action buttons when actions is omitted", () => {
+      render(<CreatorCard {...baseProps} />);
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("renders a single action button", () => {
+      render(
+        <CreatorCard
+          {...baseProps}
+          actions={
+            <Button variant="brand" fullWidth>
+              Follow for Free
+            </Button>
+          }
+        />,
+      );
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0]).toHaveTextContent("Follow for Free");
+    });
+
+    it("renders two stacked action buttons", () => {
+      render(
+        <CreatorCard
+          {...baseProps}
+          actions={
+            <>
+              <Button variant="brand" fullWidth>
+                Join for free for 3 days
+              </Button>
+              <Button variant="primary" fullWidth>
+                Follow for Free
+              </Button>
+            </>
+          }
+        />,
+      );
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0]).toHaveTextContent("Join for free for 3 days");
+      expect(buttons[1]).toHaveTextContent("Follow for Free");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations with no buttons", async () => {
+      const { container } = render(
+        <CreatorCard {...baseProps} description="MODEL & PODCASTER" avatarFallback="JD" />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations with one button", async () => {
+      const { container } = render(
+        <CreatorCard
+          {...baseProps}
+          description="MODEL & PODCASTER"
+          avatarFallback="JD"
+          actions={
+            <Button variant="brand" fullWidth>
+              Follow for Free
+            </Button>
+          }
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations with two buttons", async () => {
+      const { container } = render(
+        <CreatorCard
+          {...baseProps}
+          description="MODEL & PODCASTER"
+          avatarFallback="JD"
+          actions={
+            <>
+              <Button variant="brand" fullWidth>
+                Join for free for 3 days
+              </Button>
+              <Button variant="primary" fullWidth>
+                Follow for Free
+              </Button>
+            </>
+          }
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/CreatorCard/CreatorCard.test.tsx
+++ b/src/components/CreatorCard/CreatorCard.test.tsx
@@ -53,25 +53,6 @@ describe("CreatorCard", () => {
     });
   });
 
-  describe("rounded prop", () => {
-    it.each([
-      ["none", "rounded-none"],
-      ["xs", "rounded-xs"],
-      ["sm", "rounded-sm"],
-      ["md", "rounded-md"],
-      ["lg", "rounded-lg"],
-      ["xl", "rounded-xl"],
-    ] as const)("applies %s rounded class", (rounded, expectedClass) => {
-      render(<CreatorCard {...baseProps} data-testid="card" rounded={rounded} />);
-      expect(screen.getByTestId("card")).toHaveClass(expectedClass);
-    });
-
-    it("defaults to lg rounded", () => {
-      render(<CreatorCard {...baseProps} data-testid="card" />);
-      expect(screen.getByTestId("card")).toHaveClass("rounded-lg");
-    });
-  });
-
   describe("actions", () => {
     it("renders no action buttons when actions is omitted", () => {
       render(<CreatorCard {...baseProps} />);

--- a/src/components/CreatorCard/CreatorCard.test.tsx
+++ b/src/components/CreatorCard/CreatorCard.test.tsx
@@ -32,7 +32,25 @@ describe("CreatorCard", () => {
     });
 
     it("renders avatar fallback content", async () => {
-      render(<CreatorCard {...baseProps} avatarFallback="JD" />);
+      render(<CreatorCard {...baseProps} avatar={{ fallback: "JD" }} />);
+      expect(await screen.findByText("JD")).toBeInTheDocument();
+    });
+
+    it("forwards avatar props to the inner Avatar", async () => {
+      render(
+        <CreatorCard
+          {...baseProps}
+          avatar={{
+            fallback: "JD",
+            size: 64,
+            className: "custom-avatar",
+            onlineIndicator: true,
+          }}
+        />,
+      );
+      const avatar = screen.getByTestId("avatar");
+      expect(avatar).toHaveClass("custom-avatar");
+      expect(avatar).toHaveClass("size-16");
       expect(await screen.findByText("JD")).toBeInTheDocument();
     });
 
@@ -101,7 +119,7 @@ describe("CreatorCard", () => {
   describe("accessibility", () => {
     it("has no accessibility violations with no buttons", async () => {
       const { container } = render(
-        <CreatorCard {...baseProps} description="MODEL & PODCASTER" avatarFallback="JD" />,
+        <CreatorCard {...baseProps} description="MODEL & PODCASTER" avatar={{ fallback: "JD" }} />,
       );
       expect(await axe(container)).toHaveNoViolations();
     });
@@ -111,7 +129,7 @@ describe("CreatorCard", () => {
         <CreatorCard
           {...baseProps}
           description="MODEL & PODCASTER"
-          avatarFallback="JD"
+          avatar={{ fallback: "JD" }}
           actions={
             <Button variant="brand" fullWidth>
               Follow for Free
@@ -127,7 +145,7 @@ describe("CreatorCard", () => {
         <CreatorCard
           {...baseProps}
           description="MODEL & PODCASTER"
-          avatarFallback="JD"
+          avatar={{ fallback: "JD" }}
           actions={
             <>
               <Button variant="brand" fullWidth>

--- a/src/components/CreatorCard/CreatorCard.tsx
+++ b/src/components/CreatorCard/CreatorCard.tsx
@@ -49,7 +49,7 @@ export const CreatorCard = React.forwardRef<HTMLDivElement, CreatorCardProps>(
       <div
         ref={ref}
         className={cn(
-          "relative isolate flex aspect-290/450 w-full max-w-full flex-col justify-end overflow-hidden bg-bg-primary",
+          "relative isolate flex aspect-290/450 max-w-full flex-col justify-end overflow-hidden bg-bg-primary",
           className,
         )}
         {...props}

--- a/src/components/CreatorCard/CreatorCard.tsx
+++ b/src/components/CreatorCard/CreatorCard.tsx
@@ -11,17 +11,8 @@ export interface CreatorCardProps extends React.HTMLAttributes<HTMLDivElement> {
   name: string;
   /** Optional secondary line shown below the name (e.g. role or tagline). */
   description?: string;
-  /** URL of the avatar image. */
-  avatarSrc?: string;
-  /** Alt text for the avatar image. @default name */
-  avatarAlt?: string;
-  /** Fallback content rendered when the avatar image has not loaded (e.g. initials). */
-  avatarFallback?: React.ReactNode;
-  /** Additional props forwarded to the inner {@link Avatar}. */
-  avatarProps?: Omit<
-    React.ComponentPropsWithoutRef<typeof Avatar>,
-    "src" | "alt" | "fallback" | "size"
-  >;
+  /** Avatar props forwarded to the inner {@link Avatar}. */
+  avatar?: React.ComponentPropsWithoutRef<typeof Avatar>;
   /**
    * Action buttons rendered at the bottom of the card. Pass zero, one, or two
    * `Button` elements to render variants with no, one, or two CTAs.
@@ -42,8 +33,7 @@ export interface CreatorCardProps extends React.HTMLAttributes<HTMLDivElement> {
  *   imageSrc="/creator.jpg"
  *   name="Jane Doe"
  *   description="MODEL & PODCASTER"
- *   avatarSrc="/avatar.jpg"
- *   avatarFallback="JD"
+ *   avatar={{ src: "/avatar.jpg", alt: "Jane Doe", fallback: "JD" }}
  *   actions={
  *     <>
  *       <Button variant="brand" fullWidth>Join for free for 3 days</Button>
@@ -54,22 +44,7 @@ export interface CreatorCardProps extends React.HTMLAttributes<HTMLDivElement> {
  * ```
  */
 export const CreatorCard = React.forwardRef<HTMLDivElement, CreatorCardProps>(
-  (
-    {
-      className,
-      imageSrc,
-      imageAlt = "",
-      name,
-      description,
-      avatarSrc,
-      avatarAlt,
-      avatarFallback,
-      avatarProps,
-      actions,
-      ...props
-    },
-    ref,
-  ) => {
+  ({ className, imageSrc, imageAlt = "", name, description, avatar, actions, ...props }, ref) => {
     return (
       <div
         ref={ref}
@@ -95,10 +70,10 @@ export const CreatorCard = React.forwardRef<HTMLDivElement, CreatorCardProps>(
           <div className="flex items-center gap-4">
             <Avatar
               size={48}
-              src={avatarSrc}
-              alt={avatarAlt ?? name}
-              fallback={avatarFallback}
-              {...avatarProps}
+              src={avatar?.src}
+              alt={avatar?.alt ?? name}
+              fallback={avatar?.fallback}
+              {...avatar}
             />
             <div className="min-w-0 flex-1">
               <p className="typography-bold-heading-sm truncate text-content-primary">{name}</p>

--- a/src/components/CreatorCard/CreatorCard.tsx
+++ b/src/components/CreatorCard/CreatorCard.tsx
@@ -74,7 +74,7 @@ export const CreatorCard = React.forwardRef<HTMLDivElement, CreatorCardProps>(
       <div
         ref={ref}
         className={cn(
-          "relative isolate flex aspect-290/450 w-72 flex-col justify-end overflow-hidden bg-bg-primary",
+          "relative isolate flex aspect-290/450 w-full max-w-full flex-col justify-end overflow-hidden bg-bg-primary",
           className,
         )}
         {...props}

--- a/src/components/CreatorCard/CreatorCard.tsx
+++ b/src/components/CreatorCard/CreatorCard.tsx
@@ -1,18 +1,6 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
-import { Avatar, type AvatarProps } from "../Avatar/Avatar";
-
-/** Border-radius preset for the card. */
-export type CreatorCardRounded = "none" | "xs" | "sm" | "md" | "lg" | "xl";
-
-const ROUNDED_CLASSES: Record<CreatorCardRounded, string> = {
-  none: "rounded-none",
-  xs: "rounded-xs",
-  sm: "rounded-sm",
-  md: "rounded-md",
-  lg: "rounded-lg",
-  xl: "rounded-xl",
-};
+import { Avatar } from "../Avatar/Avatar";
 
 export interface CreatorCardProps extends React.HTMLAttributes<HTMLDivElement> {
   /** URL of the background media (image or video poster). */
@@ -30,14 +18,15 @@ export interface CreatorCardProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Fallback content rendered when the avatar image has not loaded (e.g. initials). */
   avatarFallback?: React.ReactNode;
   /** Additional props forwarded to the inner {@link Avatar}. */
-  avatarProps?: Omit<AvatarProps, "src" | "alt" | "fallback" | "size">;
+  avatarProps?: Omit<
+    React.ComponentPropsWithoutRef<typeof Avatar>,
+    "src" | "alt" | "fallback" | "size"
+  >;
   /**
    * Action buttons rendered at the bottom of the card. Pass zero, one, or two
    * `Button` elements to render variants with no, one, or two CTAs.
    */
   actions?: React.ReactNode;
-  /** Border-radius preset for the card corners. @default "lg" */
-  rounded?: CreatorCardRounded;
 }
 
 /**
@@ -55,7 +44,6 @@ export interface CreatorCardProps extends React.HTMLAttributes<HTMLDivElement> {
  *   description="MODEL & PODCASTER"
  *   avatarSrc="/avatar.jpg"
  *   avatarFallback="JD"
- *   rounded="lg"
  *   actions={
  *     <>
  *       <Button variant="brand" fullWidth>Join for free for 3 days</Button>
@@ -78,19 +66,15 @@ export const CreatorCard = React.forwardRef<HTMLDivElement, CreatorCardProps>(
       avatarFallback,
       avatarProps,
       actions,
-      rounded = "lg",
       ...props
     },
     ref,
   ) => {
-    const roundedClass = ROUNDED_CLASSES[rounded];
-
     return (
       <div
         ref={ref}
         className={cn(
           "relative isolate flex aspect-290/450 w-72 flex-col justify-end overflow-hidden bg-bg-primary",
-          roundedClass,
           className,
         )}
         {...props}
@@ -98,15 +82,14 @@ export const CreatorCard = React.forwardRef<HTMLDivElement, CreatorCardProps>(
         <img
           src={imageSrc}
           alt={imageAlt}
+          loading="lazy"
           className="absolute inset-0 size-full object-cover"
-          aria-hidden={imageAlt === "" ? true : undefined}
         />
         <div
           className={cn(
             "pointer-events-none absolute inset-x-0 bottom-0 bg-linear-to-t from-bg-primary via-bg-primary/90 to-transparent",
             actions ? "h-3/5" : "h-1/3",
           )}
-          aria-hidden="true"
         />
         <div className="relative flex flex-col gap-4 p-4">
           <div className="flex items-center gap-4">

--- a/src/components/CreatorCard/CreatorCard.tsx
+++ b/src/components/CreatorCard/CreatorCard.tsx
@@ -1,0 +1,136 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { Avatar, type AvatarProps } from "../Avatar/Avatar";
+
+/** Border-radius preset for the card. */
+export type CreatorCardRounded = "none" | "xs" | "sm" | "md" | "lg" | "xl";
+
+const ROUNDED_CLASSES: Record<CreatorCardRounded, string> = {
+  none: "rounded-none",
+  xs: "rounded-xs",
+  sm: "rounded-sm",
+  md: "rounded-md",
+  lg: "rounded-lg",
+  xl: "rounded-xl",
+};
+
+export interface CreatorCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** URL of the background media (image or video poster). */
+  imageSrc: string;
+  /** Alt text for the background image. @default "" */
+  imageAlt?: string;
+  /** Creator display name shown as the heading. */
+  name: string;
+  /** Optional secondary line shown below the name (e.g. role or tagline). */
+  description?: string;
+  /** URL of the avatar image. */
+  avatarSrc?: string;
+  /** Alt text for the avatar image. @default name */
+  avatarAlt?: string;
+  /** Fallback content rendered when the avatar image has not loaded (e.g. initials). */
+  avatarFallback?: React.ReactNode;
+  /** Additional props forwarded to the inner {@link Avatar}. */
+  avatarProps?: Omit<AvatarProps, "src" | "alt" | "fallback" | "size">;
+  /**
+   * Action buttons rendered at the bottom of the card. Pass zero, one, or two
+   * `Button` elements to render variants with no, one, or two CTAs.
+   */
+  actions?: React.ReactNode;
+  /** Border-radius preset for the card corners. @default "lg" */
+  rounded?: CreatorCardRounded;
+}
+
+/**
+ * A portrait media card highlighting a creator with avatar, name, optional
+ * tagline, and up to two stacked action buttons over a background image.
+ *
+ * Pass zero, one, or two {@link Button} elements via `actions` to render the
+ * no-button, single-button, or two-button variants.
+ *
+ * @example
+ * ```tsx
+ * <CreatorCard
+ *   imageSrc="/creator.jpg"
+ *   name="Jane Doe"
+ *   description="MODEL & PODCASTER"
+ *   avatarSrc="/avatar.jpg"
+ *   avatarFallback="JD"
+ *   rounded="lg"
+ *   actions={
+ *     <>
+ *       <Button variant="brand" fullWidth>Join for free for 3 days</Button>
+ *       <Button variant="primary" fullWidth>Follow for Free</Button>
+ *     </>
+ *   }
+ * />
+ * ```
+ */
+export const CreatorCard = React.forwardRef<HTMLDivElement, CreatorCardProps>(
+  (
+    {
+      className,
+      imageSrc,
+      imageAlt = "",
+      name,
+      description,
+      avatarSrc,
+      avatarAlt,
+      avatarFallback,
+      avatarProps,
+      actions,
+      rounded = "lg",
+      ...props
+    },
+    ref,
+  ) => {
+    const roundedClass = ROUNDED_CLASSES[rounded];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "relative isolate flex aspect-290/450 w-72 flex-col justify-end overflow-hidden bg-bg-primary",
+          roundedClass,
+          className,
+        )}
+        {...props}
+      >
+        <img
+          src={imageSrc}
+          alt={imageAlt}
+          className="absolute inset-0 size-full object-cover"
+          aria-hidden={imageAlt === "" ? true : undefined}
+        />
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-x-0 bottom-0 bg-linear-to-t from-bg-primary via-bg-primary/90 to-transparent",
+            actions ? "h-3/5" : "h-1/3",
+          )}
+          aria-hidden="true"
+        />
+        <div className="relative flex flex-col gap-4 p-4">
+          <div className="flex items-center gap-4">
+            <Avatar
+              size={48}
+              src={avatarSrc}
+              alt={avatarAlt ?? name}
+              fallback={avatarFallback}
+              {...avatarProps}
+            />
+            <div className="min-w-0 flex-1">
+              <p className="typography-bold-heading-sm truncate text-content-primary">{name}</p>
+              {description && (
+                <p className="typography-semibold-body-sm truncate text-content-secondary dark:text-brand-primary-default">
+                  {description}
+                </p>
+              )}
+            </div>
+          </div>
+          {actions && <div className="flex flex-col gap-2">{actions}</div>}
+        </div>
+      </div>
+    );
+  },
+);
+
+CreatorCard.displayName = "CreatorCard";

--- a/src/components/CreatorCover/CreatorCover.stories.tsx
+++ b/src/components/CreatorCover/CreatorCover.stories.tsx
@@ -39,7 +39,11 @@ const defaultArgs = {
   name: "JANE DOE",
   tagline: "GLOBAL POPSTAR",
   tag: "New Joiner",
-  action: "Join for free for 7 days",
+  action: (
+    <Button variant="primary" size="48" fullWidth>
+      Join for free for 7 days
+    </Button>
+  ),
 };
 
 export const Default: Story = {
@@ -91,26 +95,4 @@ export const CustomActionNode: Story = {
     ),
   },
   decorators: [wrapperDecorator],
-};
-
-export const FadeBottom: Story = {
-  args: {
-    ...defaultArgs,
-    fadeBottom: true,
-  },
-  parameters: {
-    chromatic: {
-      modes: {
-        light: { theme: "light" },
-        dark: { theme: "dark" },
-      },
-    },
-  },
-  decorators: [
-    (Story: () => React.ReactElement) => (
-      <div className="w-200">
-        <Story />
-      </div>
-    ),
-  ],
 };

--- a/src/components/CreatorCover/CreatorCover.test.tsx
+++ b/src/components/CreatorCover/CreatorCover.test.tsx
@@ -66,16 +66,20 @@ describe("CreatorCover", () => {
       expect(screen.getByTestId("custom-tag")).toBeInTheDocument();
     });
 
-    it("renders a string action as a full-width button", () => {
-      render(<CreatorCover {...baseProps} action="Join for free for 7 days" />);
-      const button = screen.getByRole("button", { name: "Join for free for 7 days" });
-      expect(button).toBeInTheDocument();
-      expect(button).toHaveClass("w-full");
-    });
-
     it("renders a node action as-is", () => {
-      render(<CreatorCover {...baseProps} action={<Button variant="brand">Subscribe</Button>} />);
-      expect(screen.getByRole("button", { name: "Subscribe" })).toBeInTheDocument();
+      render(
+        <CreatorCover
+          {...baseProps}
+          action={
+            <Button variant="primary" fullWidth>
+              Subscribe
+            </Button>
+          }
+        />,
+      );
+      const button = screen.getByRole("button", { name: "Subscribe" });
+      expect(button).toHaveClass("w-full");
+      expect(button).toBeInTheDocument();
     });
 
     it("applies custom className", () => {
@@ -96,7 +100,11 @@ describe("CreatorCover", () => {
           {...baseProps}
           tagline="Global Popstar"
           tag="New Joiner"
-          action="Join for free for 7 days"
+          action={
+            <Button variant="primary" fullWidth>
+              Join for free for 7 days
+            </Button>
+          }
         />,
       );
       expect(await axe(container)).toHaveNoViolations();

--- a/src/components/CreatorCover/CreatorCover.tsx
+++ b/src/components/CreatorCover/CreatorCover.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
-import { Button } from "../Button/Button";
 import { Pill } from "../Pill/Pill";
 
 /** Slot that accepts a string (rendered as default styling) or a node for full control. */
@@ -28,9 +27,8 @@ export interface CreatorCoverProps extends Omit<React.HTMLAttributes<HTMLElement
   tag?: CreatorCoverSlot;
   /**
    * Primary call to action displayed below the title.
-   * A string renders a full-width white {@link Button} with that label; pass a node for links, loading, etc.
    */
-  action?: CreatorCoverSlot;
+  action?: React.ReactNode;
   /** When `true`, fades the bottom of the component to transparent and increases bottom padding to 64px. @default false */
   fadeBottom?: boolean;
 }
@@ -47,7 +45,7 @@ export interface CreatorCoverProps extends Omit<React.HTMLAttributes<HTMLElement
  *   name="JANE DOE"
  *   tagline="GLOBAL POPSTAR"
  *   tag="New Joiner"
- *   action="Join for free for 7 days"
+ *   action={<Button variant="primary" size="48" fullWidth>Join for free for 7 days</Button>}
  * />
  * ```
  */
@@ -59,14 +57,6 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
     const headingId = React.useId();
 
     const renderedTag = isNonEmptyString(tag) ? <Pill variant="brand">{tag}</Pill> : tag;
-
-    const renderedAction = isNonEmptyString(action) ? (
-      <Button variant="white" size="48" fullWidth>
-        {action}
-      </Button>
-    ) : (
-      action
-    );
 
     return (
       <section
@@ -113,7 +103,7 @@ export const CreatorCover = React.forwardRef<HTMLElement, CreatorCoverProps>(
               </p>
             ) : null}
           </div>
-          {renderedAction ? <div className="w-full pt-2">{renderedAction}</div> : null}
+          {action ? <div className="w-full pt-2">{action}</div> : null}
         </div>
       </section>
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,11 @@ export type {
 } from "./components/Count/Count";
 export { Count } from "./components/Count/Count";
 export type {
+  CreatorCardProps,
+  CreatorCardRounded,
+} from "./components/CreatorCard/CreatorCard";
+export { CreatorCard } from "./components/CreatorCard/CreatorCard";
+export type {
   DialogBodyProps,
   DialogCloseProps,
   DialogContentProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,10 +107,7 @@ export type {
   CountVariant,
 } from "./components/Count/Count";
 export { Count } from "./components/Count/Count";
-export type {
-  CreatorCardProps,
-  CreatorCardRounded,
-} from "./components/CreatorCard/CreatorCard";
+export type { CreatorCardProps } from "./components/CreatorCard/CreatorCard";
 export { CreatorCard } from "./components/CreatorCard/CreatorCard";
 export type {
   DialogBodyProps,


### PR DESCRIPTION
## Summary

Adds a new `CreatorCard` component — a portrait media card highlighting a creator with an avatar, name, optional tagline, and up to two stacked CTA buttons over a background image. Implemented from the [Figma design](https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-76229).

The card holds a fixed `290:450` portrait aspect ratio and fills its container width, so consumers control sizing by sizing the wrapper.

## Changes

- New component at `src/components/CreatorCard/CreatorCard.tsx` using `forwardRef`, `cn()`, and the existing `Avatar` component.
- `actions` slot accepts zero, one, or two `<Button>` children to render the no-button, single-button, or two-button variants. The bottom gradient height adapts based on whether actions are present.
- `avatar` prop accepts the full set of `Avatar` props (`src`, `alt`, `fallback`, `size`, `onlineIndicator`, `platinumShow`, `className`, etc.) and forwards them to the inner `Avatar`. `alt` falls back to `name` when omitted.
- `description` is optional and rendered below the name in the secondary text style (brand accent in dark mode).
- Unit tests covering API contracts (className, ref forwarding, attribute spreading, image alt handling, avatar prop forwarding), each `actions` variant (none / one / two buttons), and axe accessibility.
- Story file with `TwoButtons`, `OneButton`, `NoButtons`, `AvatarOptions`, `ContainerScaling`, and `WithoutDescription` stories, plus the Figma `design` parameter.
- Exported `CreatorCard` and `CreatorCardProps` from `src/index.ts`.
- Added a `CreatorCardDemo` section to `App.tsx` (button variants + container-width scaling grid) and wired it into the navigation.

## Checklist

- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] New/updated components have stories
- [x] New/updated components have accessibility tests
- [x] New/updated components have forwardRef unit tests
- [x] New/updated components have className chaining unit tests
- [x] Exported in `src/index.ts` (if consumable by vendors)
- [x] Figma link added to story `design` parameter (if applicable)
- [x] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<img width="1000" height="432" alt="Screenshot 2026-05-06 at 10 58 00" src="https://github.com/user-attachments/assets/29c0fc27-d47c-461a-b918-65ef4033547e" />
<img width="1000" height="432" alt="Screenshot 2026-05-06 at 10 58 13" src="https://github.com/user-attachments/assets/9f93e0ec-a585-472d-8b4e-97a9681f4222" />