### PR TITLE
feat: export useSuppressClickAfterDrag and tighten its signature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,11 @@ export {
 } from "./components/Avatar/Avatar";
 export type { BadgeProps, BadgeVariant } from "./components/Badge/Badge";
 export { Badge } from "./components/Badge/Badge";
-export type { BannerLayout, BannerProps, BannerVariant } from "./components/Banner/Banner";
+export type {
+  BannerLayout,
+  BannerProps,
+  BannerVariant,
+} from "./components/Banner/Banner";
 export { Banner } from "./components/Banner/Banner";
 export type { BottomNavigationProps } from "./components/BottomNavigation/BottomNavigation";
 export { BottomNavigation } from "./components/BottomNavigation/BottomNavigation";
@@ -508,7 +512,12 @@ export type {
 export { InlineEdit } from "./components/InlineEdit/InlineEdit";
 export type { LoaderProps } from "./components/Loader/Loader";
 export { Loader } from "./components/Loader/Loader";
-export type { LogoColor, LogoProps, LogoSize, LogoVariant } from "./components/Logo/Logo";
+export type {
+  LogoColor,
+  LogoProps,
+  LogoSize,
+  LogoVariant,
+} from "./components/Logo/Logo";
 export { Logo } from "./components/Logo/Logo";
 export type {
   MobileStepperPosition,
@@ -581,10 +590,7 @@ export type {
   SnackbarVariant,
 } from "./components/Snackbar/Snackbar";
 export { Snackbar } from "./components/Snackbar/Snackbar";
-export type {
-  StepItem,
-  StepperProps,
-} from "./components/Stepper/Stepper";
+export type { StepItem, StepperProps } from "./components/Stepper/Stepper";
 export { Stepper } from "./components/Stepper/Stepper";
 export type {
   StepperStepProps,
@@ -696,3 +702,4 @@ export {
 } from "./components/Tooltip/Tooltip";
 export { cn } from "./utils/cn";
 export type { OmitDistributed } from "./utils/types";
+export { useSuppressClickAfterDrag } from "./utils/useSuppressClickAfterDrag";

--- a/src/utils/useSuppressClickAfterDrag.ts
+++ b/src/utils/useSuppressClickAfterDrag.ts
@@ -31,13 +31,16 @@ type GatedHandlers = {
  * #2702 (DismissableLayer touch dismiss). For the DropdownMenu pointerdown
  * variant see `components/DropdownMenu/DropdownMenu.tsx`.
  */
-export function useSuppressClickAfterDrag<P extends GatedHandlers>(props: P): P {
+export function useSuppressClickAfterDrag<P extends GatedHandlers = GatedHandlers>(
+  props?: P,
+): P & Required<GatedHandlers> {
   const tapRef = React.useRef<ActiveTap | null>(null);
+  const consumer = props ?? ({} as P);
 
   return {
-    ...props,
+    ...consumer,
     onPointerDown(event) {
-      props.onPointerDown?.(event);
+      consumer.onPointerDown?.(event);
       if (event.pointerType === "mouse") {
         tapRef.current = null;
         return;
@@ -53,7 +56,7 @@ export function useSuppressClickAfterDrag<P extends GatedHandlers>(props: P): P 
       };
     },
     onPointerMove(event) {
-      props.onPointerMove?.(event);
+      consumer.onPointerMove?.(event);
       const tap = tapRef.current;
       if (tap === null || event.pointerId !== tap.pointerId || tap.movedPastThreshold) return;
       const dx = event.clientX - tap.x;
@@ -63,7 +66,7 @@ export function useSuppressClickAfterDrag<P extends GatedHandlers>(props: P): P 
       }
     },
     onPointerCancel(event) {
-      props.onPointerCancel?.(event);
+      consumer.onPointerCancel?.(event);
       const tap = tapRef.current;
       if (tap !== null && event.pointerId === tap.pointerId) {
         tapRef.current = null;
@@ -80,7 +83,7 @@ export function useSuppressClickAfterDrag<P extends GatedHandlers>(props: P): P 
         event.stopPropagation();
         return;
       }
-      props.onClick?.(event);
+      consumer.onClick?.(event);
     },
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #474. The touch-drag click-suppression hook landed in #474 as an internal util, but apps that import \`@radix-ui/react-popover\` directly (i.e. don't go through \`@fanvue/ui\`'s \`InfoBox\`) can't reach the same gate. Pandora has 3 such call sites:

- \`eden/src/pagecomponents/SettingsPage/ManagerSettingsPages/TeamMemberInsightsTab.tsx\`
- \`eden/src/pagecomponents/SettingsPage/ManagerSettingsPages/CreatorInsightsTab.tsx\`
- \`eden/src/components/DateRangeFilter.tsx\`

This PR exports the hook from the package's public entry point so those call sites can apply the same gate without duplicating the logic.

While there, makes the hook's input optional and tightens the return type so standalone calls — \`useSuppressClickAfterDrag()\` — have the four gated handlers properly typed (instead of \`{}\`).

## What changes

- \`src/index.ts\` — adds \`export { useSuppressClickAfterDrag }\`.
- \`src/utils/useSuppressClickAfterDrag.ts\`:
  - Generic now defaults to \`GatedHandlers\` so \`useSuppressClickAfterDrag()\` (no args) is valid.
  - Return type is \`P & Required<GatedHandlers>\` — callers always get the four handlers typed, plus anything they passed in.
  - Renames the internal param mirror from \`props\` → \`consumer\` to avoid shadowing.

No behaviour change for existing internal callers (InfoBox/Dialog/Drawer triggers).

## Test plan

- [x] CI: typecheck / lint / unit tests (existing 99 / 99 in touched suites still pass locally; full suite unaffected).
- [x] Once released, the pandora follow-up PR can import \`useSuppressClickAfterDrag\` and apply it to the 3 direct \`Popover.Trigger\` call sites.

## References

- Companion fanv-ui PRs: #473 (DropdownMenu), #474 (InfoBox / Dialog / Drawer)