### PR TITLE
fix(CreatorTile): revamping due to new requirements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4459,32 +4459,57 @@ function CreatorCardDemo() {
 
 function CreatorTileDemo() {
   const sampleImage =
-    "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=480&h=720&fit=crop";
+    "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=720&h=400&fit=crop";
+  const sampleAvatar =
+    "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop";
 
   return (
     <div id="creator-tile" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-bold-heading-xs mb-4">Creator Tile</h2>
 
       <h3 className="typography-semibold-body-lg">Default</h3>
-      <div className="w-[239px]">
+      <div className="w-[361px]">
         <CreatorTile
-          imageSrc={sampleImage}
-          imageAlt="Portrait of a creator"
-          name="JANE DOE"
-          tagline="GLOBAL MUSIC ICON"
+          background={<img src={sampleImage} alt="" loading="lazy" />}
+          avatar={{ src: sampleAvatar, alt: "Aitana Lopez", fallback: "AL" }}
+          name="Aitana Lopez"
+          tagline="@fit_aitana"
+          action={
+            <Button variant="primary" size="32">
+              Follow
+            </Button>
+          }
+          className="rounded-lg"
+        />
+      </div>
+
+      <h3 className="typography-semibold-body-lg mt-4">Without action</h3>
+      <div className="w-[361px]">
+        <CreatorTile
+          background={<img src={sampleImage} alt="" loading="lazy" />}
+          avatar={{ src: sampleAvatar, alt: "Aitana Lopez", fallback: "AL" }}
+          name="Aitana Lopez"
+          tagline="@fit_aitana"
+          className="rounded-lg"
         />
       </div>
 
       <h3 className="typography-semibold-body-lg mt-4">Aspect ratio</h3>
       <div className="flex flex-wrap items-start gap-4">
         {(["tall", "medium", "short"] as const).map((aspectRatio) => (
-          <div key={aspectRatio} className="flex w-[200px] flex-col gap-2">
+          <div key={aspectRatio} className="flex w-[280px] flex-col gap-2">
             <CreatorTile
-              imageSrc={sampleImage}
-              imageAlt="Portrait of a creator"
-              name="JANE DOE"
-              tagline={aspectRatio.toUpperCase()}
+              background={<img src={sampleImage} alt="" loading="lazy" />}
+              avatar={{ src: sampleAvatar, alt: "Aitana Lopez", fallback: "AL" }}
+              name="Aitana Lopez"
+              tagline="@fit_aitana"
+              action={
+                <Button variant="primary" size="32">
+                  Follow
+                </Button>
+              }
               aspectRatio={aspectRatio}
+              className="rounded-lg"
             />
             <p className="typography-regular-body-sm text-content-secondary">
               aspectRatio=&quot;{aspectRatio}&quot;

--- a/src/components/CreatorTile/CreatorTile.stories.tsx
+++ b/src/components/CreatorTile/CreatorTile.stories.tsx
@@ -1,8 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../Button/Button";
 import { CreatorTile } from "./CreatorTile";
 
-const SAMPLE_IMAGE =
-  "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=480&h=720&fit=crop";
+const SAMPLE_BACKGROUND =
+  "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=720&h=400&fit=crop";
+const SAMPLE_AVATAR =
+  "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop";
 
 const meta = {
   title: "Components/CreatorTile",
@@ -11,7 +14,7 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-76293&m=dev",
+      url: "https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-75778&m=dev",
     },
   },
   tags: ["autodocs"],
@@ -21,55 +24,62 @@ const meta = {
       options: ["tall", "medium", "short"],
     },
   },
+  args: {
+    background: <img src={SAMPLE_BACKGROUND} alt="" loading="lazy" />,
+    name: "Aitana Lopez",
+    tagline: "@fit_aitana",
+    avatar: {
+      src: SAMPLE_AVATAR,
+      alt: "Aitana Lopez",
+      fallback: "AL",
+    },
+    action: (
+      <Button variant="primary" size="32">
+        Follow
+      </Button>
+    ),
+  },
 } satisfies Meta<typeof CreatorTile>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    imageSrc: SAMPLE_IMAGE,
-    imageAlt: "Portrait of a creator",
-    name: "JANE DOE",
-    tagline: "GLOBAL MUSIC ICON",
-  },
   render: (args) => (
-    <div className="w-[239px]">
-      <CreatorTile {...args} />
+    <div className="w-90">
+      <CreatorTile {...args} className="rounded-lg" />
     </div>
   ),
 };
 
 export const WithoutTagline: Story = {
   args: {
-    imageSrc: SAMPLE_IMAGE,
-    imageAlt: "Portrait of a creator",
-    name: "JANE DOE",
+    tagline: undefined,
   },
   render: (args) => (
-    <div className="w-[239px]">
-      <CreatorTile {...args} />
+    <div className="w-90">
+      <CreatorTile {...args} className="rounded-lg" />
+    </div>
+  ),
+};
+
+export const WithoutAction: Story = {
+  args: {
+    action: undefined,
+  },
+  render: (args) => (
+    <div className="w-90">
+      <CreatorTile {...args} className="rounded-lg" />
     </div>
   ),
 };
 
 export const AspectRatios: Story = {
-  args: {
-    imageSrc: SAMPLE_IMAGE,
-    imageAlt: "Portrait of a creator",
-    name: "JANE DOE",
-  },
-  render: () => (
+  render: (args) => (
     <div className="flex flex-wrap items-start gap-4">
       {(["tall", "medium", "short"] as const).map((aspectRatio) => (
-        <div key={aspectRatio} className="flex w-[200px] flex-col gap-2">
-          <CreatorTile
-            imageSrc={SAMPLE_IMAGE}
-            imageAlt="Portrait of a creator"
-            name="JANE DOE"
-            tagline={aspectRatio.toUpperCase()}
-            aspectRatio={aspectRatio}
-          />
+        <div key={aspectRatio} className="flex w-[280px] flex-col gap-2">
+          <CreatorTile {...args} aspectRatio={aspectRatio} className="rounded-lg" />
           <p className="typography-regular-body-sm text-content-secondary">
             aspectRatio=&quot;{aspectRatio}&quot;
           </p>

--- a/src/components/CreatorTile/CreatorTile.test.tsx
+++ b/src/components/CreatorTile/CreatorTile.test.tsx
@@ -85,15 +85,15 @@ describe("CreatorTile", () => {
   });
 
   describe("aspectRatio", () => {
-    it("uses medium (361/200) ratio by default", () => {
+    it("uses medium ratio by default", () => {
       render(<CreatorTile {...baseProps} data-testid="tile" />);
-      expect(screen.getByTestId("tile")).toHaveClass("aspect-[361/200]");
+      expect(screen.getByTestId("tile")).toHaveClass("aspect-3/2");
     });
 
     it.each([
-      ["tall", "aspect-1/2"],
-      ["medium", "aspect-[361/200]"],
-      ["short", "aspect-4/5"],
+      ["tall", "aspect-5/4"],
+      ["medium", "aspect-3/2"],
+      ["short", "aspect-9/5"],
     ] as const)("applies %s ratio class", (aspectRatio, expectedClass) => {
       render(<CreatorTile {...baseProps} data-testid="tile" aspectRatio={aspectRatio} />);
       expect(screen.getByTestId("tile")).toHaveClass(expectedClass);

--- a/src/components/CreatorTile/CreatorTile.test.tsx
+++ b/src/components/CreatorTile/CreatorTile.test.tsx
@@ -2,89 +2,100 @@ import { render, screen } from "@testing-library/react";
 import * as React from "react";
 import { describe, expect, it } from "vitest";
 import { axe } from "vitest-axe";
+import { Button } from "../Button/Button";
 import { CreatorTile } from "./CreatorTile";
 
-const SAMPLE_IMAGE =
-  "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=480&h=720&fit=crop";
+const baseProps = {
+  background: (
+    <img
+      src="https://images.unsplash.com/photo-abc?w=720&h=400&fit=crop"
+      alt=""
+      loading="lazy"
+      data-testid="background-image"
+    />
+  ),
+  name: "Aitana Lopez",
+};
 
 describe("CreatorTile", () => {
   describe("API", () => {
     it("renders the name and tagline", () => {
-      render(
-        <CreatorTile
-          imageSrc={SAMPLE_IMAGE}
-          imageAlt="Portrait"
-          name="JANE DOE"
-          tagline="GLOBAL MUSIC ICON"
-        />,
-      );
-      expect(screen.getByText("JANE DOE")).toBeInTheDocument();
-      expect(screen.getByText("GLOBAL MUSIC ICON")).toBeInTheDocument();
+      render(<CreatorTile {...baseProps} tagline="@fit_aitana" />);
+      expect(screen.getByText("Aitana Lopez")).toBeInTheDocument();
+      expect(screen.getByText("@fit_aitana")).toBeInTheDocument();
     });
 
-    it("renders the image with the provided alt text", () => {
-      render(
-        <CreatorTile imageSrc={SAMPLE_IMAGE} imageAlt="Portrait of Jane Doe" name="JANE DOE" />,
+    it("renders the background in a non-interactive full-size layer", () => {
+      render(<CreatorTile {...baseProps} />);
+      const image = screen.getByTestId("background-image");
+      const background = image.parentElement;
+      expect(background).toHaveClass("pointer-events-none");
+      expect(image).toHaveAttribute(
+        "src",
+        "https://images.unsplash.com/photo-abc?w=720&h=400&fit=crop",
       );
-      const image = screen.getByAltText("Portrait of Jane Doe");
-      expect(image).toHaveAttribute("src", SAMPLE_IMAGE);
+    });
+
+    it("renders avatar fallback content", async () => {
+      render(<CreatorTile {...baseProps} avatar={{ fallback: "AL" }} />);
+      expect(await screen.findByText("AL")).toBeInTheDocument();
+    });
+
+    it("forwards avatar props to the inner Avatar", () => {
+      render(
+        <CreatorTile
+          {...baseProps}
+          avatar={{ fallback: "AL", className: "custom-avatar", onlineIndicator: true }}
+        />,
+      );
+      const avatar = screen.getByTestId("avatar");
+      expect(avatar).toHaveClass("custom-avatar");
     });
 
     it("omits the tagline when not provided", () => {
-      render(<CreatorTile imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
-      expect(screen.queryByText("GLOBAL MUSIC ICON")).not.toBeInTheDocument();
+      render(<CreatorTile {...baseProps} />);
+      expect(screen.queryByText("@fit_aitana")).not.toBeInTheDocument();
+    });
+
+    it("renders the action element", () => {
+      render(<CreatorTile {...baseProps} action={<Button variant="primary">Follow</Button>} />);
+      expect(screen.getByRole("button", { name: "Follow" })).toBeInTheDocument();
+    });
+
+    it("omits the action when not provided", () => {
+      render(<CreatorTile {...baseProps} />);
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
 
     it("applies custom className", () => {
-      render(
-        <CreatorTile
-          data-testid="tile"
-          className="custom"
-          imageSrc={SAMPLE_IMAGE}
-          name="JANE DOE"
-        />,
-      );
+      render(<CreatorTile {...baseProps} data-testid="tile" className="custom" />);
       expect(screen.getByTestId("tile")).toHaveClass("custom");
     });
 
     it("forwards ref correctly", () => {
       const ref = React.createRef<HTMLDivElement>();
-      render(<CreatorTile ref={ref} imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
+      render(<CreatorTile {...baseProps} ref={ref} />);
       expect(ref.current).toBeInstanceOf(HTMLDivElement);
     });
 
     it("spreads additional HTML attributes", () => {
-      render(
-        <CreatorTile
-          data-testid="tile"
-          data-custom="value"
-          imageSrc={SAMPLE_IMAGE}
-          name="JANE DOE"
-        />,
-      );
+      render(<CreatorTile {...baseProps} data-testid="tile" data-custom="value" />);
       expect(screen.getByTestId("tile")).toHaveAttribute("data-custom", "value");
     });
   });
 
   describe("aspectRatio", () => {
-    it("uses medium (2/3) ratio by default", () => {
-      render(<CreatorTile data-testid="tile" imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
-      expect(screen.getByTestId("tile")).toHaveClass("aspect-2/3");
+    it("uses medium (361/200) ratio by default", () => {
+      render(<CreatorTile {...baseProps} data-testid="tile" />);
+      expect(screen.getByTestId("tile")).toHaveClass("aspect-[361/200]");
     });
 
     it.each([
       ["tall", "aspect-1/2"],
-      ["medium", "aspect-2/3"],
+      ["medium", "aspect-[361/200]"],
       ["short", "aspect-4/5"],
     ] as const)("applies %s ratio class", (aspectRatio, expectedClass) => {
-      render(
-        <CreatorTile
-          data-testid="tile"
-          imageSrc={SAMPLE_IMAGE}
-          name="JANE DOE"
-          aspectRatio={aspectRatio}
-        />,
-      );
+      render(<CreatorTile {...baseProps} data-testid="tile" aspectRatio={aspectRatio} />);
       expect(screen.getByTestId("tile")).toHaveClass(expectedClass);
     });
   });
@@ -93,17 +104,17 @@ describe("CreatorTile", () => {
     it("has no accessibility violations with name and tagline", async () => {
       const { container } = render(
         <CreatorTile
-          imageSrc={SAMPLE_IMAGE}
-          imageAlt="Portrait of Jane Doe"
-          name="JANE DOE"
-          tagline="GLOBAL MUSIC ICON"
+          {...baseProps}
+          tagline="@fit_aitana"
+          avatar={{ fallback: "AL" }}
+          action={<Button variant="primary">Follow</Button>}
         />,
       );
       expect(await axe(container)).toHaveNoViolations();
     });
 
-    it("has no accessibility violations with decorative image (empty alt)", async () => {
-      const { container } = render(<CreatorTile imageSrc={SAMPLE_IMAGE} name="JANE DOE" />);
+    it("has no accessibility violations without optional content", async () => {
+      const { container } = render(<CreatorTile {...baseProps} />);
       expect(await axe(container)).toHaveNoViolations();
     });
   });

--- a/src/components/CreatorTile/CreatorTile.tsx
+++ b/src/components/CreatorTile/CreatorTile.tsx
@@ -73,7 +73,8 @@ export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
         <div className="pointer-events-none absolute inset-0 select-none *:h-full *:w-full [&>img]:object-cover [&>video]:object-cover">
           {background}
         </div>
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-linear-to-t from-black/60 to-transparent" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 rounded-b-[inherit] bg-linear-to-t from-black/60 to-transparent" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 overflow-hidden rounded-b-[inherit] backdrop-blur-md [-webkit-mask-image:linear-gradient(to_top,black,transparent)] [mask-image:linear-gradient(to_top,black,transparent)]" />
         <div className="relative flex items-center justify-between gap-4 p-4">
           <div className="flex min-w-0 items-center gap-2">
             <Avatar

--- a/src/components/CreatorTile/CreatorTile.tsx
+++ b/src/components/CreatorTile/CreatorTile.tsx
@@ -1,29 +1,35 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { Avatar } from "../Avatar/Avatar";
 
 /** Width-to-height ratio preset for the tile. */
 export type CreatorTileAspectRatio = "tall" | "medium" | "short";
 
 const ASPECT_RATIO_CLASSES: Record<CreatorTileAspectRatio, string> = {
-  tall: "aspect-1/2",
-  medium: "aspect-2/3",
-  short: "aspect-4/5",
+  tall: "aspect-5/4",
+  medium: "aspect-3/2",
+  short: "aspect-9/5",
 };
 
 export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Source URL of the creator's image. Rendered as the tile background. */
-  imageSrc: string;
-  /** Alt text for the creator image. Use an empty string for purely decorative imagery. */
-  imageAlt?: string;
-  /** Creator name shown as the prominent overlay heading. */
+  /** Decorative background media rendered behind the creator content. */
+  background: React.ReactNode;
+  /** Creator display name shown as the prominent heading. */
   name: React.ReactNode;
-  /** Short tagline shown under the name in the brand accent color. */
+  /** Optional secondary line shown under the name (e.g. handle or tagline). */
   tagline?: React.ReactNode;
+  /** Avatar props forwarded to the inner {@link Avatar}. */
+  avatar?: React.ComponentPropsWithoutRef<typeof Avatar>;
+  /**
+   * Action element rendered on the right of the profile row (e.g. a `Button`
+   * for following the creator).
+   */
+  action?: React.ReactNode;
   /**
    * Width-to-height ratio preset.
    *
    * - `tall` – 1:2 narrow portrait
-   * - `medium` – 2:3 classic poster (default)
+   * - `medium` – 361:200 landscape banner (default)
    * - `short` – 4:5 closer to square
    *
    * @default "medium"
@@ -32,24 +38,24 @@ export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * A visual highlight tile showcasing a creator with an overlaid name and tagline.
- *
- * The tile renders a full-bleed image with a bottom gradient that ensures the
- * overlaid text remains legible regardless of the underlying photography.
+ * A visual highlight tile showcasing a creator with a full-bleed background
+ * media and an overlaid profile row containing an avatar, name, optional
+ * tagline and an action element.
  *
  * @example
  * ```tsx
  * <CreatorTile
- *   imageSrc="https://example.com/creator.jpg"
- *   imageAlt="Portrait of Jane Doe"
- *   name="JANE DOE"
- *   tagline="GLOBAL MUSIC ICON"
+ *   background={<img src="/creator.jpg" alt="" />}
+ *   avatar={{ src: "/avatar.jpg", alt: "Aitana Lopez", fallback: "AL" }}
+ *   name="Aitana Lopez"
+ *   tagline="@fit_aitana"
+ *   action={<Button variant="primary">Follow</Button>}
  * />
  * ```
  */
 export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
   (
-    { className, imageSrc, imageAlt = "", name, tagline, aspectRatio = "medium", ...props },
+    { className, background, name, tagline, avatar, action, aspectRatio = "medium", ...props },
     ref,
   ) => {
     const aspectClass = ASPECT_RATIO_CLASSES[aspectRatio];
@@ -64,20 +70,27 @@ export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
         )}
         {...props}
       >
-        <img
-          src={imageSrc}
-          alt={imageAlt}
-          loading="lazy"
-          className="absolute inset-0 -z-10 h-full w-full object-cover"
-        />
-        <div className="pointer-events-none absolute inset-0 -z-10 bg-linear-to-b from-64% from-transparent to-black/40" />
-        <div className="flex flex-col gap-1 px-6 pb-6">
-          <p className="m-0 font-black text-4xl text-white leading-none tracking-tight">{name}</p>
-          {tagline ? (
-            <p className="m-0 font-bold text-[9px] text-brand-primary-default uppercase leading-none">
-              {tagline}
-            </p>
-          ) : null}
+        <div className="pointer-events-none absolute inset-0 select-none *:h-full *:w-full [&>img]:object-cover [&>video]:object-cover">
+          {background}
+        </div>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-linear-to-t from-black/60 to-transparent" />
+        <div className="relative flex items-center justify-between gap-4 p-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <Avatar
+              size={40}
+              src={avatar?.src}
+              alt={avatar?.alt ?? (typeof name === "string" ? name : undefined)}
+              fallback={avatar?.fallback}
+              {...avatar}
+            />
+            <div className="flex min-w-0 flex-col">
+              <p className="typography-semibold-body-lg m-0 truncate text-white">{name}</p>
+              {tagline ? (
+                <p className="typography-semibold-body-md m-0 truncate text-white/50">{tagline}</p>
+              ) : null}
+            </div>
+          </div>
+          {action ? <div className="shrink-0">{action}</div> : null}
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Revamps `CreatorTile` to match the new Figma design — a full-bleed background tile with an overlaid profile row (avatar, name, tagline, action) sitting above a frosted-glass gradient.

Figma: https://www.figma.com/design/Iq9ctjP7rhIKI3PGSbduNL/Fanvue-Exploration?node-id=2379-75778&m=dev

## Changes

- **API rewrite**: dropped `imageSrc` / `imageAlt`; added `background: ReactNode`, `avatar`, and `action` props (mirrors `CreatorCard`'s slot-based composition).
- **Avatar slot**: forwards full `Avatar` props through `avatar?: ComponentPropsWithoutRef<typeof Avatar>`, rendered at 40px.
- **Action slot**: `action?: ReactNode` for a single trailing element (e.g. a Follow `Button`).
- **Aspect ratios** updated to the Figma spec: `tall` `5/4`, `medium` `3/2` (default), `short` `9/5`.
- **Bottom legibility layer**: dark linear gradient + `backdrop-blur-md` masked with a top-to-bottom linear-gradient mask, both using `rounded-b-[inherit]` so they follow whatever radius the consumer applies.
- **Typography**: name uses `typography-semibold-body-lg` white; tagline uses `typography-semibold-body-md` at `text-white/50`.
- **No baked-in radius**: the component itself ships unrounded (matching `CreatorCard`); examples in the demo and stories opt in via `className="rounded-lg"`.

## Checklist

- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] New/updated components have stories
- [x] New/updated components have accessibility tests
- [x] New/updated components have forwardRef unit tests
- [x] New/updated components have className chaining unit tests
- [x] Exported in \`src/index.ts\` (if consumable by vendors)
- [x] Figma link added to story \`design\` parameter (if applicable)
- [x] Does not have barrel file \`src/YourComponent/index.ts\`

## Screenshots / Storybook

<img width="1000" height="328" alt="Screenshot 2026-05-08 at 10 02 55" src="https://github.com/user-attachments/assets/c887fb01-bbc8-4bf1-9e13-d5b060daeb20" />
<img width="1000" height="330" alt="Screenshot 2026-05-08 at 10 03 07" src="https://github.com/user-attachments/assets/9982c2f8-b80b-4848-95b3-d8ddf9013d6e" />
