### PR TITLE
fix(InfoBox,Dialog,Drawer): suppress click on Android scroll-drag-end

### DIFF
--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -224,6 +224,46 @@ describe("Dialog", () => {
       // After cycling through all focusable elements, focus should still be inside
       await user.tab();
       expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  // Defends against the Android Chrome synthetic-click that can land on a
+  // click-based Radix trigger at the end of a scroll-drag.
+  describe("touch tap gate", () => {
+    it("does not open on a drag-end synthetic click", () => {
+      render(
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button>Open</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Test</DialogTitle>
+            </DialogHeader>
+          </DialogContent>
+        </Dialog>,
+      );
+      const trigger = screen.getByRole("button", { name: "Open" });
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+      fireEvent.pointerMove(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 100,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 100,
+      });
+      fireEvent.click(trigger);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { useSuppressClickAfterDrag } from "../../utils/useSuppressClickAfterDrag";
 import { IconButton } from "../IconButton/IconButton";
 import { ArrowLeftIcon } from "../Icons/ArrowLeftIcon";
 import { CloseIcon } from "../Icons/CloseIcon";
@@ -21,8 +22,18 @@ export const Dialog = DialogPrimitive.Root;
 /** Props for the {@link DialogTrigger} component. */
 export type DialogTriggerProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>;
 
-/** The element that opens the dialog when clicked. */
-export const DialogTrigger = DialogPrimitive.Trigger;
+/**
+ * The element that opens the dialog when clicked.
+ *
+ * On touch / pen, a press-and-release that crosses a small movement threshold
+ * is treated as a drag and the resulting synthetic click is suppressed —
+ * defends against Android Chrome opening the dialog on a scroll-drag-end.
+ */
+export const DialogTrigger = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Trigger>,
+  DialogTriggerProps
+>((props, ref) => <DialogPrimitive.Trigger ref={ref} {...useSuppressClickAfterDrag(props)} />);
+DialogTrigger.displayName = "DialogTrigger";
 
 /** Convenience alias for Radix `Dialog.Close`. Closes the dialog when clicked. */
 export const DialogClose = DialogPrimitive.Close;

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -280,6 +280,35 @@ describe("Drawer", () => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
       expect(trigger).toHaveFocus();
+    });
+  });
+
+  // Defends against the Android Chrome synthetic-click that can land on a
+  // click-based Radix trigger at the end of a scroll-drag.
+  describe("touch tap gate", () => {
+    it("does not open on a drag-end synthetic click", () => {
+      renderDrawer();
+      const trigger = screen.getByRole("button", { name: "Open drawer" });
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+      fireEvent.pointerMove(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 100,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 100,
+      });
+      fireEvent.click(trigger);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,6 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { useSuppressClickAfterDrag } from "../../utils/useSuppressClickAfterDrag";
 import { IconButton } from "../IconButton/IconButton";
 import { CloseIcon } from "../Icons/CloseIcon";
 
@@ -35,7 +36,9 @@ export interface DrawerProps extends React.ComponentPropsWithoutRef<typeof Dialo
   overlay?: boolean;
 }
 
-const DrawerContext = React.createContext<{ overlay: boolean }>({ overlay: true });
+const DrawerContext = React.createContext<{ overlay: boolean }>({
+  overlay: true,
+});
 
 /**
  * Root component that manages open/close state for a drawer.
@@ -73,8 +76,17 @@ Drawer.displayName = "Drawer";
 /** Props for the {@link DrawerTrigger} component. */
 export type DrawerTriggerProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>;
 
-/** The element that opens the drawer when clicked. */
-export const DrawerTrigger = DialogPrimitive.Trigger;
+/**
+ * The element that opens the drawer when clicked.
+ *
+ * On touch / pen, a press-and-release that crosses a small movement threshold
+ * is treated as a drag and the resulting synthetic click is suppressed —
+ * defends against Android Chrome opening the drawer on a scroll-drag-end.
+ */
+export const DrawerTrigger = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Trigger>,
+  DrawerTriggerProps
+>((props, ref) => <DialogPrimitive.Trigger ref={ref} {...useSuppressClickAfterDrag(props)} />);
 DrawerTrigger.displayName = "DrawerTrigger";
 
 /** Props for the {@link DrawerClose} component. */
@@ -184,7 +196,14 @@ export const DrawerContent = React.forwardRef<
     const overlay = overlayProp ?? ctx.overlay;
     const isHorizontal = position === "left" || position === "right";
     const sizeClass = isHorizontal
-      ? ({ sm: "max-w-sm", md: "max-w-md", lg: "max-w-lg", full: "max-w-full" } as const)[size]
+      ? (
+          {
+            sm: "max-w-sm",
+            md: "max-w-md",
+            lg: "max-w-lg",
+            full: "max-w-full",
+          } as const
+        )[size]
       : (
           {
             sm: "max-h-[24rem]",
@@ -199,7 +218,10 @@ export const DrawerContent = React.forwardRef<
         {overlay && <DrawerOverlay {...overlayProps} />}
         <DialogPrimitive.Content
           ref={ref}
-          style={{ zIndex: "calc(var(--fanvue-ui-portal-z-index, 50) + 1)", ...style }}
+          style={{
+            zIndex: "calc(var(--fanvue-ui-portal-z-index, 50) + 1)",
+            ...style,
+          }}
           className={cn(
             "fixed flex flex-col bg-surface-secondary shadow-lg outline-none backdrop-blur-lg",
             "data-[state=closed]:animate-out data-[state=open]:animate-in",

--- a/src/components/InfoBox/InfoBox.test.tsx
+++ b/src/components/InfoBox/InfoBox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -127,6 +127,54 @@ describe("InfoBox", () => {
       okButton.focus();
       await user.keyboard("{Enter}");
       expect(handleClick).toHaveBeenCalledOnce();
+    });
+  });
+
+  // Defends against the Android Chrome synthetic-click that can land on a
+  // click-based Radix trigger at the end of a scroll-drag.
+  describe("touch tap gate", () => {
+    it("does not open on a drag-end synthetic click", () => {
+      renderInfoBox();
+      const trigger = screen.getByRole("button", { name: "Open" });
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      });
+      fireEvent.pointerMove(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 100,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 100,
+      });
+      fireEvent.click(trigger);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("opens on a stationary touch tap", async () => {
+      renderInfoBox();
+      const trigger = screen.getByRole("button", { name: "Open" });
+      fireEvent.pointerDown(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 5,
+        clientY: 5,
+      });
+      fireEvent.pointerUp(trigger, {
+        pointerType: "touch",
+        pointerId: 1,
+        clientX: 6,
+        clientY: 6,
+      });
+      fireEvent.click(trigger);
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
     });
   });
 

--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -2,6 +2,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 import { FLOATING_CONTENT_COLLISION_PADDING } from "../../utils/floatingContentCollisionPadding";
+import { useSuppressClickAfterDrag } from "../../utils/useSuppressClickAfterDrag";
 import { Button } from "../Button/Button";
 
 /** Props for the {@link InfoBox} root component. */
@@ -17,8 +18,18 @@ export const InfoBox = PopoverPrimitive.Root;
 /** Props for the {@link InfoBoxTrigger} component. */
 export type InfoBoxTriggerProps = React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger>;
 
-/** The element that triggers the info box on click. */
-export const InfoBoxTrigger = PopoverPrimitive.Trigger;
+/**
+ * The element that triggers the info box on click.
+ *
+ * On touch / pen, a press-and-release that crosses a small movement threshold
+ * is treated as a drag and the resulting synthetic click is suppressed —
+ * defends against Android Chrome opening the popover on a scroll-drag-end.
+ */
+export const InfoBoxTrigger = React.forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Trigger>,
+  InfoBoxTriggerProps
+>((props, ref) => <PopoverPrimitive.Trigger ref={ref} {...useSuppressClickAfterDrag(props)} />);
+InfoBoxTrigger.displayName = "InfoBoxTrigger";
 
 /** Action button with a label and click handler. */
 interface InfoBoxButtonAction {

--- a/src/utils/useSuppressClickAfterDrag.test.tsx
+++ b/src/utils/useSuppressClickAfterDrag.test.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSuppressClickAfterDrag } from "./useSuppressClickAfterDrag";
+
+function Probe({ onClick }: { onClick: () => void }) {
+  const handlers = useSuppressClickAfterDrag({ onClick });
+  return (
+    <button type="button" {...handlers}>
+      probe
+    </button>
+  );
+}
+
+describe("useSuppressClickAfterDrag", () => {
+  it("fires onClick for a stationary touch tap", () => {
+    const onClick = vi.fn();
+    render(<Probe onClick={onClick} />);
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 10,
+      clientY: 10,
+    });
+    fireEvent.pointerUp(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 12,
+      clientY: 11,
+    });
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses onClick when the touch pointer moves past the threshold", () => {
+    const onClick = vi.fn();
+    render(<Probe onClick={onClick} />);
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerMove(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 100,
+    });
+    fireEvent.pointerUp(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 100,
+    });
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("fires onClick for a mouse click regardless of pointermove distance", () => {
+    const onClick = vi.fn();
+    render(<Probe onClick={onClick} />);
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button, {
+      pointerType: "mouse",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerMove(button, {
+      pointerType: "mouse",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 200,
+    });
+    fireEvent.pointerUp(button, {
+      pointerType: "mouse",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 200,
+    });
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats stylus (pen) input the same as touch", () => {
+    const onClick = vi.fn();
+    render(<Probe onClick={onClick} />);
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button, {
+      pointerType: "pen",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerMove(button, {
+      pointerType: "pen",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 50,
+    });
+    fireEvent.pointerUp(button, {
+      pointerType: "pen",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 50,
+    });
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("resets state on pointercancel so the next gesture is independent", () => {
+    const onClick = vi.fn();
+    render(<Probe onClick={onClick} />);
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerMove(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 100,
+    });
+    fireEvent.pointerCancel(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 100,
+    });
+    // Cancelled gesture's stray click should not suppress because tap state was cleared.
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates state across pointerIds (other-finger move does not count)", () => {
+    const onClick = vi.fn();
+    render(<Probe onClick={onClick} />);
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+    });
+    // A second finger drags past the threshold — must not influence finger 1's classification.
+    fireEvent.pointerMove(button, {
+      pointerType: "touch",
+      pointerId: 2,
+      clientX: 0,
+      clientY: 100,
+    });
+    fireEvent.pointerUp(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 1,
+      clientY: 1,
+    });
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards consumer pointer handlers", () => {
+    const onPointerDown = vi.fn();
+    const onPointerMove = vi.fn();
+    const onPointerCancel = vi.fn();
+    function Wrapper() {
+      const handlers = useSuppressClickAfterDrag({
+        onPointerDown,
+        onPointerMove,
+        onPointerCancel,
+        onClick: () => {},
+      });
+      return (
+        <button type="button" {...handlers}>
+          probe
+        </button>
+      );
+    }
+    render(<Wrapper />);
+    const button = screen.getByRole("button");
+    fireEvent.pointerDown(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerMove(button, {
+      pointerType: "touch",
+      pointerId: 1,
+      clientX: 1,
+      clientY: 1,
+    });
+    fireEvent.pointerCancel(button, { pointerType: "touch", pointerId: 1 });
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    expect(onPointerMove).toHaveBeenCalledTimes(1);
+    expect(onPointerCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/useSuppressClickAfterDrag.ts
+++ b/src/utils/useSuppressClickAfterDrag.ts
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+const TAP_MOVEMENT_THRESHOLD_PX = 10;
+
+type ActiveTap = {
+  pointerId: number;
+  x: number;
+  y: number;
+  movedPastThreshold: boolean;
+};
+
+type GatedHandlers = {
+  onPointerDown?: React.PointerEventHandler;
+  onPointerMove?: React.PointerEventHandler;
+  onPointerCancel?: React.PointerEventHandler;
+  onClick?: React.MouseEventHandler;
+};
+
+/**
+ * Composes the consumer's pointer/click handlers with a touch-drag tracker
+ * that suppresses the synthetic click an Android Chrome scroll-drag-end can
+ * dispatch on a click-based Radix trigger (Popover / Dialog / Drawer).
+ *
+ * On touch / pen input, if the press-and-release crosses a movement threshold,
+ * the subsequent `click` is preventDefault'd — short-circuiting Radix's own
+ * `onOpenToggle` via `composeEventHandlers` — and stopPropagation'd so it
+ * doesn't bubble to ancestors. Mouse input passes through unchanged because
+ * mouse never triggers the Android scroll-drag bug class.
+ *
+ * Related: radix-ui/primitives#1912 (DropdownMenu pointerdown variant) and
+ * #2702 (DismissableLayer touch dismiss). For the DropdownMenu pointerdown
+ * variant see `components/DropdownMenu/DropdownMenu.tsx`.
+ */
+export function useSuppressClickAfterDrag<P extends GatedHandlers>(props: P): P {
+  const tapRef = React.useRef<ActiveTap | null>(null);
+
+  return {
+    ...props,
+    onPointerDown(event) {
+      props.onPointerDown?.(event);
+      if (event.pointerType === "mouse") {
+        tapRef.current = null;
+        return;
+      }
+      // Keep pointermove on this element if the finger drifts off.
+      // Optional because jsdom (used in tests) doesn't implement it.
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      tapRef.current = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        movedPastThreshold: false,
+      };
+    },
+    onPointerMove(event) {
+      props.onPointerMove?.(event);
+      const tap = tapRef.current;
+      if (tap === null || event.pointerId !== tap.pointerId || tap.movedPastThreshold) return;
+      const dx = event.clientX - tap.x;
+      const dy = event.clientY - tap.y;
+      if (Math.hypot(dx, dy) > TAP_MOVEMENT_THRESHOLD_PX) {
+        tap.movedPastThreshold = true;
+      }
+    },
+    onPointerCancel(event) {
+      props.onPointerCancel?.(event);
+      const tap = tapRef.current;
+      if (tap !== null && event.pointerId === tap.pointerId) {
+        tapRef.current = null;
+      }
+    },
+    onClick(event) {
+      const tap = tapRef.current;
+      tapRef.current = null;
+      if (tap?.movedPastThreshold) {
+        // preventDefault stops Radix's onClick → onOpenToggle via
+        // composeEventHandlers. stopPropagation prevents the synthetic click
+        // from bubbling to ancestor click handlers.
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      props.onClick?.(event);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #473 (DropdownMenu touch-gate). The same Android Chrome scroll-drag-end bug class can land a synthetic `click` on any click-based Radix trigger — `Popover` (via `InfoBox`), `Dialog`, `Drawer` — opening the popover when the user only meant to scroll. This adds a shared `useSuppressClickAfterDrag` hook and applies it to those three triggers.

## Why

The Radix bug investigated for #473 has two failure modes:

1. **Trigger opens on `pointerdown`** (DropdownMenu / ContextMenu) — fixed in #473 by gating the pointerup toggle on movement.
2. **Trigger opens on `click`** (Popover / Dialog / Drawer) — Android Chrome can still dispatch a synthetic `click` at the end of a scroll-drag whenever the on-target displacement stays within Chromium's slop. The popover opens, `react-remove-scroll` engages, the user gets stuck.

iOS Safari is not affected — it fires `pointercancel` on scroll-start so no synthetic click reaches the trigger.

Fixing the trigger short-circuits the chain before scroll-lock engages.

## What changes

- **New util `src/utils/useSuppressClickAfterDrag.ts`** — composes the consumer's `onPointerDown` / `onPointerMove` / `onPointerCancel` / `onClick` handlers with a touch-drag tracker. On `pointerdown` (touch / pen) it records coords and calls `setPointerCapture` so drag-off still hits the trigger. If `pointermove` crosses a 10 px threshold (below Chromium's 15 px slop), the subsequent `click` is `preventDefault`'d — Radix's `composeEventHandlers` then skips `onOpenToggle` — and `stopPropagation`'d so it doesn't reach ancestor click handlers. Mouse input is unguarded.
- **`InfoBoxTrigger`, `DialogTrigger`, `DrawerTrigger`** — each gains a thin `forwardRef` wrapper that calls the hook. Public API unchanged.
- **Tests** — 7 hook unit tests (stationary tap, drag suppression, mouse unguarded, pen=touch, pointercancel reset, pointerId isolation, consumer-handler forwarding) plus an integration test per consumer that asserts a drag-end synthetic click does not open the popover.

## Independence from #473

This PR branches off `main`, not `simon/android-radix-popover-drag-fix`. The hook is new and DropdownMenu's PR keeps its own inline implementation (different bug class — pointerdown-open vs click-open mechanism). After both merge, a follow-up could DRY the constant and tap-tracking primitive into the shared util. Not done here to keep each PR independently reviewable and revertable.

## Not in scope

- **Tooltip** — hover / long-press only, no `react-remove-scroll`. Not affected.
- **Select** — already fixed upstream in Radix [#2939](https://github.com/radix-ui/primitives/pull/2939).
- **Autocomplete** — Popover anchor is the `<input>` (focus-driven), no click trigger.

## Test plan

- [ ] CI: lint / typecheck / unit tests (touched suites 99 / 99, full suite 3214 / 3214 pass locally).
- [ ] Android Chrome physical device: scroll a page, drag-release a finger on a `DialogTrigger` / `DrawerTrigger` / `InfoBoxTrigger` — verify the overlay **does not** open and the page keeps scrolling.
- [ ] Android Chrome: tap a trigger without dragging — verify it opens normally.
- [ ] iOS Safari: tap and drag interactions unchanged.
- [ ] Desktop mouse: click opens immediately (no perceptible delay).
- [ ] Keyboard: Tab + Enter / Space activation still opens.

## References

- Companion PR: #473 (DropdownMenu trigger gate)
- Radix issue: https://github.com/radix-ui/primitives/issues/1912
- Related: https://github.com/radix-ui/primitives/issues/2702 (DismissableLayer touch dismiss)
- Chromium scroll-slop model: https://developer.chrome.com/blog/a-more-compatible-smoother-touch