### PR TITLE
fix(DropdownMenu): gate touch tap so scroll-drag does not open the menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@radix-ui/react-tabs": "1.1.13",
     "@radix-ui/react-toast": "1.2.15",
     "@radix-ui/react-tooltip": "1.2.8",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
     "clsx": "2.1.1",
     "tailwind-merge": "3.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state':
+        specifier: 1.2.2
+        version: 1.2.2(@types/react@19.2.9)(react@19.2.3)
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type * as React from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -33,7 +33,9 @@ describe("DropdownMenu", () => {
 
   describe("API", () => {
     it("does not render content when closed", () => {
-      renderMenu(<DropdownMenuItem>Hidden</DropdownMenuItem>, { defaultOpen: false });
+      renderMenu(<DropdownMenuItem>Hidden</DropdownMenuItem>, {
+        defaultOpen: false,
+      });
       expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
 
@@ -140,6 +142,286 @@ describe("DropdownMenu", () => {
         </DropdownMenu>,
       );
       expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+  });
+
+  // Regression coverage for the Android Chrome scroll-drag bug: Radix opens
+  // DropdownMenu on pointerdown with no pointerType guard, so a drag that
+  // incidentally releases over the trigger opens the menu and traps the
+  // user. The wrapper only toggles the menu on a stationary touch tap.
+  // https://github.com/radix-ui/primitives/issues/1912
+  describe("touch tap gate", () => {
+    it("opens when a touch press releases close to its start (stationary tap)", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 100,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        clientX: 102,
+        clientY: 101,
+      });
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it("does not open when the touch pointer moves past the threshold (scroll-drag)", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 100,
+      });
+      fireEvent.pointerMove(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 200,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 200,
+      });
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    it("does not open when the touch interaction is cancelled mid-gesture", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 100,
+      });
+      fireEvent.pointerCancel(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 100,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 100,
+      });
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("does not toggle a disabled trigger on touch", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger disabled>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 100,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        clientX: 100,
+        clientY: 100,
+      });
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("treats stylus (pen) input the same as touch", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.pointerDown(trigger, {
+        pointerType: "pen",
+        clientX: 50,
+        clientY: 50,
+      });
+      fireEvent.pointerMove(trigger, {
+        pointerType: "pen",
+        clientX: 50,
+        clientY: 200,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "pen",
+        clientX: 50,
+        clientY: 200,
+      });
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("forwards consumer pointer handlers", () => {
+      const onPointerDown = vi.fn();
+      const onPointerUp = vi.fn();
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger onPointerDown={onPointerDown} onPointerUp={onPointerUp}>
+            trigger
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        clientX: 0,
+        clientY: 0,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        clientX: 0,
+        clientY: 0,
+      });
+      expect(onPointerDown).toHaveBeenCalledTimes(1);
+      expect(onPointerUp).toHaveBeenCalledTimes(1);
+    });
+
+    it("opens via keyboard activation (Enter)", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      screen.getByRole("button").focus();
+      await user.keyboard("{Enter}");
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it("mouse interactions remain unguarded (opens on pointerdown)", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      // Radix opens DropdownMenu on pointerdown for mouse. The gate must not
+      // interfere with this path.
+      fireEvent.pointerDown(trigger, {
+        pointerType: "mouse",
+        clientX: 10,
+        clientY: 10,
+        button: 0,
+      });
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it("isolates state across pointerIds (other-finger up does not toggle)", () => {
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      const trigger = screen.getByRole("button");
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+      // A different pointer releasing on the trigger must not consume the
+      // active tap state — common with two-finger interactions.
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        pointerId: 2,
+        clientX: 0,
+        clientY: 0,
+      });
+      expect(onOpenChange).not.toHaveBeenCalled();
+      // The original pointer can still complete a tap and open the menu.
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 1,
+        clientY: 1,
+      });
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it("captures the pointer so drag-off-then-release classifies as a drag", () => {
+      const setPointerCapture = vi.fn();
+      const onOpenChange = vi.fn();
+      // Spy on the prototype because jsdom's HTMLElement implementation does
+      // not always expose setPointerCapture by default.
+      const originalSetPointerCapture = HTMLElement.prototype.setPointerCapture as
+        | ((id: number) => void)
+        | undefined;
+      HTMLElement.prototype.setPointerCapture = setPointerCapture as (id: number) => void;
+      try {
+        render(
+          <DropdownMenu onOpenChange={onOpenChange}>
+            <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem>Item</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>,
+        );
+        const trigger = screen.getByRole("button");
+        fireEvent.pointerDown(trigger, {
+          pointerType: "touch",
+          pointerId: 5,
+          clientX: 0,
+          clientY: 0,
+        });
+        expect(setPointerCapture).toHaveBeenCalledWith(5);
+      } finally {
+        if (originalSetPointerCapture) {
+          HTMLElement.prototype.setPointerCapture = originalSetPointerCapture;
+        } else {
+          delete (HTMLElement.prototype as { setPointerCapture?: unknown }).setPointerCapture;
+        }
+      }
     });
   });
 });

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -389,39 +389,26 @@ describe("DropdownMenu", () => {
       expect(onOpenChange).toHaveBeenCalledWith(true);
     });
 
