### PR TITLE
feat(InlineEdit): add component and dotted Chip variant

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,6 +132,7 @@ import {
   InfoBoxTrigger,
   InfoCircleIcon,
   InfoIcon,
+  InlineEdit,
   LinkIcon,
   Loader,
   LocationIcon,
@@ -2609,6 +2610,17 @@ function ChipDemo() {
         </Chip>
       </div>
       <div className="flex flex-wrap items-center gap-3">
+        <Chip variant="square" dotted>
+          New folder
+        </Chip>
+        <Chip variant="square" dotted onClick={() => {}}>
+          New folder
+        </Chip>
+        <Chip variant="square" size="40" dotted onClick={() => {}}>
+          New folder
+        </Chip>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
         <Chip leftDot>Chip</Chip>
         <Chip leftDot selected>
           Chip
@@ -3994,6 +4006,40 @@ function AudioUploadDemo() {
   );
 }
 
+function InlineEditDemo() {
+  const [folderName, setFolderName] = useState("New folder");
+  const [folders, setFolders] = useState(["Inbox", "Drafts", "Sent"]);
+
+  return (
+    <div id="inlineedit" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-bold-heading-sm mb-4">Inline Edit</h2>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <InlineEdit value={folderName} onCommit={setFolderName} />
+          <InlineEdit size="32" value={folderName} onCommit={setFolderName} />
+          <InlineEdit value="Locked folder" onCommit={() => {}} disabled />
+          <InlineEdit
+            value={folderName}
+            onCommit={setFolderName}
+            leftIcon={<PlusIcon className="size-4" />}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          {folders.map((name, index) => (
+            <InlineEdit
+              key={index}
+              value={name}
+              onCommit={(next) =>
+                setFolders((prev) => prev.map((current, i) => (i === index ? next : current)))
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function LoaderDemo() {
   return (
     <div id="loader" className="flex scroll-mt-20 flex-col gap-4">
@@ -4558,6 +4604,7 @@ function App() {
     { id: "iconbutton", label: "Icon Button" },
     { id: "icons", label: "Icons" },
     { id: "infobox", label: "InfoBox" },
+    { id: "inlineedit", label: "Inline Edit" },
     { id: "loader", label: "Loader" },
     { id: "logo", label: "Logo" },
     { id: "stepper", label: "Stepper" },
@@ -4809,6 +4856,9 @@ function App() {
             {/* Tooltip */}
             <TooltipDemo />
             <InfoBoxDemo />
+
+            {/* Inline Edit */}
+            <InlineEditDemo />
 
             {/* Audio Upload */}
             <AudioUploadDemo />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4015,12 +4015,12 @@ function InlineEditDemo() {
       <h2 className="typography-bold-heading-sm mb-4">Inline Edit</h2>
       <div className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center gap-3">
-          <InlineEdit value={folderName} onCommit={setFolderName} />
-          <InlineEdit size="32" value={folderName} onCommit={setFolderName} />
-          <InlineEdit value="Locked folder" onCommit={() => {}} disabled />
+          <InlineEdit value={folderName} onSubmit={setFolderName} />
+          <InlineEdit size="32" value={folderName} onSubmit={setFolderName} />
+          <InlineEdit value="Locked folder" onSubmit={() => {}} disabled />
           <InlineEdit
             value={folderName}
-            onCommit={setFolderName}
+            onSubmit={setFolderName}
             leftIcon={<PlusIcon className="size-4" />}
           />
         </div>
@@ -4029,7 +4029,7 @@ function InlineEditDemo() {
             <InlineEdit
               key={index}
               value={name}
-              onCommit={(next) =>
+              onSubmit={(next: string) =>
                 setFolders((prev) => prev.map((current, i) => (i === index ? next : current)))
               }
             />

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -37,6 +37,7 @@ const meta = {
     selected: { control: "boolean" },
     disabled: { control: "boolean" },
     leftDot: { control: "boolean" },
+    dotted: { control: "boolean" },
   },
 } satisfies Meta<typeof Chip>;
 
@@ -145,6 +146,33 @@ export const WithDotDark: Story = {
     variant: "dark",
     leftDot: true,
     children: "Chip",
+  },
+};
+
+export const Dotted: Story = {
+  args: {
+    variant: "square",
+    dotted: true,
+    children: "New folder",
+  },
+};
+
+export const DottedInteractive: Story = {
+  args: {
+    variant: "square",
+    dotted: true,
+    children: "New folder",
+    onClick: () => {},
+  },
+};
+
+export const DottedSize40: Story = {
+  args: {
+    variant: "square",
+    size: "40",
+    dotted: true,
+    children: "New folder",
+    onClick: () => {},
   },
 };
 

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -119,6 +119,20 @@ describe("Chip", () => {
     });
   });
 
+  describe("dotted", () => {
+    it("applies dashed border when dotted is true", () => {
+      render(<Chip dotted>New folder</Chip>);
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("border-dashed");
+    });
+
+    it("does not apply dashed border by default", () => {
+      render(<Chip>Chip</Chip>);
+      const chip = screen.getByTestId("chip");
+      expect(chip).not.toHaveClass("border-dashed");
+    });
+  });
+
   describe("notificationLabel", () => {
     it("renders notification badge with label", () => {
       render(<Chip notificationLabel="99+">Test</Chip>);

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -18,6 +18,8 @@ export interface ChipProps extends React.HTMLAttributes<HTMLElement> {
   disabled?: boolean;
   /** Whether to show a coloured status dot at the leading edge. @default false */
   leftDot?: boolean;
+  /** Whether the chip uses a dashed border for add/create affordances. @default false */
+  dotted?: boolean;
   /** Icon element displayed before the label. */
   leftIcon?: React.ReactNode;
   /** Icon element displayed after the label. */
@@ -49,6 +51,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
       selected = false,
       disabled = false,
       leftDot = false,
+      dotted = false,
       leftIcon,
       rightIcon,
       notificationLabel,
@@ -78,14 +81,25 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           // Variant colors
           isDark && "bg-neutral-alphas-150 text-content-on-brand-inverted",
           !isDark && selected && "bg-brand-primary-muted text-neutral-alphas-900",
-          !isDark && !selected && "bg-neutral-alphas-50 text-neutral-alphas-900",
+          !isDark && !selected && !dotted && "bg-neutral-alphas-50 text-neutral-alphas-900",
+          !isDark &&
+            !selected &&
+            dotted &&
+            "border border-dashed border-border-primary bg-transparent text-neutral-alphas-900",
           // Interactive
           isInteractive && !disabled && "cursor-pointer",
           isInteractive &&
             !disabled &&
             !isDark &&
             !selected &&
+            !dotted &&
             "hover:bg-brand-primary-muted active:bg-brand-primary-muted",
+          isInteractive &&
+            !disabled &&
+            !isDark &&
+            !selected &&
+            dotted &&
+            "hover:border-neutral-alphas-500 hover:bg-neutral-alphas-50 active:border-neutral-alphas-500 active:bg-neutral-alphas-50",
           // Focus
           "focus-visible:shadow-focus-ring focus-visible:outline-none",
           // Disabled

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -18,7 +18,11 @@ export interface ChipProps extends React.HTMLAttributes<HTMLElement> {
   disabled?: boolean;
   /** Whether to show a coloured status dot at the leading edge. @default false */
   leftDot?: boolean;
-  /** Whether the chip uses a dashed border for add/create affordances. @default false */
+  /**
+   * Whether the chip uses a dashed border for add/create affordances.
+   * Has no effect when `variant="dark"` or `selected` is `true`.
+   * @default false
+   */
   dotted?: boolean;
   /** Icon element displayed before the label. */
   leftIcon?: React.ReactNode;

--- a/src/components/InlineEdit/InlineEdit.stories.tsx
+++ b/src/components/InlineEdit/InlineEdit.stories.tsx
@@ -29,11 +29,11 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     value: "New folder",
-    onCommit: () => {},
+    onSubmit: () => {},
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
-    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+    return <InlineEdit {...args} value={value} onSubmit={setValue} />;
   },
 };
 
@@ -41,11 +41,11 @@ export const Size32: Story = {
   args: {
     size: "32",
     value: "Inbox folder",
-    onCommit: () => {},
+    onSubmit: () => {},
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
-    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+    return <InlineEdit {...args} value={value} onSubmit={setValue} />;
   },
 };
 
@@ -53,11 +53,11 @@ export const Size40: Story = {
   args: {
     size: "40",
     value: "Inbox folder",
-    onCommit: () => {},
+    onSubmit: () => {},
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
-    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+    return <InlineEdit {...args} value={value} onSubmit={setValue} />;
   },
 };
 
@@ -65,38 +65,38 @@ export const Disabled: Story = {
   args: {
     disabled: true,
     value: "Locked folder",
-    onCommit: () => {},
+    onSubmit: () => {},
   },
 };
 
 export const WithLeftIcon: Story = {
   args: {
     value: "New folder",
-    onCommit: () => {},
+    onSubmit: () => {},
     leftIcon: <PlusIcon className="size-4" />,
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
-    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+    return <InlineEdit {...args} value={value} onSubmit={setValue} />;
   },
 };
 
 export const WithMaxLength: Story = {
   args: {
     value: "Folder",
-    onCommit: () => {},
+    onSubmit: () => {},
     maxLength: 20,
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
-    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+    return <InlineEdit {...args} value={value} onSubmit={setValue} />;
   },
 };
 
 export const InAList: Story = {
   args: {
     value: "",
-    onCommit: () => {},
+    onSubmit: () => {},
   },
   render: () => {
     const [folders, setFolders] = useState([
@@ -110,7 +110,7 @@ export const InAList: Story = {
           <InlineEdit
             key={folder.id}
             value={folder.name}
-            onCommit={(next) =>
+            onSubmit={(next) =>
               setFolders((prev) =>
                 prev.map((current) =>
                   current.id === folder.id ? { ...current, name: next } : current,

--- a/src/components/InlineEdit/InlineEdit.stories.tsx
+++ b/src/components/InlineEdit/InlineEdit.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { PlusIcon } from "../Icons/PlusIcon";
+import { InlineEdit } from "./InlineEdit";
+
+const meta = {
+  title: "Components/InlineEdit",
+  component: InlineEdit,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17354-271&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["32", "40"],
+    },
+    disabled: { control: "boolean" },
+  },
+} satisfies Meta<typeof InlineEdit>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: "New folder",
+    onCommit: () => {},
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+  },
+};
+
+export const Size32: Story = {
+  args: {
+    size: "32",
+    value: "Inbox folder",
+    onCommit: () => {},
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+  },
+};
+
+export const Size40: Story = {
+  args: {
+    size: "40",
+    value: "Inbox folder",
+    onCommit: () => {},
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: "Locked folder",
+    onCommit: () => {},
+  },
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    value: "New folder",
+    onCommit: () => {},
+    leftIcon: <PlusIcon className="size-4" />,
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+  },
+};
+
+export const WithMaxLength: Story = {
+  args: {
+    value: "Folder",
+    onCommit: () => {},
+    maxLength: 20,
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <InlineEdit {...args} value={value} onCommit={setValue} />;
+  },
+};
+
+export const InAList: Story = {
+  args: {
+    value: "",
+    onCommit: () => {},
+  },
+  render: () => {
+    const [folders, setFolders] = useState([
+      { id: "inbox", name: "Inbox" },
+      { id: "drafts", name: "Drafts" },
+      { id: "sent", name: "Sent" },
+    ]);
+    return (
+      <div className="flex flex-wrap gap-2">
+        {folders.map((folder) => (
+          <InlineEdit
+            key={folder.id}
+            value={folder.name}
+            onCommit={(next) =>
+              setFolders((prev) =>
+                prev.map((current) =>
+                  current.id === folder.id ? { ...current, name: next } : current,
+                ),
+              )
+            }
+          />
+        ))}
+      </div>
+    );
+  },
+};

--- a/src/components/InlineEdit/InlineEdit.test.tsx
+++ b/src/components/InlineEdit/InlineEdit.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { InlineEdit } from "./InlineEdit";
+
+function ControlledInlineEdit({
+  initialValue = "Folder",
+  ...rest
+}: { initialValue?: string } & Omit<Parameters<typeof InlineEdit>[0], "value" | "onCommit"> & {
+    onCommit?: (value: string) => void;
+  }) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <InlineEdit
+      {...rest}
+      value={value}
+      onCommit={(next) => {
+        setValue(next);
+        rest.onCommit?.(next);
+      }}
+    />
+  );
+}
+
+describe("InlineEdit", () => {
+  describe("API", () => {
+    it("applies custom className to the root element", () => {
+      render(<InlineEdit value="Folder" onCommit={() => {}} className="custom-class" />);
+      expect(screen.getByTestId("inline-edit")).toHaveClass("custom-class");
+    });
+
+    it("renders as a button by default", () => {
+      render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      const trigger = screen.getByTestId("inline-edit-trigger");
+      expect(trigger.tagName).toBe("BUTTON");
+      expect(trigger).toHaveAttribute("type", "button");
+    });
+
+    it("forwards ref to the input when editing", async () => {
+      const user = userEvent.setup();
+      const ref = vi.fn();
+      render(<InlineEdit ref={ref} value="Folder" onCommit={() => {}} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
+    });
+  });
+
+  describe("interaction", () => {
+    it("enters edit mode on click and selects the current value", async () => {
+      const user = userEvent.setup();
+      render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      const input = screen.getByTestId("inline-edit-input") as HTMLInputElement;
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveValue("Folder");
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe("Folder".length);
+    });
+
+    it("commits a new value on Enter", async () => {
+      const user = userEvent.setup();
+      const handleCommit = vi.fn();
+      render(<ControlledInlineEdit onCommit={handleCommit} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.clear(screen.getByTestId("inline-edit-input"));
+      await user.type(screen.getByTestId("inline-edit-input"), "Renamed{Enter}");
+      expect(handleCommit).toHaveBeenCalledWith("Renamed");
+      expect(screen.getByTestId("inline-edit-trigger")).toHaveTextContent("Renamed");
+    });
+
+    it("commits a new value on blur", async () => {
+      const user = userEvent.setup();
+      const handleCommit = vi.fn();
+      render(
+        <>
+          <ControlledInlineEdit onCommit={handleCommit} />
+          <button type="button">elsewhere</button>
+        </>,
+      );
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.clear(screen.getByTestId("inline-edit-input"));
+      await user.type(screen.getByTestId("inline-edit-input"), "Blurred");
+      await user.click(screen.getByRole("button", { name: "elsewhere" }));
+      expect(handleCommit).toHaveBeenCalledWith("Blurred");
+    });
+
+    it("cancels and reverts on Escape", async () => {
+      const user = userEvent.setup();
+      const handleCommit = vi.fn();
+      const handleCancel = vi.fn();
+      render(<ControlledInlineEdit onCommit={handleCommit} onCancel={handleCancel} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.clear(screen.getByTestId("inline-edit-input"));
+      await user.type(screen.getByTestId("inline-edit-input"), "Discarded{Escape}");
+      expect(handleCommit).not.toHaveBeenCalled();
+      expect(handleCancel).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("inline-edit-trigger")).toHaveTextContent("Folder");
+    });
+
+    it("rejects empty drafts and reverts to the previous value", async () => {
+      const user = userEvent.setup();
+      const handleCommit = vi.fn();
+      render(<ControlledInlineEdit onCommit={handleCommit} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.clear(screen.getByTestId("inline-edit-input"));
+      await user.type(screen.getByTestId("inline-edit-input"), "   {Enter}");
+      expect(handleCommit).not.toHaveBeenCalled();
+      expect(screen.getByTestId("inline-edit-trigger")).toHaveTextContent("Folder");
+    });
+
+    it("does not commit when the value is unchanged", async () => {
+      const user = userEvent.setup();
+      const handleCommit = vi.fn();
+      render(<ControlledInlineEdit onCommit={handleCommit} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.keyboard("{Enter}");
+      expect(handleCommit).not.toHaveBeenCalled();
+    });
+
+    it("does not enter edit mode when disabled", async () => {
+      const user = userEvent.setup();
+      render(<InlineEdit value="Folder" onCommit={() => {}} disabled />);
+      const trigger = screen.getByTestId("inline-edit-trigger");
+      await user.click(trigger);
+      expect(screen.queryByTestId("inline-edit-input")).not.toBeInTheDocument();
+      expect(trigger).toBeDisabled();
+    });
+  });
+
+  describe("leftIcon", () => {
+    it("renders the icon in display mode", () => {
+      render(
+        <InlineEdit
+          value="Folder"
+          onCommit={() => {}}
+          leftIcon={<span data-testid="icon">+</span>}
+        />,
+      );
+      expect(screen.getByTestId("icon")).toBeInTheDocument();
+    });
+
+    it("hides the icon while editing", async () => {
+      const user = userEvent.setup();
+      render(
+        <InlineEdit
+          value="Folder"
+          onCommit={() => {}}
+          leftIcon={<span data-testid="icon">+</span>}
+        />,
+      );
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      expect(screen.queryByTestId("icon")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no violations in display mode", async () => {
+      const { container } = render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no violations in edit mode", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/InlineEdit/InlineEdit.test.tsx
+++ b/src/components/InlineEdit/InlineEdit.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type * as React from "react";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
@@ -8,17 +9,17 @@ import { InlineEdit } from "./InlineEdit";
 function ControlledInlineEdit({
   initialValue = "Folder",
   ...rest
-}: { initialValue?: string } & Omit<Parameters<typeof InlineEdit>[0], "value" | "onCommit"> & {
-    onCommit?: (value: string) => void;
+}: { initialValue?: string } & Omit<Parameters<typeof InlineEdit>[0], "value" | "onSubmit"> & {
+    onSubmit?: (value: string) => void;
   }) {
   const [value, setValue] = useState(initialValue);
   return (
     <InlineEdit
       {...rest}
       value={value}
-      onCommit={(next) => {
+      onSubmit={(next) => {
         setValue(next);
-        rest.onCommit?.(next);
+        rest.onSubmit?.(next);
       }}
     />
   );
@@ -27,12 +28,12 @@ function ControlledInlineEdit({
 describe("InlineEdit", () => {
   describe("API", () => {
     it("applies custom className to the root element", () => {
-      render(<InlineEdit value="Folder" onCommit={() => {}} className="custom-class" />);
+      render(<InlineEdit value="Folder" onSubmit={() => {}} className="custom-class" />);
       expect(screen.getByTestId("inline-edit")).toHaveClass("custom-class");
     });
 
     it("renders as a button by default", () => {
-      render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      render(<InlineEdit value="Folder" onSubmit={() => {}} />);
       const trigger = screen.getByTestId("inline-edit-trigger");
       expect(trigger.tagName).toBe("BUTTON");
       expect(trigger).toHaveAttribute("type", "button");
@@ -41,16 +42,21 @@ describe("InlineEdit", () => {
     it("forwards ref to the input when editing", async () => {
       const user = userEvent.setup();
       const ref = vi.fn();
-      render(<InlineEdit ref={ref} value="Folder" onCommit={() => {}} />);
+      render(<InlineEdit ref={ref} value="Folder" onSubmit={() => {}} />);
       await user.click(screen.getByTestId("inline-edit-trigger"));
       expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
+    });
+
+    it("uses the visible value as the trigger's accessible name", () => {
+      render(<InlineEdit value="My folder" onSubmit={() => {}} />);
+      expect(screen.getByRole("button", { name: "My folder" })).toBeInTheDocument();
     });
   });
 
   describe("interaction", () => {
     it("enters edit mode on click and selects the current value", async () => {
       const user = userEvent.setup();
-      render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      render(<InlineEdit value="Folder" onSubmit={() => {}} />);
       await user.click(screen.getByTestId("inline-edit-trigger"));
       const input = screen.getByTestId("inline-edit-input") as HTMLInputElement;
       expect(input).toBeInTheDocument();
@@ -61,21 +67,21 @@ describe("InlineEdit", () => {
 
     it("commits a new value on Enter", async () => {
       const user = userEvent.setup();
-      const handleCommit = vi.fn();
-      render(<ControlledInlineEdit onCommit={handleCommit} />);
+      const handleSubmit = vi.fn();
+      render(<ControlledInlineEdit onSubmit={handleSubmit} />);
       await user.click(screen.getByTestId("inline-edit-trigger"));
       await user.clear(screen.getByTestId("inline-edit-input"));
       await user.type(screen.getByTestId("inline-edit-input"), "Renamed{Enter}");
-      expect(handleCommit).toHaveBeenCalledWith("Renamed");
+      expect(handleSubmit).toHaveBeenCalledWith("Renamed");
       expect(screen.getByTestId("inline-edit-trigger")).toHaveTextContent("Renamed");
     });
 
     it("commits a new value on blur", async () => {
       const user = userEvent.setup();
-      const handleCommit = vi.fn();
+      const handleSubmit = vi.fn();
       render(
         <>
-          <ControlledInlineEdit onCommit={handleCommit} />
+          <ControlledInlineEdit onSubmit={handleSubmit} />
           <button type="button">elsewhere</button>
         </>,
       );
@@ -83,49 +89,99 @@ describe("InlineEdit", () => {
       await user.clear(screen.getByTestId("inline-edit-input"));
       await user.type(screen.getByTestId("inline-edit-input"), "Blurred");
       await user.click(screen.getByRole("button", { name: "elsewhere" }));
-      expect(handleCommit).toHaveBeenCalledWith("Blurred");
+      expect(handleSubmit).toHaveBeenCalledWith("Blurred");
     });
 
     it("cancels and reverts on Escape", async () => {
       const user = userEvent.setup();
-      const handleCommit = vi.fn();
+      const handleSubmit = vi.fn();
       const handleCancel = vi.fn();
-      render(<ControlledInlineEdit onCommit={handleCommit} onCancel={handleCancel} />);
+      render(<ControlledInlineEdit onSubmit={handleSubmit} onCancel={handleCancel} />);
       await user.click(screen.getByTestId("inline-edit-trigger"));
       await user.clear(screen.getByTestId("inline-edit-input"));
       await user.type(screen.getByTestId("inline-edit-input"), "Discarded{Escape}");
-      expect(handleCommit).not.toHaveBeenCalled();
+      expect(handleSubmit).not.toHaveBeenCalled();
       expect(handleCancel).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId("inline-edit-trigger")).toHaveTextContent("Folder");
     });
 
     it("rejects empty drafts and reverts to the previous value", async () => {
       const user = userEvent.setup();
-      const handleCommit = vi.fn();
-      render(<ControlledInlineEdit onCommit={handleCommit} />);
+      const handleSubmit = vi.fn();
+      render(<ControlledInlineEdit onSubmit={handleSubmit} />);
       await user.click(screen.getByTestId("inline-edit-trigger"));
       await user.clear(screen.getByTestId("inline-edit-input"));
       await user.type(screen.getByTestId("inline-edit-input"), "   {Enter}");
-      expect(handleCommit).not.toHaveBeenCalled();
+      expect(handleSubmit).not.toHaveBeenCalled();
       expect(screen.getByTestId("inline-edit-trigger")).toHaveTextContent("Folder");
     });
 
     it("does not commit when the value is unchanged", async () => {
       const user = userEvent.setup();
-      const handleCommit = vi.fn();
-      render(<ControlledInlineEdit onCommit={handleCommit} />);
+      const handleSubmit = vi.fn();
+      render(<ControlledInlineEdit onSubmit={handleSubmit} />);
       await user.click(screen.getByTestId("inline-edit-trigger"));
       await user.keyboard("{Enter}");
-      expect(handleCommit).not.toHaveBeenCalled();
+      expect(handleSubmit).not.toHaveBeenCalled();
     });
 
     it("does not enter edit mode when disabled", async () => {
       const user = userEvent.setup();
-      render(<InlineEdit value="Folder" onCommit={() => {}} disabled />);
+      render(<InlineEdit value="Folder" onSubmit={() => {}} disabled />);
       const trigger = screen.getByTestId("inline-edit-trigger");
       await user.click(trigger);
       expect(screen.queryByTestId("inline-edit-input")).not.toBeInTheDocument();
       expect(trigger).toBeDisabled();
+    });
+  });
+
+  describe("validate", () => {
+    it("reverts the draft when validate returns false", async () => {
+      const user = userEvent.setup();
+      const handleSubmit = vi.fn();
+      const validate = (draft: string) => draft.length >= 3;
+      render(<ControlledInlineEdit onSubmit={handleSubmit} validate={validate} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.clear(screen.getByTestId("inline-edit-input"));
+      await user.type(screen.getByTestId("inline-edit-input"), "ab{Enter}");
+      expect(handleSubmit).not.toHaveBeenCalled();
+      expect(screen.getByTestId("inline-edit-trigger")).toHaveTextContent("Folder");
+    });
+
+    it("commits when validate returns true", async () => {
+      const user = userEvent.setup();
+      const handleSubmit = vi.fn();
+      const validate = (draft: string) => draft.length >= 3;
+      render(<ControlledInlineEdit onSubmit={handleSubmit} validate={validate} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.clear(screen.getByTestId("inline-edit-input"));
+      await user.type(screen.getByTestId("inline-edit-input"), "abcd{Enter}");
+      expect(handleSubmit).toHaveBeenCalledWith("abcd");
+    });
+  });
+
+  describe("forwarded handlers", () => {
+    it("calls a consumer onChange before updating the draft", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<InlineEdit value="Folder" onSubmit={() => {}} onChange={handleChange} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.type(screen.getByTestId("inline-edit-input"), "!");
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it("lets a consumer onKeyDown suppress Enter handling", async () => {
+      const user = userEvent.setup();
+      const handleSubmit = vi.fn();
+      const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") event.preventDefault();
+      };
+      render(<ControlledInlineEdit onSubmit={handleSubmit} onKeyDown={handleKeyDown} />);
+      await user.click(screen.getByTestId("inline-edit-trigger"));
+      await user.clear(screen.getByTestId("inline-edit-input"));
+      await user.type(screen.getByTestId("inline-edit-input"), "Renamed{Enter}");
+      expect(handleSubmit).not.toHaveBeenCalled();
+      expect(screen.getByTestId("inline-edit-input")).toBeInTheDocument();
     });
   });
 
@@ -134,7 +190,7 @@ describe("InlineEdit", () => {
       render(
         <InlineEdit
           value="Folder"
-          onCommit={() => {}}
+          onSubmit={() => {}}
           leftIcon={<span data-testid="icon">+</span>}
         />,
       );
@@ -146,7 +202,7 @@ describe("InlineEdit", () => {
       render(
         <InlineEdit
           value="Folder"
-          onCommit={() => {}}
+          onSubmit={() => {}}
           leftIcon={<span data-testid="icon">+</span>}
         />,
       );
@@ -157,13 +213,13 @@ describe("InlineEdit", () => {
 
   describe("accessibility", () => {
     it("has no violations in display mode", async () => {
-      const { container } = render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      const { container } = render(<InlineEdit value="Folder" onSubmit={() => {}} />);
       expect(await axe(container)).toHaveNoViolations();
     });
 
     it("has no violations in edit mode", async () => {
       const user = userEvent.setup();
-      const { container } = render(<InlineEdit value="Folder" onCommit={() => {}} />);
+      const { container } = render(<InlineEdit value="Folder" onSubmit={() => {}} />);
       await user.click(screen.getByTestId("inline-edit-trigger"));
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/src/components/InlineEdit/InlineEdit.tsx
+++ b/src/components/InlineEdit/InlineEdit.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { Chip } from "../Chip/Chip";
 
 /** Height of the inline edit field in pixels. */
 export type InlineEditSize = "32" | "40";
@@ -7,83 +8,92 @@ export type InlineEditSize = "32" | "40";
 export interface InlineEditProps
   extends Omit<
     React.InputHTMLAttributes<HTMLInputElement>,
-    "value" | "defaultValue" | "size" | "onChange" | "onBlur" | "onKeyDown"
+    "value" | "defaultValue" | "size" | "onSubmit"
   > {
   /** Current value displayed in the chip and used as the starting draft when editing. */
   value: string;
   /** Called with the trimmed draft when the user commits an edit (Enter or blur). */
-  onCommit: (value: string) => void;
+  onSubmit: (value: string) => void;
   /** Called when the user cancels an edit with Escape. */
   onCancel?: () => void;
   /** Height of the field in pixels. @default "40" */
   size?: InlineEditSize;
   /** Whether the field is disabled — prevents entering edit mode. @default false */
   disabled?: boolean;
-  /** Maximum length of the input value when editing. */
-  maxLength?: number;
-  /** Accessible label for the edit affordance. @default "Edit" */
+  /** Accessible label for the edit input. @default "Edit" */
   editLabel?: string;
   /** Icon rendered before the value in display mode. Hidden when editing. */
   leftIcon?: React.ReactNode;
+  /**
+   * Validator for the trimmed draft on commit. Returning `false` reverts to
+   * the previous value without calling `onSubmit`. @default rejects empty drafts
+   */
+  validate?: (draft: string) => boolean;
   /** Additional class name applied to the root element. */
   className?: string;
 }
-
-const SIZE_CLASSES: Record<InlineEditSize, string> = {
-  "32": "h-8",
-  "40": "h-10",
-};
 
 /**
  * A chip-styled inline edit field. Renders as a dashed-border button that
  * swaps to a text input on click, allowing the value to be edited in place.
  *
- * Enter and blur commit the draft via `onCommit`. Escape reverts to `value`
- * and calls `onCancel`. Empty drafts are rejected and revert to `value`.
+ * Enter and blur commit the draft via `onSubmit`. Escape reverts to `value`
+ * and calls `onCancel`. Drafts that fail `validate` are reverted.
  *
  * The forwarded ref points at the underlying `<input>` and is only populated
  * while the field is in edit mode — it resolves to `null` in display mode.
  *
+ * Consumers may pass `onChange`, `onBlur`, and `onKeyDown` to participate in
+ * input events. The component's own handlers run after the consumer's, and
+ * keyboard handling is skipped if the consumer calls `event.preventDefault()`.
+ *
  * @example
  * ```tsx
  * const [name, setName] = useState("New folder");
- * <InlineEdit value={name} onCommit={setName} />
+ * <InlineEdit value={name} onSubmit={setName} />
  * ```
  */
 export const InlineEdit = React.forwardRef<HTMLInputElement, InlineEditProps>(
   (
     {
       value,
-      onCommit,
+      onSubmit,
       onCancel,
       size = "40",
       disabled = false,
-      maxLength,
       editLabel = "Edit",
       leftIcon,
+      validate,
       className,
       placeholder,
+      onChange,
+      onBlur,
+      onKeyDown,
       ...inputProps
     },
     ref,
   ) => {
     const [isEditing, setIsEditing] = React.useState(false);
     const [draft, setDraft] = React.useState(value);
-    const inputRef = React.useRef<HTMLInputElement>(null);
+    const inputRef = React.useRef<HTMLInputElement | null>(null);
 
-    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+    const setInputRef = React.useCallback(
+      (node: HTMLInputElement | null) => {
+        inputRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          (ref as React.RefObject<HTMLInputElement | null>).current = node;
+        }
+      },
+      [ref],
+    );
 
     React.useEffect(() => {
       if (!isEditing) {
         setDraft(value);
       }
     }, [value, isEditing]);
-
-    const enterEditMode = () => {
-      if (disabled) return;
-      setDraft(value);
-      setIsEditing(true);
-    };
 
     React.useEffect(() => {
       if (!isEditing) return;
@@ -93,28 +103,45 @@ export const InlineEdit = React.forwardRef<HTMLInputElement, InlineEditProps>(
       input.select();
     }, [isEditing]);
 
-    const exitEditMode = () => {
-      setIsEditing(false);
+    const enterEditMode = () => {
+      if (disabled) return;
+      setDraft(value);
+      setIsEditing(true);
     };
 
     const commit = () => {
       const trimmed = draft.trim();
-      if (trimmed.length === 0 || trimmed === value) {
+      const isValid = validate ? validate(trimmed) : trimmed.length > 0;
+      if (!isValid) {
         setDraft(value);
-        exitEditMode();
+        setIsEditing(false);
         return;
       }
-      onCommit(trimmed);
-      exitEditMode();
+      if (trimmed !== value) {
+        onSubmit(trimmed);
+      }
+      setIsEditing(false);
     };
 
     const cancel = () => {
       setDraft(value);
-      exitEditMode();
+      setIsEditing(false);
       onCancel?.();
     };
 
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event);
+      setDraft(event.target.value);
+    };
+
+    const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+      onBlur?.(event);
+      commit();
+    };
+
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
       if (event.key === "Enter") {
         event.preventDefault();
         commit();
@@ -125,13 +152,6 @@ export const InlineEdit = React.forwardRef<HTMLInputElement, InlineEditProps>(
     };
 
     const showLeftIcon = Boolean(leftIcon) && !isEditing;
-    const chipClassName = cn(
-      "typography-semibold-body-sm inline-flex items-center rounded-xs border border-dashed border-border-primary bg-transparent px-3 text-content-primary motion-safe:transition-colors motion-safe:duration-150",
-      SIZE_CLASSES[size],
-      disabled && "pointer-events-none opacity-50",
-    );
-    const iconAdornmentClassName = "pl-9";
-
     const sizerText = (isEditing ? draft : value) || placeholder || " ";
 
     return (
@@ -142,56 +162,50 @@ export const InlineEdit = React.forwardRef<HTMLInputElement, InlineEditProps>(
         <span
           aria-hidden="true"
           className={cn(
-            chipClassName,
-            "invisible block whitespace-pre",
-            showLeftIcon && iconAdornmentClassName,
+            "typography-semibold-body-sm invisible block whitespace-pre border border-transparent px-3",
+            size === "32" ? "h-8" : "h-10",
+            showLeftIcon && "pl-9",
           )}
         >
           {sizerText}
         </span>
-        {showLeftIcon && (
-          <span
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-content-primary"
-          >
-            <span className="flex size-4 shrink-0 items-center justify-center">{leftIcon}</span>
-          </span>
-        )}
         {isEditing ? (
-          <input
-            ref={inputRef}
-            type="text"
-            value={draft}
-            maxLength={maxLength}
-            placeholder={placeholder}
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={handleKeyDown}
-            onBlur={commit}
-            aria-label={editLabel}
-            data-testid="inline-edit-input"
-            className={cn(
-              chipClassName,
-              "absolute inset-0 block h-auto w-full min-w-0 outline-none focus-visible:shadow-focus-ring",
-            )}
-            {...inputProps}
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={enterEditMode}
-            disabled={disabled}
-            aria-label={editLabel}
-            data-testid="inline-edit-trigger"
-            className={cn(
-              chipClassName,
-              "absolute inset-0 h-auto w-full cursor-text whitespace-nowrap focus-visible:shadow-focus-ring focus-visible:outline-none",
-              !disabled &&
-                "hover:border-neutral-alphas-500 hover:bg-neutral-alphas-50 active:border-neutral-alphas-500 active:bg-neutral-alphas-50",
-              showLeftIcon && iconAdornmentClassName,
-            )}
+          <Chip
+            asChild
+            dotted
+            variant="square"
+            size={size}
+            className="absolute inset-0 block h-auto w-full focus-within:shadow-focus-ring"
           >
-            <span className="min-w-0 truncate">{value}</span>
-          </button>
+            <span>
+              <input
+                ref={setInputRef}
+                type="text"
+                value={draft}
+                placeholder={placeholder}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                aria-label={editLabel}
+                data-testid="inline-edit-input"
+                className="block h-full w-full bg-transparent px-3 outline-none"
+                {...inputProps}
+              />
+            </span>
+          </Chip>
+        ) : (
+          <Chip
+            dotted
+            variant="square"
+            size={size}
+            disabled={disabled}
+            leftIcon={leftIcon}
+            onClick={enterEditMode}
+            data-testid="inline-edit-trigger"
+            className="absolute inset-0 h-auto w-full cursor-text"
+          >
+            {value}
+          </Chip>
         )}
       </span>
     );

--- a/src/components/InlineEdit/InlineEdit.tsx
+++ b/src/components/InlineEdit/InlineEdit.tsx
@@ -1,0 +1,198 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Height of the inline edit field in pixels. */
+export type InlineEditSize = "32" | "40";
+
+export interface InlineEditProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "value" | "defaultValue" | "size" | "onChange" | "onBlur" | "onKeyDown"
+  > {
+  /** Current value displayed in the chip and used as the starting draft when editing. */
+  value: string;
+  /** Called with the trimmed draft when the user commits an edit (Enter or blur). */
+  onCommit: (value: string) => void;
+  /** Called when the user cancels an edit with Escape. */
+  onCancel?: () => void;
+  /** Height of the field in pixels. @default "40" */
+  size?: InlineEditSize;
+  /** Whether the field is disabled — prevents entering edit mode. @default false */
+  disabled?: boolean;
+  /** Maximum length of the input value when editing. */
+  maxLength?: number;
+  /** Accessible label for the edit affordance. @default "Edit" */
+  editLabel?: string;
+  /** Icon rendered before the value in display mode. Hidden when editing. */
+  leftIcon?: React.ReactNode;
+  /** Additional class name applied to the root element. */
+  className?: string;
+}
+
+const SIZE_CLASSES: Record<InlineEditSize, string> = {
+  "32": "h-8",
+  "40": "h-10",
+};
+
+/**
+ * A chip-styled inline edit field. Renders as a dashed-border button that
+ * swaps to a text input on click, allowing the value to be edited in place.
+ *
+ * Enter and blur commit the draft via `onCommit`. Escape reverts to `value`
+ * and calls `onCancel`. Empty drafts are rejected and revert to `value`.
+ *
+ * @example
+ * ```tsx
+ * const [name, setName] = useState("New folder");
+ * <InlineEdit value={name} onCommit={setName} />
+ * ```
+ */
+export const InlineEdit = React.forwardRef<HTMLInputElement, InlineEditProps>(
+  (
+    {
+      value,
+      onCommit,
+      onCancel,
+      size = "40",
+      disabled = false,
+      maxLength,
+      editLabel = "Edit",
+      leftIcon,
+      className,
+      placeholder,
+      ...inputProps
+    },
+    ref,
+  ) => {
+    const [isEditing, setIsEditing] = React.useState(false);
+    const [draft, setDraft] = React.useState(value);
+    const inputRef = React.useRef<HTMLInputElement>(null);
+
+    React.useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+    React.useEffect(() => {
+      if (!isEditing) {
+        setDraft(value);
+      }
+    }, [value, isEditing]);
+
+    const enterEditMode = () => {
+      if (disabled) return;
+      setDraft(value);
+      setIsEditing(true);
+    };
+
+    React.useEffect(() => {
+      if (!isEditing) return;
+      const input = inputRef.current;
+      if (!input) return;
+      input.focus();
+      input.select();
+    }, [isEditing]);
+
+    const exitEditMode = () => {
+      setIsEditing(false);
+    };
+
+    const commit = () => {
+      const trimmed = draft.trim();
+      if (trimmed.length === 0 || trimmed === value) {
+        setDraft(value);
+        exitEditMode();
+        return;
+      }
+      onCommit(trimmed);
+      exitEditMode();
+    };
+
+    const cancel = () => {
+      setDraft(value);
+      exitEditMode();
+      onCancel?.();
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        commit();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        cancel();
+      }
+    };
+
+    const showLeftIcon = Boolean(leftIcon) && !isEditing;
+    const chipClassName = cn(
+      "typography-semibold-body-sm inline-flex items-center rounded-xs border border-dashed border-border-primary bg-transparent px-3 text-content-primary motion-safe:transition-colors motion-safe:duration-150",
+      SIZE_CLASSES[size],
+      disabled && "pointer-events-none opacity-50",
+    );
+    const iconAdornmentClassName = "pl-9";
+
+    const sizerText = (isEditing ? draft : value) || placeholder || " ";
+
+    return (
+      <span
+        data-testid="inline-edit"
+        className={cn("relative inline-block align-middle", className)}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            chipClassName,
+            "invisible block whitespace-pre",
+            showLeftIcon && iconAdornmentClassName,
+          )}
+        >
+          {sizerText}
+        </span>
+        {showLeftIcon && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-content-primary"
+          >
+            <span className="flex size-4 shrink-0 items-center justify-center">{leftIcon}</span>
+          </span>
+        )}
+        {isEditing ? (
+          <input
+            ref={inputRef}
+            type="text"
+            value={draft}
+            maxLength={maxLength}
+            placeholder={placeholder}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={commit}
+            aria-label={editLabel}
+            data-testid="inline-edit-input"
+            className={cn(
+              chipClassName,
+              "absolute inset-0 block h-auto w-full min-w-0 outline-none focus-visible:shadow-focus-ring",
+            )}
+            {...inputProps}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={enterEditMode}
+            disabled={disabled}
+            aria-label={`${editLabel}: ${value}`}
+            data-testid="inline-edit-trigger"
+            className={cn(
+              chipClassName,
+              "absolute inset-0 h-auto w-full cursor-text whitespace-nowrap focus-visible:shadow-focus-ring focus-visible:outline-none",
+              !disabled &&
+                "hover:border-neutral-alphas-500 hover:bg-neutral-alphas-50 active:border-neutral-alphas-500 active:bg-neutral-alphas-50",
+              showLeftIcon && iconAdornmentClassName,
+            )}
+          >
+            <span className="min-w-0 truncate">{value}</span>
+          </button>
+        )}
+      </span>
+    );
+  },
+);
+
+InlineEdit.displayName = "InlineEdit";

--- a/src/components/InlineEdit/InlineEdit.tsx
+++ b/src/components/InlineEdit/InlineEdit.tsx
@@ -41,6 +41,9 @@ const SIZE_CLASSES: Record<InlineEditSize, string> = {
  * Enter and blur commit the draft via `onCommit`. Escape reverts to `value`
  * and calls `onCancel`. Empty drafts are rejected and revert to `value`.
  *
+ * The forwarded ref points at the underlying `<input>` and is only populated
+ * while the field is in edit mode — it resolves to `null` in display mode.
+ *
  * @example
  * ```tsx
  * const [name, setName] = useState("New folder");
@@ -177,7 +180,7 @@ export const InlineEdit = React.forwardRef<HTMLInputElement, InlineEditProps>(
             type="button"
             onClick={enterEditMode}
             disabled={disabled}
-            aria-label={`${editLabel}: ${value}`}
+            aria-label={editLabel}
             data-testid="inline-edit-trigger"
             className={cn(
               chipClassName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,6 +501,11 @@ export {
   InfoBoxContent,
   InfoBoxTrigger,
 } from "./components/InfoBox/InfoBox";
+export type {
+  InlineEditProps,
+  InlineEditSize,
+} from "./components/InlineEdit/InlineEdit";
+export { InlineEdit } from "./components/InlineEdit/InlineEdit";
 export type { LoaderProps } from "./components/Loader/Loader";
 export { Loader } from "./components/Loader/Loader";
 export type { LogoColor, LogoProps, LogoVariant } from "./components/Logo/Logo";


### PR DESCRIPTION
- Adds `InlineEdit`: a chip-styled inline editor that swaps between a static label and a text input on click. Enter and blur commit the draft via `onCommit`; Escape reverts and calls `onCancel`. Optional `leftIcon` shows in display mode only (icon space is reclaimed in edit mode).
- Adds a `dotted` variant to `Chip` for dashed-border add/create affordances, with matching hover/active states.
- Stories, tests (axe + interaction + API), exports in `src/index.ts`, and an `App.tsx` demo entry.

Figma: `Fanvue-Library` nodes [17354-271](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17354-271) (default) / [17354-265](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17354-265) (hover).