### PR TITLE
chore(deps): bump fast-uri to >=3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
       "rollup": ">=4.59.0",
       "storybook": ">=10.2.10",
       "picomatch": ">=4.0.4",
-      "micromatch>picomatch": "2.3.2"
+      "micromatch>picomatch": "2.3.2",
+      "fast-uri": ">=3.1.2"
     }
   },
   "size-limit": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   storybook: '>=10.2.10'
   picomatch: '>=4.0.4'
   micromatch>picomatch: 2.3.2
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -2635,8 +2636,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6192,7 +6193,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6710,7 +6711,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Adds a pnpm override pinning `fast-uri` to `>=3.1.2`, fixing two high-severity advisories pulled in transitively via `ajv` (used by `@commitlint/*` and `@microsoft/tsdoc-config` under `vite-plugin-dts`).
  - [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments (patched in 3.1.1)
  - [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters (patched in 3.1.2)
- Unblocks the CI `pnpm audit --audit-level=high` step.

## Test plan
- [x] `pnpm audit --audit-level=high` exits 0 locally (6 moderate findings remain, no high/critical)
- [x] Lockfile resolves `fast-uri@3.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)