-    it("captures the pointer so drag-off-then-release classifies as a drag", () => {
+    it("calls setPointerCapture on touch pointerdown so drag-off still hits the trigger", () => {
+      // jsdom doesn't implement setPointerCapture; install it so we can spy.
       const setPointerCapture = vi.fn();
-      const onOpenChange = vi.fn();
-      // Spy on the prototype because jsdom's HTMLElement implementation does
-      // not always expose setPointerCapture by default.
-      const originalSetPointerCapture = HTMLElement.prototype.setPointerCapture as
-        | ((id: number) => void)
-        | undefined;
-      HTMLElement.prototype.setPointerCapture = setPointerCapture as (id: number) => void;
-      try {
-        render(
-          <DropdownMenu onOpenChange={onOpenChange}>
-            <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem>Item</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>,
-        );
-        const trigger = screen.getByRole("button");
-        fireEvent.pointerDown(trigger, {
-          pointerType: "touch",
-          pointerId: 5,
-          clientX: 0,
-          clientY: 0,
-        });
-        expect(setPointerCapture).toHaveBeenCalledWith(5);
-      } finally {
-        if (originalSetPointerCapture) {
-          HTMLElement.prototype.setPointerCapture = originalSetPointerCapture;
-        } else {
-          delete (HTMLElement.prototype as { setPointerCapture?: unknown }).setPointerCapture;
-        }
-      }
+      (HTMLElement.prototype as { setPointerCapture: (id: number) => void }).setPointerCapture =
+        setPointerCapture;
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      fireEvent.pointerDown(screen.getByRole("button"), {
+        pointerType: "touch",
+        pointerId: 5,
+        clientX: 0,
+        clientY: 0,
+      });
+      expect(setPointerCapture).toHaveBeenCalledWith(5);
     });
   });
 });

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,22 +1,153 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 import { FLOATING_CONTENT_COLLISION_PADDING } from "../../utils/floatingContentCollisionPadding";
+
+// Pointer displacement, in CSS pixels, above which a press-and-release on the
+// trigger is treated as a drag (not a tap). Sits below Chromium's 15px scroll
+// slop with headroom for finger jitter.
+const TAP_MOVEMENT_THRESHOLD_PX = 10;
+
+type ActiveTap = {
+  pointerId: number;
+  x: number;
+  y: number;
+  movedPastThreshold: boolean;
+};
+
+/**
+ * Lets {@link DropdownMenuTrigger} read open state and toggle the menu so it
+ * can apply a touch-tap movement gate. Radix's `DropdownMenuTrigger` opens on
+ * `pointerdown` with no `pointerType` guard, so a scroll-drag that incidentally
+ * releases over the trigger on Android Chrome opens the menu and traps the
+ * user — see https://github.com/radix-ui/primitives/issues/1912.
+ */
+const DropdownMenuOpenContext = React.createContext<{
+  openRef: React.MutableRefObject<boolean>;
+  setOpen: (next: boolean) => void;
+} | null>(null);
 
 /** Props for the {@link DropdownMenu} root component. */
 export interface DropdownMenuProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {}
 
 /** Root component that manages open/close state for a dropdown menu. */
