### PR TITLE
fix(ChatInput): Remove focus outline

### DIFF
--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -307,7 +307,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       <div
         className={cn(
           "relative flex flex-col gap-6 rounded-lg border border-border-primary bg-surface-primary",
-          "has-focus-visible:shadow-focus-ring has-focus-visible:outline-none",
+          "has-focus-visible:outline-none",
           "motion-safe:transition-colors",
           disabled && "opacity-50",
           className,


### PR DESCRIPTION
## Summary

I don't know exactly when this snuck in or why I didn't spot it but I left a focus outline on the chatinput right before merging. 

## Changes

Remove focus outline
## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

Was:
<img width="454" height="227" alt="image" src="https://github.com/user-attachments/assets/f5997f5d-31e8-4dce-a54c-1932cfc1bae4" />

Is:
<img width="459" height="221" alt="image" src="https://github.com/user-attachments/assets/1a0d515b-dfc2-426d-9c9a-2015bd5b2cd6" />
