### PR TITLE
feat: Attached images sit inside input

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -578,6 +578,9 @@ function TextAreaShowcase() {
 function ChatInputShowcase() {
   const [value, setValue] = useState("");
   const [model, setModel] = useState("fanvue-ai");
+  const [chatAttachments, setChatAttachments] = useState<
+    { id: string; src: string; name: string }[]
+  >([]);
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
   };
@@ -639,6 +642,26 @@ function ChatInputShowcase() {
           selectValue={model}
           onSelectChange={setModel}
           name="chat-full"
+          autoComplete="off"
+        />
+        <ChatInput
+          placeholder="Attachments inside input"
+          showFileButton
+          onFileClick={() =>
+            setChatAttachments((prev) => [
+              ...prev,
+              {
+                id: crypto.randomUUID(),
+                src: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=128&h=128&fit=crop",
+                name: "Attachment",
+              },
+            ])
+          }
+          attachments={chatAttachments}
+          onAttachmentRemove={(id) =>
+            setChatAttachments((prev) => prev.filter((item) => item.id !== id))
+          }
+          name="chat-attachments"
           autoComplete="off"
         />
         <ChatInput

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -579,7 +579,7 @@ function ChatInputShowcase() {
   const [value, setValue] = useState("");
   const [model, setModel] = useState("fanvue-ai");
   const [chatAttachments, setChatAttachments] = useState<
-    { id: string; src: string; name: string }[]
+    { id: string; src: string; ariaLabel: string }[]
   >([]);
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
@@ -653,7 +653,7 @@ function ChatInputShowcase() {
               {
                 id: crypto.randomUUID(),
                 src: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=128&h=128&fit=crop",
-                name: "Attachment",
+                ariaLabel: "Attachment",
               },
             ])
           }

--- a/src/components/ChatInput/ChatInput.stories.tsx
+++ b/src/components/ChatInput/ChatInput.stories.tsx
@@ -105,16 +105,18 @@ export const WithFileButtonAndModelSelector: Story = {
 
 export const WithAttachments: Story = {
   render: () => {
-    const [attachments, setAttachments] = useState<{ id: string; src: string; name: string }[]>([
+    const [attachments, setAttachments] = useState<
+      { id: string; src: string; ariaLabel: string }[]
+    >([
       {
         id: "a",
         src: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=128&h=128&fit=crop",
-        name: "Attachment preview one",
+        ariaLabel: "Attachment preview one",
       },
       {
         id: "b",
         src: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=128&h=128&fit=crop",
-        name: "Attachment preview two",
+        ariaLabel: "Attachment preview two",
       },
     ]);
 
@@ -128,7 +130,7 @@ export const WithAttachments: Story = {
             {
               id: crypto.randomUUID(),
               src: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=128&h=128&fit=crop",
-              name: "New attachment",
+              ariaLabel: "New attachment",
             },
           ])
         }
@@ -142,11 +144,13 @@ export const WithAttachments: Story = {
 export const WithAttachmentsAndModelSelector: Story = {
   render: () => {
     const [model, setModel] = useState("fanvue-ai");
-    const [attachments, setAttachments] = useState<{ id: string; src: string; name: string }[]>([
+    const [attachments, setAttachments] = useState<
+      { id: string; src: string; ariaLabel: string }[]
+    >([
       {
         id: "a",
         src: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=128&h=128&fit=crop",
-        name: "Attachment preview one",
+        ariaLabel: "Attachment preview one",
       },
     ]);
 
@@ -160,7 +164,7 @@ export const WithAttachmentsAndModelSelector: Story = {
             {
               id: crypto.randomUUID(),
               src: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=128&h=128&fit=crop",
-              name: "New attachment",
+              ariaLabel: "New attachment",
             },
           ])
         }

--- a/src/components/ChatInput/ChatInput.stories.tsx
+++ b/src/components/ChatInput/ChatInput.stories.tsx
@@ -103,6 +103,88 @@ export const WithFileButtonAndModelSelector: Story = {
   },
 };
 
+export const WithAttachments: Story = {
+  render: () => {
+    const [attachments, setAttachments] = useState<{ id: string; src: string; name: string }[]>([
+      {
+        id: "a",
+        src: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=128&h=128&fit=crop",
+        name: "Attachment preview one",
+      },
+      {
+        id: "b",
+        src: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=128&h=128&fit=crop",
+        name: "Attachment preview two",
+      },
+    ]);
+
+    return (
+      <ChatInput
+        placeholder="Type a message..."
+        showFileButton
+        onFileClick={() =>
+          setAttachments((prev) => [
+            ...prev,
+            {
+              id: crypto.randomUUID(),
+              src: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=128&h=128&fit=crop",
+              name: "New attachment",
+            },
+          ])
+        }
+        attachments={attachments}
+        onAttachmentRemove={(id) => setAttachments((prev) => prev.filter((x) => x.id !== id))}
+      />
+    );
+  },
+};
+
+export const WithAttachmentsAndModelSelector: Story = {
+  render: () => {
+    const [model, setModel] = useState("fanvue-ai");
+    const [attachments, setAttachments] = useState<{ id: string; src: string; name: string }[]>([
+      {
+        id: "a",
+        src: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?w=128&h=128&fit=crop",
+        name: "Attachment preview one",
+      },
+    ]);
+
+    return (
+      <ChatInput
+        placeholder="Type a message..."
+        showFileButton
+        onFileClick={() =>
+          setAttachments((prev) => [
+            ...prev,
+            {
+              id: crypto.randomUUID(),
+              src: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=128&h=128&fit=crop",
+              name: "New attachment",
+            },
+          ])
+        }
+        attachments={attachments}
+        onAttachmentRemove={(id) => setAttachments((prev) => prev.filter((x) => x.id !== id))}
+        selectOptions={SELECT_OPTIONS}
+        selectValue={model}
+        onSelectChange={setModel}
+      />
+    );
+  },
+};
+
+export const WithCustomAttachmentPreviews: Story = {
+  args: {
+    placeholder: "Type a message...",
+    attachmentPreviews: (
+      <div className="typography-regular-body-md shrink-0 rounded-sm border border-dashed border-border-primary px-3 py-2 text-content-secondary">
+        Custom preview slot
+      </div>
+    ),
+  },
+};
+
 export const WithCustomToolbarRight: Story = {
   args: {
     placeholder: "Type a message...",

--- a/src/components/ChatInput/ChatInput.test.tsx
+++ b/src/components/ChatInput/ChatInput.test.tsx
@@ -227,16 +227,11 @@ describe("ChatInput", () => {
       expect(handleRemove).toHaveBeenCalledTimes(1);
     });
 
-    it("does not reserve preview layout when attachmentPreviews is an empty array", () => {
-      render(<ChatInput placeholder="Test" attachmentPreviews={[]} />);
-      expect(screen.getByRole("textbox")).toHaveClass("pt-4");
-    });
-
     it("renders built-in thumbnails when attachments are provided", () => {
       const { container } = render(
         <ChatInput
           placeholder="Test"
-          attachments={[{ id: "x", src: "https://example.com/a.png", name: "One" }]}
+          attachments={[{ id: "x", src: "https://example.com/a.png", ariaLabel: "One" }]}
           onAttachmentRemove={() => {}}
         />,
       );
@@ -251,7 +246,7 @@ describe("ChatInput", () => {
       render(
         <ChatInput
           placeholder="Test"
-          attachments={[{ id: "x", src: "https://example.com/a.png", name: "One" }]}
+          attachments={[{ id: "x", src: "https://example.com/a.png", ariaLabel: "One" }]}
           onAttachmentRemove={handleRemove}
         />,
       );
@@ -452,7 +447,7 @@ describe("ChatInput", () => {
             {
               id: "a",
               src: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-              name: "Sample",
+              ariaLabel: "Sample",
             },
           ]}
           onAttachmentRemove={() => {}}

--- a/src/components/ChatInput/ChatInput.test.tsx
+++ b/src/components/ChatInput/ChatInput.test.tsx
@@ -199,6 +199,90 @@ describe("ChatInput", () => {
     });
   });
 
+  describe("attachment previews", () => {
+    it("renders attachment preview slot inside the container", () => {
+      render(
+        <ChatInput
+          placeholder="Test"
+          attachmentPreviews={<div data-testid="attachment-slot">Preview</div>}
+        />,
+      );
+      expect(screen.getByTestId("attachment-slot")).toHaveTextContent("Preview");
+    });
+
+    it("fires remove handler from content inside attachment previews", async () => {
+      const user = userEvent.setup();
+      const handleRemove = vi.fn();
+      render(
+        <ChatInput
+          placeholder="Test"
+          attachmentPreviews={
+            <button type="button" aria-label="Remove attachment" onClick={handleRemove}>
+              Remove
+            </button>
+          }
+        />,
+      );
+      await user.click(screen.getByLabelText("Remove attachment"));
+      expect(handleRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not reserve preview layout when attachmentPreviews is an empty array", () => {
+      render(<ChatInput placeholder="Test" attachmentPreviews={[]} />);
+      expect(screen.getByRole("textbox")).toHaveClass("pt-4");
+    });
+
+    it("renders built-in thumbnails when attachments are provided", () => {
+      const { container } = render(
+        <ChatInput
+          placeholder="Test"
+          attachments={[{ id: "x", src: "https://example.com/a.png", name: "One" }]}
+          onAttachmentRemove={() => {}}
+        />,
+      );
+      const img = container.querySelector("img");
+      expect(img).toBeTruthy();
+      expect(img).toHaveAttribute("src", "https://example.com/a.png");
+    });
+
+    it("calls onAttachmentRemove when a built-in remove control is used", async () => {
+      const user = userEvent.setup();
+      const handleRemove = vi.fn();
+      render(
+        <ChatInput
+          placeholder="Test"
+          attachments={[{ id: "x", src: "https://example.com/a.png", name: "One" }]}
+          onAttachmentRemove={handleRemove}
+        />,
+      );
+      await user.click(screen.getByLabelText("Remove One"));
+      expect(handleRemove).toHaveBeenCalledWith("x");
+    });
+
+    it("disables built-in remove controls when onAttachmentRemove is omitted", () => {
+      render(
+        <ChatInput
+          placeholder="Test"
+          attachments={[{ id: "x", src: "https://example.com/a.png" }]}
+        />,
+      );
+      expect(screen.getByLabelText("Remove attachment")).toBeDisabled();
+    });
+
+    it("prefers attachmentPreviews over attachments when attachmentPreviews is defined", () => {
+      render(
+        <ChatInput
+          placeholder="Test"
+          attachments={[{ id: "x", src: "https://example.com/a.png" }]}
+          onAttachmentRemove={() => {}}
+          attachmentPreviews={<div data-testid="custom-strip">Custom</div>}
+        />,
+      );
+      expect(screen.getByTestId("custom-strip")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Remove attachment")).not.toBeInTheDocument();
+    });
+  });
+
   describe("inline select", () => {
     it("renders the selected option label", () => {
       render(
@@ -337,6 +421,41 @@ describe("ChatInput", () => {
           placeholder="Type a message..."
           selectOptions={MODEL_OPTIONS}
           selectValue="fanvue-ai"
+        />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations (with attachment previews)", async () => {
+      const { container } = render(
+        <ChatInput
+          placeholder="Type a message..."
+          attachmentPreviews={
+            <div
+              role="img"
+              aria-label="Sample attachment"
+              className="size-16 shrink-0 rounded-lg bg-neutral-alphas-100"
+            />
+          }
+        />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations (with default attachments)", async () => {
+      const { container } = render(
+        <ChatInput
+          placeholder="Type a message..."
+          attachments={[
+            {
+              id: "a",
+              src: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+              name: "Sample",
+            },
+          ]}
+          onAttachmentRemove={() => {}}
         />,
       );
       const results = await axe(container);

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -12,8 +12,8 @@ export interface ChatInputAttachmentItem {
   id: string;
   /** Image URL for the thumbnail. */
   src: string;
-  /** Optional label for the remove control `aria-label`. */
-  name?: string;
+  /** Optional value passed to the remove control `aria-label`. */
+  ariaLabel?: string;
 }
 
 /** A single option for the inline model/dropdown selector. */
@@ -100,12 +100,6 @@ function calculateHeight(rows: number): number {
   return LINE_HEIGHT * rows + TEXTAREA_PY * 2;
 }
 
-function attachmentPreviewNodeHasContent(node: React.ReactNode): boolean {
-  if (node == null || node === false) return false;
-  if (Array.isArray(node)) return node.length > 0 && node.some(Boolean);
-  return true;
-}
-
 interface ChatInputDefaultAttachmentThumbnailsProps {
   attachments: ChatInputAttachmentItem[];
   onAttachmentRemove?: (id: string) => void;
@@ -123,15 +117,15 @@ function ChatInputDefaultAttachmentThumbnails({
       className="relative size-16 shrink-0 overflow-hidden rounded-sm border border-neutral-200 bg-bg-secondary"
     >
       <img src={item.src} alt="" className="size-full object-cover" />
-      <button
-        type="button"
-        aria-label={item.name ? `Remove ${item.name}` : "Remove attachment"}
-        className="absolute top-0.5 right-0.5 flex size-5 items-center justify-center rounded-full bg-neutral-900/60 text-white hover:bg-neutral-900/80"
+      <IconButton
+        variant="tertiary"
+        size="24"
+        aria-label={item.ariaLabel ? `Remove ${item.ariaLabel}` : "Remove attachment"}
+        icon={<CloseIcon className="!size-3" />}
         disabled={disabled || !onAttachmentRemove}
         onClick={() => onAttachmentRemove?.(item.id)}
-      >
-        <CloseIcon className="size-3" />
-      </button>
+        className="absolute top-0.5 right-0.5 size-5 bg-neutral-900/40 p-1 text-white hover:bg-neutral-900/55"
+      />
     </div>
   ));
 }
@@ -283,12 +277,9 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
     const maxHeight = calculateHeight(maxRows);
 
     const useCustomAttachmentPreviews = attachmentPreviews !== undefined;
-    const customAttachmentStrip =
-      useCustomAttachmentPreviews && attachmentPreviewNodeHasContent(attachmentPreviews)
-        ? attachmentPreviews
-        : null;
+    const customAttachmentStrip = useCustomAttachmentPreviews ? attachmentPreviews : null;
     const defaultAttachmentStrip =
-      !useCustomAttachmentPreviews && (attachments?.length ?? 0) > 0 ? (
+      !useCustomAttachmentPreviews && !!attachments?.length ? (
         <ChatInputDefaultAttachmentThumbnails
           attachments={attachments ?? []}
           disabled={disabled}
@@ -316,7 +307,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       <div
         className={cn(
           "relative flex flex-col gap-6 rounded-lg border border-border-primary bg-surface-primary",
-          "has-focus-visible:border-neutral-alphas-400 has-focus-visible:outline-none",
+          "has-focus-visible:shadow-focus-ring has-focus-visible:outline-none",
           "motion-safe:transition-colors",
           disabled && "opacity-50",
           className,

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -4,6 +4,17 @@ import { IconButton } from "../IconButton/IconButton";
 import { AddIcon } from "../Icons/AddIcon";
 import { ArrowUpIcon } from "../Icons/ArrowUpIcon";
 import { ChevronDownIcon } from "../Icons/ChevronDownIcon";
+import { CloseIcon } from "../Icons/CloseIcon";
+
+/** A single image thumbnail in the built-in attachment strip. */
+export interface ChatInputAttachmentItem {
+  /** Stable id passed to {@link ChatInputProps.onAttachmentRemove} and used as React `key`. */
+  id: string;
+  /** Image URL for the thumbnail. */
+  src: string;
+  /** Optional label for the remove control `aria-label`. */
+  name?: string;
+}
 
 /** A single option for the inline model/dropdown selector. */
 export interface ChatInputSelectOption {
@@ -63,6 +74,21 @@ export interface ChatInputProps
   selectValue?: string;
   /** Callback fired when the user picks a different dropdown option. */
   onSelectChange?: (value: string) => void;
+  /**
+   * Image attachments shown in the built-in thumbnail strip. Ignored when {@link ChatInputProps.attachmentPreviews}
+   * is provided (including `null`).
+   */
+  attachments?: ChatInputAttachmentItem[];
+  /**
+   * Called when the user removes a built-in thumbnail. The remove button is disabled when this is
+   * omitted or the input is {@link ChatInputProps.disabled}.
+   */
+  onAttachmentRemove?: (id: string) => void;
+  /**
+   * Replaces the built-in attachment strip entirely. When set to any value other than `undefined`
+   * (including `null` or `[]`), {@link ChatInputProps.attachments} is ignored.
+   */
+  attachmentPreviews?: React.ReactNode;
   /** Additional className applied to the outermost container. */
   className?: string;
 }
@@ -72,6 +98,42 @@ const TEXTAREA_PY = 12;
 
 function calculateHeight(rows: number): number {
   return LINE_HEIGHT * rows + TEXTAREA_PY * 2;
+}
+
+function attachmentPreviewNodeHasContent(node: React.ReactNode): boolean {
+  if (node == null || node === false) return false;
+  if (Array.isArray(node)) return node.length > 0 && node.some(Boolean);
+  return true;
+}
+
+interface ChatInputDefaultAttachmentThumbnailsProps {
+  attachments: ChatInputAttachmentItem[];
+  onAttachmentRemove?: (id: string) => void;
+  disabled?: boolean;
+}
+
+function ChatInputDefaultAttachmentThumbnails({
+  attachments,
+  onAttachmentRemove,
+  disabled = false,
+}: ChatInputDefaultAttachmentThumbnailsProps) {
+  return attachments.map((item) => (
+    <div
+      key={item.id}
+      className="relative size-16 shrink-0 overflow-hidden rounded-sm border border-neutral-200 bg-bg-secondary"
+    >
+      <img src={item.src} alt="" className="size-full object-cover" />
+      <button
+        type="button"
+        aria-label={item.name ? `Remove ${item.name}` : "Remove attachment"}
+        className="absolute top-0.5 right-0.5 flex size-5 items-center justify-center rounded-full bg-neutral-900/60 text-white hover:bg-neutral-900/80"
+        disabled={disabled || !onAttachmentRemove}
+        onClick={() => onAttachmentRemove?.(item.id)}
+      >
+        <CloseIcon className="size-3" />
+      </button>
+    </div>
+  ));
 }
 
 /**
@@ -105,6 +167,25 @@ function calculateHeight(rows: number): number {
  *   onSubmit={(text) => send(text)}
  * />
  * ```
+ *
+ * @example
+ * ```tsx
+ * <ChatInput
+ *   showFileButton
+ *   onFileClick={() => openPicker()}
+ *   attachments={files}
+ *   onAttachmentRemove={(id) => setFiles((prev) => prev.filter((f) => f.id !== id))}
+ * />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <ChatInput
+ *   showFileButton
+ *   onFileClick={() => openPicker()}
+ *   attachmentPreviews={<CustomVideoStrip items={items} />}
+ * />
+ * ```
  */
 export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
   (
@@ -131,6 +212,9 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       selectOptions,
       selectValue,
       onSelectChange,
+      attachments,
+      onAttachmentRemove,
+      attachmentPreviews,
       style,
       ...textareaProps
     },
@@ -198,6 +282,22 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
     const minHeight = calculateHeight(minRows);
     const maxHeight = calculateHeight(maxRows);
 
+    const useCustomAttachmentPreviews = attachmentPreviews !== undefined;
+    const customAttachmentStrip =
+      useCustomAttachmentPreviews && attachmentPreviewNodeHasContent(attachmentPreviews)
+        ? attachmentPreviews
+        : null;
+    const defaultAttachmentStrip =
+      !useCustomAttachmentPreviews && (attachments?.length ?? 0) > 0 ? (
+        <ChatInputDefaultAttachmentThumbnails
+          attachments={attachments ?? []}
+          disabled={disabled}
+          onAttachmentRemove={onAttachmentRemove}
+        />
+      ) : null;
+    const resolvedAttachmentStrip = customAttachmentStrip ?? defaultAttachmentStrip;
+    const hasAttachmentStrip = resolvedAttachmentStrip != null;
+
     const selectedOption =
       selectOptions?.find((o) => o.value === selectValue) ?? selectOptions?.[0];
     const resolvedToolbarRight =
@@ -222,30 +322,38 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
           className,
         )}
       >
-        <textarea
-          {...textareaProps}
-          ref={mergedRef}
-          value={isControlled ? value : internalValue}
-          placeholder={placeholder}
-          maxLength={maxLength}
-          disabled={disabled}
-          aria-label={ariaLabel ?? placeholder}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          rows={minRows}
-          className={cn(
-            "w-full resize-none bg-transparent px-4 pt-4",
-            "typography-regular-body-md text-content-primary",
-            "placeholder:text-content-tertiary",
-            "focus:outline-none disabled:cursor-not-allowed",
-            "overflow-y-auto",
-          )}
-          style={{
-            minHeight: `${minHeight}px`,
-            maxHeight: `${maxHeight}px`,
-            ...style,
-          }}
-        />
+        <div className="flex flex-col">
+          {hasAttachmentStrip ? (
+            <div className="flex gap-2 overflow-x-auto px-4 pt-4 pb-2 [scrollbar-width:thin]">
+              {resolvedAttachmentStrip}
+            </div>
+          ) : null}
+          <textarea
+            {...textareaProps}
+            ref={mergedRef}
+            value={isControlled ? value : internalValue}
+            placeholder={placeholder}
+            maxLength={maxLength}
+            disabled={disabled}
+            aria-label={ariaLabel ?? placeholder}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            rows={minRows}
+            className={cn(
+              "w-full resize-none bg-transparent px-4",
+              hasAttachmentStrip ? "pt-0" : "pt-4",
+              "typography-regular-body-md text-content-primary",
+              "placeholder:text-content-tertiary",
+              "focus:outline-none disabled:cursor-not-allowed",
+              "overflow-y-auto",
+            )}
+            style={{
+              minHeight: `${minHeight}px`,
+              maxHeight: `${maxHeight}px`,
+              ...style,
+            }}
+          />
+        </div>
 
         <div className="flex items-center justify-between gap-2 px-4 pb-4">
           <div className="flex items-center gap-1">

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,11 @@ export {
   CardHeader,
   CardTitle,
 } from "./components/Card/Card";
-export type { ChatInputProps, ChatInputSelectOption } from "./components/ChatInput/ChatInput";
+export type {
+  ChatInputAttachmentItem,
+  ChatInputProps,
+  ChatInputSelectOption,
+} from "./components/ChatInput/ChatInput";
 export { ChatInput } from "./components/ChatInput/ChatInput";
 export type {
   CheckboxProps,


### PR DESCRIPTION
## Summary

https://www.figma.com/design/59ZXgZ6KIDx23YV0MB2Bvf/Content-Agent?node-id=2549-47081&t=N3Vp8TTmgLhc5Ong-1

 - Embeds attached images inside the chatinput area
 - Component used to render preview can be overridden or default to a simple row.

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<img width="399" height="261" alt="image" src="https://github.com/user-attachments/assets/8a1a50e8-2b8f-4d1a-b506-918706715c82" />