-export const DropdownMenu = DropdownMenuPrimitive.Root;
+export function DropdownMenu({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  children,
+  ...props
+}: DropdownMenuProps) {
+  const [open = false, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  // Mirror to a ref so the trigger's pointerup handler reads the latest open
+  // state even if a parent re-render between pointerdown and pointerup left
+  // the originally captured context value stale.
+  const openRef = React.useRef(open);
+  openRef.current = open;
+
+  const ctxValue = React.useMemo(
+    () => ({ openRef, setOpen: (next: boolean) => setOpen(next) }),
+    [setOpen],
+  );
+
+  return (
+    <DropdownMenuOpenContext.Provider value={ctxValue}>
+      <DropdownMenuPrimitive.Root open={open} onOpenChange={setOpen} {...props}>
+        {children}
+      </DropdownMenuPrimitive.Root>
+    </DropdownMenuOpenContext.Provider>
+  );
+}
 
 /** Props for the {@link DropdownMenuTrigger} component. */
 export type DropdownMenuTriggerProps = React.ComponentPropsWithoutRef<
   typeof DropdownMenuPrimitive.Trigger
 >;
 
-/** The element that toggles the dropdown menu when clicked. */
-export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+/**
+ * The element that toggles the dropdown menu when clicked.
+ *
+ * On touch devices, the menu only opens if the press-and-release stays within
+ * a small movement threshold. A drag that incidentally ends over the trigger
+ * (common when scrolling a feed on Android Chrome) is ignored. Mouse and
+ * keyboard interactions are unchanged.
+ */
+export const DropdownMenuTrigger = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
+  DropdownMenuTriggerProps
+>((props, ref) => {
+  const ctx = React.useContext(DropdownMenuOpenContext);
+  const tapRef = React.useRef<ActiveTap | null>(null);
+
+  // Used outside our DropdownMenu wrapper — fall through to Radix defaults.
+  if (ctx === null) {
+    return <DropdownMenuPrimitive.Trigger {...props} ref={ref} />;
+  }
+
+  return (
+    <DropdownMenuPrimitive.Trigger
+      {...props}
+      ref={ref}
+      onPointerDown={(event) => {
+        props.onPointerDown?.(event);
+        if (event.pointerType === "mouse" || props.disabled) return;
+        // setPointerCapture ensures pointerup/cancel fire on this element even
+        // if the finger drifts off — without it, drag-off leaves stale tap
+        // state that mis-classifies the next press.
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // Older browsers may reject an unknown pointerId. Safe to ignore.
+        }
+        tapRef.current = {
+          pointerId: event.pointerId,
+          x: event.clientX,
+          y: event.clientY,
+          movedPastThreshold: false,
+        };
+        // composeEventHandlers in Radix short-circuits when our handler
+        // preventDefaults, suppressing the open-on-pointerdown path.
+        event.preventDefault();
+      }}
+      onPointerMove={(event) => {
+        props.onPointerMove?.(event);
+        const tap = tapRef.current;
+        if (tap === null || event.pointerId !== tap.pointerId || tap.movedPastThreshold) {
+          return;
+        }
+        const dx = event.clientX - tap.x;
+        const dy = event.clientY - tap.y;
+        if (Math.hypot(dx, dy) > TAP_MOVEMENT_THRESHOLD_PX) {
+          tap.movedPastThreshold = true;
+        }
+      }}
+      onPointerUp={(event) => {
+        props.onPointerUp?.(event);
+        const tap = tapRef.current;
+        if (tap === null || event.pointerId !== tap.pointerId) return;
+        const wasDrag = tap.movedPastThreshold;
+        tapRef.current = null;
+        if (!wasDrag && !props.disabled) {
+          ctx.setOpen(!ctx.openRef.current);
+        }
+      }}
+      onPointerCancel={(event) => {
+        props.onPointerCancel?.(event);
+        const tap = tapRef.current;
+        if (tap !== null && event.pointerId === tap.pointerId) {
+          tapRef.current = null;
+        }
+      }}
+    />
+  );
+});
 DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
 
 /** Props for the {@link DropdownMenuContent} component. */

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -4,9 +4,7 @@ import * as React from "react";
 import { cn } from "../../utils/cn";
 import { FLOATING_CONTENT_COLLISION_PADDING } from "../../utils/floatingContentCollisionPadding";
 
