### PR TITLE
feat(Logo): add size prop for proportional resizing

### DIFF
--- a/src/components/Logo/Logo.stories.tsx
+++ b/src/components/Logo/Logo.stories.tsx
@@ -21,6 +21,10 @@ const meta = {
       control: "select",
       options: ["fullColour", "decolour", "whiteAlways", "blackAlways"],
     },
+    size: {
+      control: "select",
+      options: ["16", "20", "24", "32", "40", "48", "64"],
+    },
   },
 } satisfies Meta<typeof Logo>;
 
@@ -149,4 +153,18 @@ export const PortraitBlackAlways: Story = {
     variant: "portrait",
     color: "blackAlways",
   },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-6">
+      <Logo size="16" />
+      <Logo size="20" />
+      <Logo size="24" />
+      <Logo size="32" />
+      <Logo size="40" />
+      <Logo size="48" />
+      <Logo size="64" />
+    </div>
+  ),
 };

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -50,6 +50,27 @@ describe("Logo", () => {
       expect(text).toBeInTheDocument();
     });
 
+    it("applies size class to both icon and wordmark", () => {
+      const { container } = render(<Logo variant="full" size="48" />);
+      const icon = container.querySelector('[data-testid="logo-icon"]');
+      const wordmark = container.querySelector('[data-testid="logo-wordmark"]');
+
+      expect(icon).toHaveClass("h-12");
+      expect(wordmark).toHaveClass("h-12");
+    });
+
+    it("defaults to size 32 for full variant", () => {
+      const { container } = render(<Logo />);
+      const icon = container.querySelector('[data-testid="logo-icon"]');
+      expect(icon).toHaveClass("h-8");
+    });
+
+    it("defaults to size 40 for icon variant", () => {
+      const { container } = render(<Logo variant="icon" />);
+      const icon = container.querySelector('[data-testid="logo-icon"]');
+      expect(icon).toHaveClass("h-10");
+    });
+
     it("renders portrait type with both icon and wordmark in column", () => {
       const { container } = render(<Logo variant="portrait" />);
       const logo = container.querySelector('[data-testid="logo"]');

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -54,12 +54,26 @@ const getLogoColors = (color: LogoColor, variant: LogoVariant) => {
 export type LogoVariant = "full" | "icon" | "wordmark" | "portrait";
 /** Colour scheme of the logo. */
 export type LogoColor = "fullColour" | "decolour" | "whiteAlways" | "blackAlways";
+/** Height of the logo in pixels. Both icon and wordmark scale proportionally. */
+export type LogoSize = "16" | "20" | "24" | "32" | "40" | "48" | "64";
+
+const sizeClasses: Record<LogoSize, string> = {
+  "16": "h-4",
+  "20": "h-5",
+  "24": "h-6",
+  "32": "h-8",
+  "40": "h-10",
+  "48": "h-12",
+  "64": "h-16",
+};
 
 export interface LogoProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Layout variant of the logo. @default "full" */
   variant?: LogoVariant;
   /** Colour scheme of the logo. @default "fullColour" */
   color?: LogoColor;
+  /** Height of the logo in pixels. @default "32" (or "40" when `variant="icon"`) */
+  size?: LogoSize;
   /**
    * Accessible label for the logo. Required when `type` is `"icon"` and
    * the logo is used inside interactive contexts (links, buttons).
@@ -72,8 +86,6 @@ export interface LogoProps extends React.HTMLAttributes<HTMLDivElement> {
 const WordmarkSVG = ({ className }: { className?: string }) => {
   return (
     <svg
-      width="128"
-      height="30"
       viewBox="0 0 128 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -99,10 +111,11 @@ const WordmarkSVG = ({ className }: { className?: string }) => {
  * ```
  */
 export const Logo = React.forwardRef<HTMLDivElement, LogoProps>(
-  ({ className, variant = "full", color = "fullColour", ...props }, ref) => {
+  ({ className, variant = "full", color = "fullColour", size, ...props }, ref) => {
     const colors = getLogoColors(color, variant);
     const showIcon = variant === "full" || variant === "icon" || variant === "portrait";
     const showWordmark = variant === "full" || variant === "wordmark" || variant === "portrait";
+    const sizeClass = sizeClasses[size ?? (variant === "icon" ? "40" : "32")];
 
     // When aria-label is provided, add role="img" for proper accessibility
     const ariaProps = props["aria-label"] ? { role: "img" as const } : {};
@@ -125,7 +138,7 @@ export const Logo = React.forwardRef<HTMLDivElement, LogoProps>(
             viewBox="0 0 39 39"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-            className={cn("shrink-0", variant === "icon" ? "h-10 w-10" : "h-8 w-8")}
+            className={cn("w-auto shrink-0", sizeClass)}
             aria-hidden="true"
             data-testid="logo-icon"
           >
@@ -143,7 +156,7 @@ export const Logo = React.forwardRef<HTMLDivElement, LogoProps>(
             />
           </svg>
         )}
-        {showWordmark && <WordmarkSVG className={cn(colors.textClass)} />}
+        {showWordmark && <WordmarkSVG className={cn("w-auto", sizeClass, colors.textClass)} />}
       </div>
     );
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -503,7 +503,7 @@ export {
 } from "./components/InfoBox/InfoBox";
 export type { LoaderProps } from "./components/Loader/Loader";
 export { Loader } from "./components/Loader/Loader";
-export type { LogoColor, LogoProps, LogoVariant } from "./components/Logo/Logo";
+export type { LogoColor, LogoProps, LogoSize, LogoVariant } from "./components/Logo/Logo";
 export { Logo } from "./components/Logo/Logo";
 export type {
   MobileStepperPosition,


### PR DESCRIPTION
## Summary
- Adds a typed `size` prop to `Logo` (`"24" | "32" | "40" | "48" | "64"`) so both the icon and wordmark SVGs scale together proportionally via their viewBox aspect ratios.
- Matches the existing token convention used by `Chip` and `Count` (stringified pixel heights).
- Default is `"32"` for all variants except `variant="icon"`, which defaults to `"40"` to preserve the prior visual size.
- Exposes `LogoSize` from the package entry point so consumers wrapping `Logo` can type their own props.

### Usage
```tsx
<Logo />                                  // 32px
<Logo size="48" />                        // 48px
<Logo variant="icon" />                   // 40px (preserved)
<Logo variant="portrait" size="64" />     // 64px stack
```

### Why a `size` prop rather than `className`
The wrapper's `className` can't reach the inner SVGs cleanly, and `flex-col` (portrait) breaks `h-full w-auto` patterns. A typed token set is more predictable for a package consumed downstream and stays consistent with the rest of the library.

## Test plan
- [x] Unit tests cover size class application on both SVGs and the variant-aware default
- [x] Storybook `Sizes` story renders the full scale
- [x] `pnpm tsc --noEmit` clean
- [x] Visual check in storybook (`pnpm storybook`)
- [x] Verify no visible regression in the `App.tsx` Logo showcase block

🤖 Generated with [Claude Code](https://claude.com/claude-code)