### PR TITLE
feat(creator-tile): adding CreatorTile component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4377,24 +4377,6 @@ function CreatorTileDemo() {
         />
       </div>
 
-      <h3 className="typography-semibold-body-lg mt-4">Radius scale</h3>
-      <div className="flex flex-wrap items-start gap-4">
-        {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((radius) => (
-          <div key={radius} className="flex w-[180px] flex-col gap-2">
-            <CreatorTile
-              imageSrc={sampleImage}
-              imageAlt="Portrait of a creator"
-              name="JANE DOE"
-              tagline={`RADIUS ${radius.toUpperCase()}`}
-              radius={radius}
-            />
-            <p className="typography-regular-body-sm text-content-secondary">
-              radius=&quot;{radius}&quot;
-            </p>
-          </div>
-        ))}
-      </div>
-
       <h3 className="typography-semibold-body-lg mt-4">Aspect ratio</h3>
       <div className="flex flex-wrap items-start gap-4">
         {(["tall", "medium", "short"] as const).map((aspectRatio) => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ import {
   CompassIcon,
   CopyIcon,
   Count,
+  CreatorTile,
   CrossIcon,
   CrownIcon,
   Dialog,
@@ -4276,6 +4277,63 @@ function CardDemo() {
   );
 }
 
+function CreatorTileDemo() {
+  const sampleImage =
+    "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=480&h=720&fit=crop";
+
+  return (
+    <div id="creator-tile" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-bold-heading-xs mb-4">Creator Tile</h2>
+
+      <h3 className="typography-semibold-body-lg">Default</h3>
+      <div className="w-[239px]">
+        <CreatorTile
+          imageSrc={sampleImage}
+          imageAlt="Portrait of a creator"
+          name="JANE DOE"
+          tagline="GLOBAL MUSIC ICON"
+        />
+      </div>
+
+      <h3 className="typography-semibold-body-lg mt-4">Radius scale</h3>
+      <div className="flex flex-wrap items-start gap-4">
+        {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((radius) => (
+          <div key={radius} className="flex w-[180px] flex-col gap-2">
+            <CreatorTile
+              imageSrc={sampleImage}
+              imageAlt="Portrait of a creator"
+              name="JANE DOE"
+              tagline={`RADIUS ${radius.toUpperCase()}`}
+              radius={radius}
+            />
+            <p className="typography-regular-body-sm text-content-secondary">
+              radius=&quot;{radius}&quot;
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <h3 className="typography-semibold-body-lg mt-4">Aspect ratio</h3>
+      <div className="flex flex-wrap items-start gap-4">
+        {(["tall", "medium", "short"] as const).map((aspectRatio) => (
+          <div key={aspectRatio} className="flex w-[200px] flex-col gap-2">
+            <CreatorTile
+              imageSrc={sampleImage}
+              imageAlt="Portrait of a creator"
+              name="JANE DOE"
+              tagline={aspectRatio.toUpperCase()}
+              aspectRatio={aspectRatio}
+            />
+            <p className="typography-regular-body-sm text-content-secondary">
+              aspectRatio=&quot;{aspectRatio}&quot;
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function App() {
   const [dark, setDark] = useState(false);
   const [tocOpen, setTocOpen] = useState(false);
@@ -4300,6 +4358,7 @@ function App() {
     { id: "checkbox", label: "Checkbox" },
     { id: "chip", label: "Chip" },
     { id: "count", label: "Count" },
+    { id: "creator-tile", label: "Creator Tile" },
     { id: "datepicker", label: "Date Picker" },
     { id: "dialog", label: "Dialog" },
     { id: "divider", label: "Divider" },
@@ -4560,6 +4619,9 @@ function App() {
 
             {/* Card */}
             <CardDemo />
+
+            {/* Creator Tile */}
+            <CreatorTileDemo />
 
             {/* Toast */}
             <ToastDemo />

--- a/src/components/CreatorTile/CreatorTile.stories.tsx
+++ b/src/components/CreatorTile/CreatorTile.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CreatorTile } from "./CreatorTile";
+
+const SAMPLE_IMAGE =
+  "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=480&h=720&fit=crop";
+
+const meta = {
+  title: "Components/CreatorTile",
+  component: CreatorTile,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-76293&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    radius: {
+      control: "select",
+      options: ["none", "xs", "sm", "md", "lg", "xl"],
+    },
+    aspectRatio: {
+      control: "select",
+      options: ["tall", "medium", "short"],
+    },
+  },
+} satisfies Meta<typeof CreatorTile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    imageSrc: SAMPLE_IMAGE,
+    imageAlt: "Portrait of a creator",
+    name: "JANE DOE",
+    tagline: "GLOBAL MUSIC ICON",
+  },
+  render: (args) => (
+    <div className="w-[239px]">
+      <CreatorTile {...args} />
+    </div>
+  ),
+};
+
+export const WithoutTagline: Story = {
+  args: {
+    imageSrc: SAMPLE_IMAGE,
+    imageAlt: "Portrait of a creator",
+    name: "JANE DOE",
+  },
+  render: (args) => (
+    <div className="w-[239px]">
+      <CreatorTile {...args} />
+    </div>
+  ),
+};
+
+export const RadiusScale: Story = {
+  args: {
+    imageSrc: SAMPLE_IMAGE,
+    imageAlt: "Portrait of a creator",
+    name: "JANE DOE",
+  },
+  render: () => (
+    <div className="flex flex-wrap items-start gap-4">
+      {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((radius) => (
+        <div key={radius} className="flex w-[180px] flex-col gap-2">
+          <CreatorTile
+            imageSrc={SAMPLE_IMAGE}
+            imageAlt="Portrait of a creator"
+            name="JANE DOE"
+            tagline={`RADIUS ${radius.toUpperCase()}`}
+            radius={radius}
+          />
+          <p className="typography-regular-body-sm text-content-secondary">
+            radius=&quot;{radius}&quot;
+          </p>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const AspectRatios: Story = {
+  args: {
+    imageSrc: SAMPLE_IMAGE,
+    imageAlt: "Portrait of a creator",
+    name: "JANE DOE",
+  },
+  render: () => (
+    <div className="flex flex-wrap items-start gap-4">
+      {(["tall", "medium", "short"] as const).map((aspectRatio) => (
+        <div key={aspectRatio} className="flex w-[200px] flex-col gap-2">
+          <CreatorTile
+            imageSrc={SAMPLE_IMAGE}
+            imageAlt="Portrait of a creator"
+            name="JANE DOE"
+            tagline={aspectRatio.toUpperCase()}
+            aspectRatio={aspectRatio}
+          />
+          <p className="typography-regular-body-sm text-content-secondary">
+            aspectRatio=&quot;{aspectRatio}&quot;
+          </p>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const NoRoundedEdges: Story = {
+  args: {
+    imageSrc: SAMPLE_IMAGE,
+    imageAlt: "Portrait of a creator",
+    name: "JANE DOE",
+    tagline: "SHARP CORNERS",
+    radius: "none",
+  },
+  render: (args) => (
+    <div className="w-[239px]">
+      <CreatorTile {...args} />
+    </div>
+  ),
+};

--- a/src/components/CreatorTile/CreatorTile.stories.tsx
+++ b/src/components/CreatorTile/CreatorTile.stories.tsx
@@ -16,10 +16,6 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
-    radius: {
-      control: "select",
-      options: ["none", "xs", "sm", "md", "lg", "xl"],
-    },
     aspectRatio: {
       control: "select",
       options: ["tall", "medium", "short"],
@@ -57,32 +53,6 @@ export const WithoutTagline: Story = {
   ),
 };
 
-export const RadiusScale: Story = {
-  args: {
-    imageSrc: SAMPLE_IMAGE,
-    imageAlt: "Portrait of a creator",
-    name: "JANE DOE",
-  },
-  render: () => (
-    <div className="flex flex-wrap items-start gap-4">
-      {(["none", "xs", "sm", "md", "lg", "xl"] as const).map((radius) => (
-        <div key={radius} className="flex w-[180px] flex-col gap-2">
-          <CreatorTile
-            imageSrc={SAMPLE_IMAGE}
-            imageAlt="Portrait of a creator"
-            name="JANE DOE"
-            tagline={`RADIUS ${radius.toUpperCase()}`}
-            radius={radius}
-          />
-          <p className="typography-regular-body-sm text-content-secondary">
-            radius=&quot;{radius}&quot;
-          </p>
-        </div>
-      ))}
-    </div>
-  ),
-};
-
 export const AspectRatios: Story = {
   args: {
     imageSrc: SAMPLE_IMAGE,
@@ -105,21 +75,6 @@ export const AspectRatios: Story = {
           </p>
         </div>
       ))}
-    </div>
-  ),
-};
-
-export const NoRoundedEdges: Story = {
-  args: {
-    imageSrc: SAMPLE_IMAGE,
-    imageAlt: "Portrait of a creator",
-    name: "JANE DOE",
-    tagline: "SHARP CORNERS",
-    radius: "none",
-  },
-  render: (args) => (
-    <div className="w-[239px]">
-      <CreatorTile {...args} />
     </div>
   ),
 };

--- a/src/components/CreatorTile/CreatorTile.test.tsx
+++ b/src/components/CreatorTile/CreatorTile.test.tsx
@@ -66,27 +66,6 @@ describe("CreatorTile", () => {
     });
   });
 
-  describe("radius", () => {
-    it("uses lg rounding by default", () => {
-      render(<CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
-      expect(screen.getByTestId("tile")).toHaveClass("rounded-lg");
-    });
-
-    it.each(["xs", "sm", "md", "lg", "xl"] as const)("supports %s rounding", (radius) => {
-      render(
-        <CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" radius={radius} />,
-      );
-      expect(screen.getByTestId("tile")).toHaveClass(`rounded-${radius}`);
-    });
-
-    it("supports no rounded edges via `none`", () => {
-      render(
-        <CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" radius="none" />,
-      );
-      expect(screen.getByTestId("tile")).toHaveClass("rounded-none");
-    });
-  });
-
   describe("aspectRatio", () => {
     it("uses medium (2/3) ratio by default", () => {
       render(<CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);

--- a/src/components/CreatorTile/CreatorTile.test.tsx
+++ b/src/components/CreatorTile/CreatorTile.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { CreatorTile } from "./CreatorTile";
+
+const SAMPLE_IMAGE =
+  "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=480&h=720&fit=crop";
+
+describe("CreatorTile", () => {
+  describe("API", () => {
+    it("renders the name and tagline", () => {
+      render(
+        <CreatorTile
+          imageSrc={SAMPLE_IMAGE}
+          imageAlt="Portrait"
+          name="JANE DOE"
+          tagline="GLOBAL MUSIC ICON"
+        />,
+      );
+      expect(screen.getByText("JANE DOE")).toBeInTheDocument();
+      expect(screen.getByText("GLOBAL MUSIC ICON")).toBeInTheDocument();
+    });
+
+    it("renders the image with the provided alt text", () => {
+      render(
+        <CreatorTile imageSrc={SAMPLE_IMAGE} imageAlt="Portrait of Jane Doe" name="JANE DOE" />,
+      );
+      const image = screen.getByAltText("Portrait of Jane Doe");
+      expect(image).toHaveAttribute("src", SAMPLE_IMAGE);
+    });
+
+    it("omits the tagline when not provided", () => {
+      render(<CreatorTile imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
+      expect(screen.queryByText("GLOBAL MUSIC ICON")).not.toBeInTheDocument();
+    });
+
+    it("applies custom className", () => {
+      render(
+        <CreatorTile
+          data-testid="tile"
+          className="custom"
+          imageSrc={SAMPLE_IMAGE}
+          name="JANE DOE"
+        />,
+      );
+      expect(screen.getByTestId("tile")).toHaveClass("custom");
+    });
+
+    it("forwards ref correctly", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<CreatorTile ref={ref} imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("spreads additional HTML attributes", () => {
+      render(
+        <CreatorTile
+          data-testid="tile"
+          data-custom="value"
+          imageSrc={SAMPLE_IMAGE}
+          name="JANE DOE"
+        />,
+      );
+      expect(screen.getByTestId("tile")).toHaveAttribute("data-custom", "value");
+    });
+  });
+
+  describe("radius", () => {
+    it("uses lg rounding by default", () => {
+      render(<CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
+      expect(screen.getByTestId("tile")).toHaveClass("rounded-lg");
+    });
+
+    it.each(["xs", "sm", "md", "lg", "xl"] as const)("supports %s rounding", (radius) => {
+      render(
+        <CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" radius={radius} />,
+      );
+      expect(screen.getByTestId("tile")).toHaveClass(`rounded-${radius}`);
+    });
+
+    it("supports no rounded edges via `none`", () => {
+      render(
+        <CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" radius="none" />,
+      );
+      expect(screen.getByTestId("tile")).toHaveClass("rounded-none");
+    });
+  });
+
+  describe("aspectRatio", () => {
+    it("uses medium (2/3) ratio by default", () => {
+      render(<CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
+      expect(screen.getByTestId("tile")).toHaveClass("aspect-2/3");
+    });
+
+    it.each([
+      ["tall", "aspect-1/2"],
+      ["medium", "aspect-2/3"],
+      ["short", "aspect-4/5"],
+    ] as const)("applies %s ratio class", (aspectRatio, expectedClass) => {
+      render(
+        <CreatorTile
+          data-testid="tile"
+          imageSrc={SAMPLE_IMAGE}
+          name="JANE DOE"
+          aspectRatio={aspectRatio}
+        />,
+      );
+      expect(screen.getByTestId("tile")).toHaveClass(expectedClass);
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations with name and tagline", async () => {
+      const { container } = render(
+        <CreatorTile
+          imageSrc={SAMPLE_IMAGE}
+          imageAlt="Portrait of Jane Doe"
+          name="JANE DOE"
+          tagline="GLOBAL MUSIC ICON"
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations with decorative image (empty alt)", async () => {
+      const { container } = render(<CreatorTile imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/CreatorTile/CreatorTile.tsx
+++ b/src/components/CreatorTile/CreatorTile.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Corner radius preset for the tile. `none` removes all rounding. */
+export type CreatorTileRadius = "none" | "xs" | "sm" | "md" | "lg" | "xl";
+
+const RADIUS_CLASSES: Record<CreatorTileRadius, string> = {
+  none: "rounded-none",
+  xs: "rounded-xs",
+  sm: "rounded-sm",
+  md: "rounded-md",
+  lg: "rounded-lg",
+  xl: "rounded-xl",
+};
+
+/** Width-to-height ratio preset for the tile. */
+export type CreatorTileAspectRatio = "tall" | "medium" | "short";
+
+const ASPECT_RATIO_CLASSES: Record<CreatorTileAspectRatio, string> = {
+  tall: "aspect-1/2",
+  medium: "aspect-2/3",
+  short: "aspect-4/5",
+};
+
+export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Source URL of the creator's image. Rendered as the tile background. */
+  imageSrc: string;
+  /** Alt text for the creator image. Use an empty string for purely decorative imagery. */
+  imageAlt?: string;
+  /** Creator name shown as the prominent overlay heading. */
+  name: React.ReactNode;
+  /** Short tagline shown under the name in the brand accent color. */
+  tagline?: React.ReactNode;
+  /**
+   * Corner radius preset. Pass `none` for sharp corners.
+   * @default "lg"
+   */
+  radius?: CreatorTileRadius;
+  /**
+   * Width-to-height ratio preset.
+   *
+   * - `tall` – 1:2 narrow portrait
+   * - `medium` – 2:3 classic poster (default)
+   * - `short` – 4:5 closer to square
+   *
+   * @default "medium"
+   */
+  aspectRatio?: CreatorTileAspectRatio;
+}
+
+/**
+ * A visual highlight tile showcasing a creator with an overlaid name and tagline.
+ *
+ * The tile renders a full-bleed image with a bottom gradient that ensures the
+ * overlaid text remains legible regardless of the underlying photography.
+ *
+ * @example
+ * ```tsx
+ * <CreatorTile
+ *   imageSrc="https://example.com/creator.jpg"
+ *   imageAlt="Portrait of Jane Doe"
+ *   name="JANE DOE"
+ *   tagline="GLOBAL MUSIC ICON"
+ * />
+ * ```
+ */
+export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
+  (
+    {
+      className,
+      imageSrc,
+      imageAlt = "",
+      name,
+      tagline,
+      radius = "lg",
+      aspectRatio = "medium",
+      ...props
+    },
+    ref,
+  ) => {
+    const radiusClass = RADIUS_CLASSES[radius];
+    const aspectClass = ASPECT_RATIO_CLASSES[aspectRatio];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "relative isolate flex w-full flex-col justify-end overflow-hidden",
+          aspectClass,
+          radiusClass,
+          className,
+        )}
+        {...props}
+      >
+        <img
+          src={imageSrc}
+          alt={imageAlt}
+          decoding="async"
+          className="absolute inset-0 -z-10 h-full w-full object-cover"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 bg-linear-to-b from-64% from-transparent to-black/40"
+        />
+        <div className="flex flex-col gap-1 px-6 pb-6">
+          <p className="m-0 font-black text-4xl text-white leading-none tracking-tight">{name}</p>
+          {tagline ? (
+            <p className="m-0 font-bold text-[9px] text-brand-primary-default uppercase leading-none">
+              {tagline}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    );
+  },
+);
+
+CreatorTile.displayName = "CreatorTile";

--- a/src/components/CreatorTile/CreatorTile.tsx
+++ b/src/components/CreatorTile/CreatorTile.tsx
@@ -1,18 +1,6 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
 
-/** Corner radius preset for the tile. `none` removes all rounding. */
-export type CreatorTileRadius = "none" | "xs" | "sm" | "md" | "lg" | "xl";
-
-const RADIUS_CLASSES: Record<CreatorTileRadius, string> = {
-  none: "rounded-none",
-  xs: "rounded-xs",
-  sm: "rounded-sm",
-  md: "rounded-md",
-  lg: "rounded-lg",
-  xl: "rounded-xl",
-};
-
 /** Width-to-height ratio preset for the tile. */
 export type CreatorTileAspectRatio = "tall" | "medium" | "short";
 
@@ -31,11 +19,6 @@ export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
   name: React.ReactNode;
   /** Short tagline shown under the name in the brand accent color. */
   tagline?: React.ReactNode;
-  /**
-   * Corner radius preset. Pass `none` for sharp corners.
-   * @default "lg"
-   */
-  radius?: CreatorTileRadius;
   /**
    * Width-to-height ratio preset.
    *
@@ -66,19 +49,9 @@ export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
   (
-    {
-      className,
-      imageSrc,
-      imageAlt = "",
-      name,
-      tagline,
-      radius = "lg",
-      aspectRatio = "medium",
-      ...props
-    },
+    { className, imageSrc, imageAlt = "", name, tagline, aspectRatio = "medium", ...props },
     ref,
   ) => {
-    const radiusClass = RADIUS_CLASSES[radius];
     const aspectClass = ASPECT_RATIO_CLASSES[aspectRatio];
 
     return (
@@ -87,7 +60,6 @@ export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
         className={cn(
           "relative isolate flex w-full flex-col justify-end overflow-hidden",
           aspectClass,
-          radiusClass,
           className,
         )}
         {...props}
@@ -95,13 +67,10 @@ export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
         <img
           src={imageSrc}
           alt={imageAlt}
-          decoding="async"
+          loading="lazy"
           className="absolute inset-0 -z-10 h-full w-full object-cover"
         />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0 -z-10 bg-linear-to-b from-64% from-transparent to-black/40"
-        />
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-linear-to-b from-64% from-transparent to-black/40" />
         <div className="flex flex-col gap-1 px-6 pb-6">
           <p className="m-0 font-black text-4xl text-white leading-none tracking-tight">{name}</p>
           {tagline ? (

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,12 @@ export type {
 } from "./components/Count/Count";
 export { Count } from "./components/Count/Count";
 export type {
+  CreatorTileAspectRatio,
+  CreatorTileProps,
+  CreatorTileRadius,
+} from "./components/CreatorTile/CreatorTile";
+export { CreatorTile } from "./components/CreatorTile/CreatorTile";
+export type {
   DialogBodyProps,
   DialogCloseProps,
   DialogContentProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,9 @@ export { Count } from "./components/Count/Count";
 export type {
   CreatorTileAspectRatio,
   CreatorTileProps,
-  CreatorTileRadius,
 } from "./components/CreatorTile/CreatorTile";
 export { CreatorTile } from "./components/CreatorTile/CreatorTile";
+export type {
   CyclingTextProps,
   CyclingTextSizing,
 } from "./components/CyclingText/CyclingText";


### PR DESCRIPTION
## Summary

Adds a new `CreatorTile` component — a visual highlight tile that renders a full-bleed creator image with an overlaid name and accent-coloured tagline, matching the [Highlight Card](https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-76293) design in Figma.

The component exposes an `aspectRatio` preset so consumers can scale it across layouts without reaching for raw Tailwind classes:

- **`aspectRatio`** — `tall` (1:2), `medium` (2:3, default), `short` (4:5)

## Changes

- **`src/components/CreatorTile/CreatorTile.tsx`** — new component with `forwardRef`, `displayName`, `cn()`-based class merging, and JSDoc on every public prop. Uses design tokens from `theme.css` (`text-brand-primary-default` for the green tagline) and a bottom gradient overlay to keep the overlaid text legible.
- **`src/components/CreatorTile/CreatorTile.test.tsx`** — unit tests covering API contracts (className, ref forwarding, attribute spreading), every `aspectRatio` preset, and axe accessibility violations for both the labelled and decorative-image variants.
- **`src/components/CreatorTile/CreatorTile.stories.tsx`** — CSF3 stories (`Default`, `WithoutTagline`, `AspectRatios`) with the Figma design link in the `design` parameter.
- **`src/index.ts`** — explicit named exports for `CreatorTile`, `CreatorTileProps`, and `CreatorTileAspectRatio`.
- **`src/App.tsx`** — registered the demo, added a `creator-tile` TOC entry, and rendered the aspect-ratio scale in the showcase page.

## Checklist

- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] New/updated components have stories
- [x] New/updated components have accessibility tests
- [x] New/updated components have forwardRef unit tests
- [x] New/updated components have className chaining unit tests
- [x] Exported in `src/index.ts` (if consumable by vendors)
- [x] Figma link added to story `design` parameter (if applicable)
- [x] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

Once Chromatic publishes this branch, link the new `Components/CreatorTile` story back into Figma via the Storybook Connect plugin (`Shift+I`) to complete the two-way integration.