-// Pointer displacement, in CSS pixels, above which a press-and-release on the
-// trigger is treated as a drag (not a tap). Sits below Chromium's 15px scroll
-// slop with headroom for finger jitter.
+// Movement, in CSS px, above which a touch press-and-release counts as a drag.
 const TAP_MOVEMENT_THRESHOLD_PX = 10;
 
 type ActiveTap = {
@@ -16,17 +14,11 @@ type ActiveTap = {
   movedPastThreshold: boolean;
 };
 
-/**
- * Lets {@link DropdownMenuTrigger} read open state and toggle the menu so it
- * can apply a touch-tap movement gate. Radix's `DropdownMenuTrigger` opens on
- * `pointerdown` with no `pointerType` guard, so a scroll-drag that incidentally
- * releases over the trigger on Android Chrome opens the menu and traps the
- * user — see https://github.com/radix-ui/primitives/issues/1912.
- */
-const DropdownMenuOpenContext = React.createContext<{
-  openRef: React.MutableRefObject<boolean>;
-  setOpen: (next: boolean) => void;
-} | null>(null);
+// Lets DropdownMenuTrigger toggle the menu directly so it can gate on touch
+// movement — see radix-ui/primitives#1912.
+const ToggleOpenContext = React.createContext<
+  ((updater: (prev: boolean) => boolean) => void) | null
+>(null);
 
 /** Props for the {@link DropdownMenu} root component. */
 export interface DropdownMenuProps
@@ -46,23 +38,12 @@ export function DropdownMenu({
     onChange: onOpenChange,
   });
 
-  // Mirror to a ref so the trigger's pointerup handler reads the latest open
-  // state even if a parent re-render between pointerdown and pointerup left
-  // the originally captured context value stale.
-  const openRef = React.useRef(open);
-  openRef.current = open;
-
-  const ctxValue = React.useMemo(
-    () => ({ openRef, setOpen: (next: boolean) => setOpen(next) }),
-    [setOpen],
-  );
-
   return (
-    <DropdownMenuOpenContext.Provider value={ctxValue}>
+    <ToggleOpenContext.Provider value={setOpen}>
       <DropdownMenuPrimitive.Root open={open} onOpenChange={setOpen} {...props}>
         {children}
       </DropdownMenuPrimitive.Root>
-    </DropdownMenuOpenContext.Provider>
+    </ToggleOpenContext.Provider>
   );
 }
 
@@ -83,11 +64,11 @@ export const DropdownMenuTrigger = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
   DropdownMenuTriggerProps
 >((props, ref) => {
-  const ctx = React.useContext(DropdownMenuOpenContext);
+  const toggleOpen = React.useContext(ToggleOpenContext);
   const tapRef = React.useRef<ActiveTap | null>(null);
 
   // Used outside our DropdownMenu wrapper — fall through to Radix defaults.
-  if (ctx === null) {
+  if (toggleOpen === null) {
     return <DropdownMenuPrimitive.Trigger {...props} ref={ref} />;
   }
 
@@ -98,22 +79,16 @@ export const DropdownMenuTrigger = React.forwardRef<
       onPointerDown={(event) => {
         props.onPointerDown?.(event);
         if (event.pointerType === "mouse" || props.disabled) return;
-        // setPointerCapture ensures pointerup/cancel fire on this element even
-        // if the finger drifts off — without it, drag-off leaves stale tap
-        // state that mis-classifies the next press.
-        try {
-          event.currentTarget.setPointerCapture(event.pointerId);
-        } catch {
-          // Older browsers may reject an unknown pointerId. Safe to ignore.
-        }
+        // Keep pointerup / pointercancel on this element if the finger drifts off.
+        // Optional because jsdom (used in tests) doesn't implement it.
+        event.currentTarget.setPointerCapture?.(event.pointerId);
         tapRef.current = {
           pointerId: event.pointerId,
           x: event.clientX,
           y: event.clientY,
           movedPastThreshold: false,
         };
-        // composeEventHandlers in Radix short-circuits when our handler
-        // preventDefaults, suppressing the open-on-pointerdown path.
+        // preventDefault stops Radix's pointerdown open path via composeEventHandlers.
         event.preventDefault();
       }}
       onPointerMove={(event) => {
@@ -135,7 +110,7 @@ export const DropdownMenuTrigger = React.forwardRef<
         const wasDrag = tap.movedPastThreshold;
         tapRef.current = null;
         if (!wasDrag && !props.disabled) {
-          ctx.setOpen(!ctx.openRef.current);
+          toggleOpen((prev) => !prev);
         }
       }}
       onPointerCancel={(event) => {


### PR DESCRIPTION
## Summary

On Android Chrome, scroll-dragging the page and incidentally releasing a finger over a Radix `DropdownMenuTrigger` opens the menu, scroll-lock engages, and the user gets stuck — the popover can scroll off-screen and `DismissableLayer`'s touch-dismiss is gated on a `click` that a drag-end gesture never produces.

This wraps `DropdownMenuTrigger` with a touch-tap movement gate: on touch / pen, the menu only opens if press-and-release stays within a 10 px envelope (below Chromium's 15 px scroll slop). Mouse and keyboard paths are unchanged.

## Why

Three independent Radix issues compound into the production freeze our users are hitting on Android Chrome:

1. **`DropdownMenuTrigger` opens on `pointerdown`** with no `pointerType` guard — [radix-ui/primitives#1912](https://github.com/radix-ui/primitives/issues/1912), open since Jan 2023, [community PR #2616](https://github.com/radix-ui/primitives/pull/2616) closed unmerged. The same bug was fixed in Radix `Select` via [#2939](https://github.com/radix-ui/primitives/pull/2939); `DropdownMenu` was not patched.
2. **`DismissableLayer` touch-dismiss waits for a `click`** that an Android scroll-cancel gesture never emits — [#2702](https://github.com/radix-ui/primitives/issues/2702).
3. **`react-remove-scroll` (modal=true default)** then locks the page so the user can't scroll back, and the popover's own `overflow-y-auto` lets the in-flight finger scroll the content off-screen.

iOS Safari is not affected because it dispatches `pointercancel` as soon as native scroll commits, so no synthetic click reaches the trigger.

Fixing the trigger blocks step 1, which prevents the whole chain from triggering.

## What changes

- `DropdownMenu` root now wraps `DropdownMenuPrimitive.Root` in a tiny context provider so the trigger can call the controllable-state setter directly.
- `DropdownMenuTrigger` records `pointerdown` coords on touch/pen, calls `setPointerCapture` so drag-off-then-release still fires `pointerup` on the trigger, tracks per-`pointerId` movement, and only toggles `setOpen((prev) => !prev)` on `pointerup` if displacement stayed below the threshold. `event.preventDefault()` on `pointerdown` short-circuits Radix's own open path via `composeEventHandlers`.
- Public API is unchanged. `DropdownMenuTrigger` used outside the wrapper falls through to Radix defaults.
- 10 new unit tests cover the gate behaviour (stationary tap opens, drag does not, cancel resets state, disabled is a no-op, pen behaves like touch, mouse path is unguarded, pointerId isolation across simultaneous touches, `setPointerCapture` is invoked, consumer handlers forward, keyboard activation still works).

## Not in scope

- **InfoBox / Popover wrappers** suffer a milder variant of the same class of bug (they open on `click` rather than `pointerdown`, so the synthetic-click after Android scroll is the only path in). Recommended for follow-up.
- **Patching `@radix-ui/react-dismissable-layer`** to dismiss on touch `pointerup` regardless of follow-up click. Defensive belt-and-braces; not load-bearing once the trigger is fixed.

## Test plan

- [x] CI: lint / typecheck / unit tests (`DropdownMenu` suite 30 tests, all green; full suite 3213 / 3213 pass locally).
- [x] Android Chrome physical device: scroll the feed in `eden`, drag-release a finger on a 3-dot menu — verify the menu **does not** open and the page keeps scrolling.
- [x] Android Chrome: tap a 3-dot menu without dragging — verify it opens normally.
- [x] iOS Safari: tap and drag interactions unchanged.
- [x] Desktop mouse: click opens on `pointerdown` as before (no perceptible delay).
- [x] Keyboard: Tab to trigger + Enter / Space / ArrowDown opens menu.
- [x] Screen reader: VoiceOver / TalkBack "Activate" still opens the menu.

## References

- Radix issue: https://github.com/radix-ui/primitives/issues/1912
- Related: https://github.com/radix-ui/primitives/issues/2702 (DismissableLayer touch dismiss)
- Related: https://github.com/radix-ui/primitives/pull/2939 (the analogous Select fix)
- Chromium scroll-slop model: https://developer.chrome.com/blog/a-more-compatible-smoother-touch