### PR TITLE
feat(Table): evolve to v2 design (ENG-10971)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2143,7 +2143,12 @@ function CheckboxDemo() {
     <div id="checkbox" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-bold-heading-sm mb-4">Checkbox</h2>
       <div className="flex flex-col gap-4">
-        <Checkbox label="Default checkbox" />
+        <Checkbox label="Default checkbox (20px)" />
+        <Checkbox
+          label="Compact checkbox (16px)"
+          size="16"
+          helperText="Used in dense surfaces like data tables"
+        />
         <Checkbox label="Small text size" size="small" helperText="Label and helper are smaller" />
         <Checkbox label="Checked checkbox" checked />
         <Checkbox label="Indeterminate checkbox" checked="indeterminate" />
@@ -3072,7 +3077,7 @@ function TableDemo() {
                 <TableHeader>
                   <TableRow>
                     <TableHead intent="checkbox">
-                      <Checkbox aria-label="Select all rows" />
+                      <Checkbox size="16" aria-label="Select all rows" />
                     </TableHead>
                     <TableHead>Date</TableHead>
                     <TableHead>Title</TableHead>
@@ -3086,7 +3091,7 @@ function TableDemo() {
                     (date) => (
                       <TableRow key={date}>
                         <TableCell intent="checkbox">
-                          <Checkbox aria-label={`Select row ${date}`} />
+                          <Checkbox size="16" aria-label={`Select row ${date}`} />
                         </TableCell>
                         <TableCell>{date}</TableCell>
                         <TableCell intent="multiline">
@@ -3146,7 +3151,7 @@ function TableDemo() {
                 <TableHeader>
                   <TableRow>
                     <TableHead intent="checkbox">
-                      <Checkbox aria-label="Select all" />
+                      <Checkbox size="16" aria-label="Select all" />
                     </TableHead>
                     <TableHead>Title</TableHead>
                     <TableHead>Media</TableHead>
@@ -3156,7 +3161,7 @@ function TableDemo() {
                 <TableBody>
                   <TableRow>
                     <TableCell intent="checkbox">
-                      <Checkbox aria-label="Select row" />
+                      <Checkbox size="16" aria-label="Select row" />
                     </TableCell>
                     <TableCell>Sample row</TableCell>
                     <TableCell>
@@ -3199,7 +3204,7 @@ function TableDemo() {
                   <TableRow>
                     <TableCell intent="sideLabel">Checkbox</TableCell>
                     <TableCell>
-                      <Checkbox aria-label="Demo row select" />
+                      <Checkbox size="16" aria-label="Demo row select" />
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -3266,7 +3271,7 @@ function TableDemo() {
                   <TableRow>
                     <TableCell intent="sideLabel">Avatar</TableCell>
                     <TableCell>
-                      <Avatar src={TABLE_DEMO_MEDIA} alt="" fallback="U" size={40} />
+                      <Avatar src={TABLE_DEMO_MEDIA} alt="" fallback="U" size={24} />
                     </TableCell>
                   </TableRow>
                   <TableRow>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,6 +202,7 @@ import {
   TableBody,
   TableCard,
   TableCell,
+  TableCellContent,
   TableCellGroup,
   TableHead,
   TableHeader,
@@ -213,6 +214,7 @@ import {
   TableRow,
   TableRowsPerPageSelect,
   TableScrollArea,
+  TableSortLabel,
   TableStackedText,
   TableStatusDot,
   TableToolbar,
@@ -3046,10 +3048,12 @@ function TableDemo() {
       <h2 className="typography-h3 mb-4">Table</h2>
       <div className="flex max-w-4xl flex-col gap-12">
         <div>
-          <h3 className="typography-semibold-body-lg mb-3 text-content-primary">Table — md</h3>
+          <h3 className="typography-semibold-body-lg mb-3 text-content-primary">
+            Table — default (v2)
+          </h3>
           <TableCard>
             <TableToolbar>
-              <span className="typography-regular-body-md text-foreground-default">2 selected</span>
+              <span className="typography-regular-body-sm text-content-primary">2 selected</span>
               <div className="flex flex-wrap gap-1">
                 <Button variant="tertiary" size="32" leftIcon={<UsersIcon className="size-3.5" />}>
                   Assign to creators
@@ -3205,7 +3209,19 @@ function TableDemo() {
                   <TableRow>
                     <TableCell intent="sideLabel">Cell + info</TableCell>
                     <TableCell intent="stacked">
+                      <TableCellContent primary="Cell" secondary="Secondary line" />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell intent="sideLabel">Cell + info (legacy)</TableCell>
+                    <TableCell intent="stacked">
                       <TableStackedText title="Cell" subtitle="Secondary line" />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell intent="sideLabel">Sortable header</TableCell>
+                    <TableCell>
+                      <TableSortLabel direction="asc">Title</TableSortLabel>
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -3307,7 +3323,7 @@ function TableDemo() {
           <h3 className="typography-semibold-body-lg mb-3 text-content-primary">
             Pagination — desktop
           </h3>
-          <div className="max-w-[628px] rounded-md bg-bg-primary py-4">
+          <div className="max-w-[628px] rounded-3xl border border-border-strong">
             <TablePagination
               leadingSlot={<TableRowsPerPageSelect id="app-table-pag-desk" />}
               paginationSlot={
@@ -3329,7 +3345,7 @@ function TableDemo() {
           </h3>
           <TablePagination
             layout="mobile"
-            className="max-w-sm rounded-md bg-bg-primary py-4"
+            className="max-w-sm rounded-3xl border border-border-strong"
             leadingSlot={<TableRowsPerPageSelect id="app-table-pag-mob" />}
             paginationSlot={
               <Pagination

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   argTypes: {
     size: {
       control: "select",
-      options: ["default", "small"],
+      options: ["20", "16", "default", "small"],
     },
     checked: {
       control: "select",
@@ -110,6 +110,15 @@ export const WithLabelAndLongHelperText: Story = {
   args: {
     label: "Subscribe to newsletter",
     helperText: "Get weekly updates about new features and releases",
+  },
+};
+
+export const Compact16: Story = {
+  name: "Compact (16px)",
+  args: {
+    size: "16",
+    label: "Compact checkbox",
+    helperText: "16px box, used in dense surfaces like data tables",
   },
 };
 

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -61,6 +61,19 @@ describe("Checkbox", () => {
       await user.click(checkbox);
       expect(handleChange).not.toHaveBeenCalled();
     });
+
+    it("renders 20px box by default", () => {
+      const { container } = render(<Checkbox aria-label="Default size" />);
+      const checkbox = container.querySelector('[data-testid="checkbox"]');
+      expect(checkbox).toHaveClass("size-5");
+    });
+
+    it("renders 16px box when size is '16'", () => {
+      const { container } = render(<Checkbox size="16" aria-label="Compact size" />);
+      const checkbox = container.querySelector('[data-testid="checkbox"]');
+      expect(checkbox).toHaveClass("size-4");
+      expect(checkbox).not.toHaveClass("size-5");
+    });
   });
 
   describe("accessibility", () => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,12 +4,35 @@ import { cn } from "../../utils/cn";
 import { CheckIcon } from "../Icons/CheckIcon";
 import { MinusIcon } from "../Icons/MinusIcon";
 
-/** Size variant controlling label and helper text typography. */
-export type CheckboxSize = "default" | "small";
+/**
+ * Size variant for the checkbox.
+ *
+ * - `"20"` (default) — 20px box, body-lg label.
+ * - `"16"` — 16px box, body-md label, used in compact contexts like data tables.
+ * - `"default"` and `"small"` are legacy aliases retained for back-compat
+ *   (`"default"` → `"20"`, `"small"` → `"20"` with smaller label typography).
+ */
+export type CheckboxSize =
+  | "20"
+  | "16"
+  /** @deprecated Use `"20"` instead. */
+  | "default"
+  /** @deprecated Use `"20"` (the smaller-typography variant remains via `"small"`). */
+  | "small";
+
+const BOX_SIZE_CLASS: Record<"20" | "16", string> = {
+  "20": "size-5",
+  "16": "size-4",
+};
+
+const INDICATOR_SIZE_CLASS: Record<"20" | "16", string> = {
+  "20": "size-3",
+  "16": "size-2.5",
+};
 
 export interface CheckboxProps
   extends Omit<React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, "asChild"> {
-  /** Size variant that controls label and helper text typography. @default "default" */
+  /** Size variant. @default "20" */
   size?: CheckboxSize;
   /** Label text displayed next to the checkbox. */
   label?: string;
@@ -32,10 +55,12 @@ export interface CheckboxProps
  * ```
  */
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ className, size = "default", label, helperText, disabled, name, ...props }, ref) => {
+  ({ className, size = "20", label, helperText, disabled, name, ...props }, ref) => {
     const id = React.useId();
     const helperTextId = helperText ? `${id}-helper` : undefined;
     const hasLabel = Boolean(label || helperText);
+    const boxSize: "20" | "16" = size === "16" ? "16" : "20";
+    const useSmallLabelTypography = size === "small";
 
     if (
       process.env.NODE_ENV !== "production" &&
@@ -64,7 +89,8 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     const checkboxElement = (
       <span
         className={cn(
-          "relative inline-flex size-5 shrink-0",
+          "relative inline-flex shrink-0",
+          BOX_SIZE_CLASS[boxSize],
           // Alignment when used with label
           label && (helperText ? "mt-1" : "mt-0.5"),
         )}
@@ -89,7 +115,8 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           onCheckedChange={handleCheckedChange}
           className={cn(
             // Base styles
-            "flex size-5 items-center justify-center rounded border-2",
+            "flex items-center justify-center rounded border-2",
+            BOX_SIZE_CLASS[boxSize],
             "transition-[border-color,background-color,color,box-shadow] duration-150",
             // Default state
             "border-content-primary bg-transparent text-transparent",
@@ -111,7 +138,8 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           <CheckboxPrimitive.Indicator
             forceMount
             className={cn(
-              "flex size-3 items-center justify-center text-content-primary-inverted",
+              "flex items-center justify-center text-content-primary-inverted",
+              INDICATOR_SIZE_CLASS[boxSize],
               "data-[state=unchecked]:invisible",
             )}
           >
@@ -141,7 +169,9 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
               className={cn(
                 "cursor-pointer select-none text-content-primary",
                 "group-has-disabled:cursor-not-allowed group-has-disabled:text-content-tertiary",
-                size === "small" ? "typography-semibold-body-md" : "typography-semibold-body-lg",
+                useSmallLabelTypography
+                  ? "typography-semibold-body-md"
+                  : "typography-semibold-body-lg",
               )}
             >
               {label}
@@ -154,7 +184,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             className={cn(
               "ml-7 text-content-secondary",
               "in-[.is-disabled]:cursor-not-allowed in-[.is-disabled]:text-content-tertiary",
-              size === "small" ? "typography-regular-body-sm" : "typography-regular-body-md",
+              useSmallLabelTypography ? "typography-regular-body-sm" : "typography-regular-body-md",
             )}
           >
             {helperText}

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -5,6 +5,7 @@ import { Badge } from "../Badge/Badge";
 import { Button } from "../Button/Button";
 import { Checkbox } from "../Checkbox/Checkbox";
 import { Chip } from "../Chip/Chip";
+import { IconButton } from "../IconButton/IconButton";
 import { ChevronDownIcon } from "../Icons/ChevronDownIcon";
 import { MoreIcon } from "../Icons/MoreIcon";
 import { MoreVerticalIcon } from "../Icons/MoreVerticalIcon";
@@ -146,8 +147,10 @@ export const Default: Story = {
                     </Button>
                   </TableCell>
                   <TableCell intent="checkbox">
-                    <MoreVerticalIcon
-                      className="size-4 text-content-primary"
+                    <IconButton
+                      variant="tertiary"
+                      size="32"
+                      icon={<MoreVerticalIcon />}
                       aria-label="Row actions"
                     />
                   </TableCell>
@@ -194,7 +197,7 @@ export const WithToolbar: Story = {
             <TableHeader>
               <TableRow>
                 <TableHead intent="checkbox">
-                  <Checkbox aria-label="Select all rows" />
+                  <Checkbox size="16" aria-label="Select all rows" />
                 </TableHead>
                 <TableHead>Date</TableHead>
                 <TableHead>Title</TableHead>
@@ -208,7 +211,7 @@ export const WithToolbar: Story = {
                 (date) => (
                   <TableRow key={date}>
                     <TableCell intent="checkbox">
-                      <Checkbox aria-label={`Select row ${date}`} />
+                      <Checkbox size="16" aria-label={`Select row ${date}`} />
                     </TableCell>
                     <TableCell>{date}</TableCell>
                     <TableCell intent="multiline">
@@ -322,7 +325,7 @@ export const LargeRows: Story = {
             <TableHeader>
               <TableRow>
                 <TableHead intent="checkbox">
-                  <Checkbox aria-label="Select all" />
+                  <Checkbox size="16" aria-label="Select all" />
                 </TableHead>
                 <TableHead>Title</TableHead>
                 <TableHead>Media</TableHead>
@@ -332,7 +335,7 @@ export const LargeRows: Story = {
             <TableBody>
               <TableRow>
                 <TableCell intent="checkbox">
-                  <Checkbox aria-label="Select row" />
+                  <Checkbox size="16" aria-label="Select row" />
                 </TableCell>
                 <TableCell>
                   <TableCellContent primary="Sample label" secondary="Created today" />
@@ -397,7 +400,7 @@ export const CellVariants: Story = {
                 <TableRow>
                   <TableCell intent="sideLabel">Checkbox</TableCell>
                   <TableCell>
-                    <Checkbox aria-label="Row select" />
+                    <Checkbox size="16" aria-label="Row select" />
                   </TableCell>
                 </TableRow>
                 <TableRow>
@@ -455,7 +458,7 @@ export const CellVariants: Story = {
                 <TableRow>
                   <TableCell intent="sideLabel">Avatar</TableCell>
                   <TableCell>
-                    <Avatar src={TABLE_MEDIA_SRC} alt="" fallback="U" size={40} />
+                    <Avatar src={TABLE_MEDIA_SRC} alt="" fallback="U" size={24} />
                   </TableCell>
                 </TableRow>
                 <TableRow>
@@ -537,7 +540,7 @@ export const AllStatesV2: Story = {
             <TableHeader>
               <TableRow>
                 <TableHead intent="checkbox">
-                  <Checkbox aria-label="Select all rows" />
+                  <Checkbox size="16" aria-label="Select all rows" />
                 </TableHead>
                 <TableHead>
                   <TableSortLabel direction="asc">Product</TableSortLabel>
@@ -563,14 +566,14 @@ export const AllStatesV2: Story = {
               ].map((row, idx) => (
                 <TableRow key={row.status}>
                   <TableCell intent="checkbox">
-                    <Checkbox aria-label={`Select ${row.status}`} />
+                    <Checkbox size="16" aria-label={`Select ${row.status}`} />
                   </TableCell>
                   <TableCell intent="stacked">
                     <TableCellContent primary="Product Name" secondary="SKU-00321" />
                   </TableCell>
                   <TableCell>
                     <TableCellGroup>
-                      <Avatar src={TABLE_MEDIA_SRC} alt="" fallback={`U${idx}`} size={32} />
+                      <Avatar src={TABLE_MEDIA_SRC} alt="" fallback={`U${idx}`} size={24} />
                       <span>@jane_doe</span>
                     </TableCellGroup>
                   </TableCell>
@@ -599,8 +602,10 @@ export const AllStatesV2: Story = {
                     </Button>
                   </TableCell>
                   <TableCell intent="checkbox">
-                    <MoreVerticalIcon
-                      className="size-4 text-content-primary"
+                    <IconButton
+                      variant="tertiary"
+                      size="32"
+                      icon={<MoreVerticalIcon />}
                       aria-label="Row actions"
                     />
                   </TableCell>

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -12,11 +12,13 @@ import { ShareIcon } from "../Icons/ShareIcon";
 import { TrashBinIcon } from "../Icons/TrashBinIcon";
 import { UsersIcon } from "../Icons/UsersIcon";
 import { Pagination } from "../Pagination/Pagination";
+import { Pill } from "../Pill/Pill";
 import {
   Table,
   TableBody,
   TableCard,
   TableCell,
+  TableCellContent,
   TableCellGroup,
   TableHead,
   TableHeader,
@@ -37,13 +39,16 @@ import { TablePagination } from "./TablePagination";
 const TABLE_MEDIA_SRC =
   "https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=112&h=160&fit=crop";
 
+const V2_FIGMA_URL =
+  "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18411-85630";
+
 const meta = {
   title: "Components/Table",
   parameters: {
     layout: "padded",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=15042-40225",
+      url: V2_FIGMA_URL,
     },
   },
   tags: ["autodocs"],
@@ -53,14 +58,124 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const VariantMd: Story = {
-  name: "Table — md",
-  render: function VariantMdStory() {
+type ProductRow = {
+  name: string;
+  created: string;
+  price: string;
+  purchases: string;
+  status: { label: "Active" | "Inactive" | "Warning"; variant: "green" | "error" | "gold" };
+};
+
+const PRODUCT_ROWS: ProductRow[] = [
+  {
+    name: "Product Name",
+    created: "16 May, 01:15 AM",
+    price: "$5.99 / month",
+    purchases: "$0.00",
+    status: { label: "Active", variant: "green" },
+  },
+  {
+    name: "Product Name",
+    created: "16 May, 01:15 AM",
+    price: "$5.99 / month",
+    purchases: "$0.00",
+    status: { label: "Active", variant: "green" },
+  },
+  {
+    name: "Product Name",
+    created: "16 May, 01:15 AM",
+    price: "$5.99 / month",
+    purchases: "$156.25",
+    status: { label: "Inactive", variant: "error" },
+  },
+  {
+    name: "Product Name",
+    created: "16 May, 01:15 AM",
+    price: "$5.99 / month",
+    purchases: "$0.00",
+    status: { label: "Warning", variant: "gold" },
+  },
+];
+
+export const Default: Story = {
+  name: "Default",
+  render: function DefaultStory() {
+    const [page, setPage] = React.useState(2);
+    return (
+      <TableCard className="max-w-4xl">
+        <TableScrollArea>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Product</TableHead>
+                <TableHead>Thumbnail</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Price</TableHead>
+                <TableHead>Purchases</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+                <TableHead intent="checkbox">
+                  <span className="sr-only">More</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {PRODUCT_ROWS.map((row, index) => (
+                <TableRow key={`${row.name}-${index}`}>
+                  <TableCell>{row.name}</TableCell>
+                  <TableCell>
+                    <TableCellGroup>
+                      <TableMediaThumbnail src={TABLE_MEDIA_SRC} alt="" />
+                      <ChevronDownIcon
+                        className="size-4 shrink-0 text-content-primary"
+                        aria-hidden
+                      />
+                    </TableCellGroup>
+                  </TableCell>
+                  <TableCell>{row.created}</TableCell>
+                  <TableCell>{row.price}</TableCell>
+                  <TableCell>{row.purchases}</TableCell>
+                  <TableCell>
+                    <Pill variant={row.status.variant}>{row.status.label}</Pill>
+                  </TableCell>
+                  <TableCell>
+                    <Button variant="secondary" size="32">
+                      Copy
+                    </Button>
+                  </TableCell>
+                  <TableCell intent="checkbox">
+                    <MoreVerticalIcon
+                      className="size-4 text-content-primary"
+                      aria-label="Row actions"
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableScrollArea>
+        <TablePagination
+          leadingSlot={<TableRowsPerPageSelect />}
+          paginationSlot={
+            <Pagination className="pb-0" totalPages={5} currentPage={page} onPageChange={setPage} />
+          }
+          summary="20–30 of 100 rows"
+        />
+      </TableCard>
+    );
+  },
+};
+
+export const WithToolbar: Story = {
+  name: "With toolbar (bulk select)",
+  render: function WithToolbarStory() {
     const [page, setPage] = React.useState(2);
     return (
       <TableCard className="max-w-4xl">
         <TableToolbar>
-          <span className="typography-regular-body-md text-content-primary">2 selected</span>
+          <span className="typography-regular-body-sm text-content-primary">2 selected</span>
           <div className="flex flex-wrap gap-1">
             <Button variant="tertiary" size="32" leftIcon={<UsersIcon className="size-3.5" />}>
               Assign to creators
@@ -99,7 +214,7 @@ export const VariantMd: Story = {
                     <TableCell intent="multiline">
                       <TableLineClamp>
                         Placeholder description text for this row.{" "}
-                        <button type="button" className="typography-semibold-body-md">
+                        <button type="button" className="typography-semibold-body-sm">
                           Read more
                         </button>
                       </TableLineClamp>
@@ -109,7 +224,7 @@ export const VariantMd: Story = {
                         <TableMediaThumbnail src={TABLE_MEDIA_SRC} alt="" />
                         <span>5</span>
                         <ChevronDownIcon
-                          className="size-5 shrink-0 text-content-primary"
+                          className="size-4 shrink-0 text-content-primary"
                           aria-hidden
                         />
                       </TableCellGroup>
@@ -122,7 +237,7 @@ export const VariantMd: Story = {
                         />
                         <span>5</span>
                         <ChevronDownIcon
-                          className="size-5 shrink-0 text-content-primary"
+                          className="size-4 shrink-0 text-content-primary"
                           aria-hidden
                         />
                       </TableCellGroup>
@@ -148,15 +263,57 @@ export const VariantMd: Story = {
   },
 };
 
-export const VariantLg: Story = {
-  name: "Table — lg",
-  parameters: {
-    design: {
-      type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=15042-40225",
-    },
+export const Sortable: Story = {
+  name: "Sortable header",
+  render: function SortableStory() {
+    type Direction = "asc" | "desc" | null;
+    const Demo = () => {
+      const [direction, setDirection] = React.useState<Direction>("asc");
+      const next: Record<NonNullable<Direction>, Direction> = { asc: "desc", desc: null };
+      const cycle = () => setDirection((d) => (d == null ? "asc" : next[d]));
+      return (
+        <TableCard className="max-w-2xl">
+          <TableScrollArea>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    <button type="button" onClick={cycle} className="cursor-pointer">
+                      <TableSortLabel direction={direction}>Title</TableSortLabel>
+                    </button>
+                  </TableHead>
+                  <TableHead>Owner</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Quarterly review</TableCell>
+                  <TableCell>Jane Doe</TableCell>
+                  <TableCell>
+                    <Pill variant="green">Active</Pill>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Roadmap planning</TableCell>
+                  <TableCell>John Doe</TableCell>
+                  <TableCell>
+                    <Pill variant="gold">Warning</Pill>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableScrollArea>
+        </TableCard>
+      );
+    };
+    return <Demo />;
   },
-  render: function VariantLgStory() {
+};
+
+export const LargeRows: Story = {
+  name: "Variant — lg (80px rows)",
+  render: function LargeRowsStory() {
     const [page, setPage] = React.useState(1);
     return (
       <TableCard size="lg" className="max-w-3xl">
@@ -177,7 +334,9 @@ export const VariantLg: Story = {
                 <TableCell intent="checkbox">
                   <Checkbox aria-label="Select row" />
                 </TableCell>
-                <TableCell>Sample label</TableCell>
+                <TableCell>
+                  <TableCellContent primary="Sample label" secondary="Created today" />
+                </TableCell>
                 <TableCell>
                   <TableMediaThumbnail src={TABLE_MEDIA_SRC} alt="" align="center" />
                 </TableCell>
@@ -201,13 +360,8 @@ export const VariantLg: Story = {
 };
 
 export const CellVariants: Story = {
-  name: "Cell variants (Figma)",
-  parameters: {
-    design: {
-      type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=854-3764",
-    },
-  },
+  name: "Cell variants",
+  parameters: { design: { type: "figma", url: V2_FIGMA_URL } },
   render: () => (
     <div className="flex max-w-3xl flex-col gap-10">
       <div>
@@ -219,7 +373,7 @@ export const CellVariants: Story = {
                 <TableRow>
                   <TableHead>Title</TableHead>
                   <TableHead intent="sort">
-                    <TableSortLabel>Sortable</TableSortLabel>
+                    <TableSortLabel direction="asc">Sortable</TableSortLabel>
                   </TableHead>
                 </TableRow>
               </TableHeader>
@@ -253,6 +407,12 @@ export const CellVariants: Story = {
                 <TableRow>
                   <TableCell intent="sideLabel">Cell + info</TableCell>
                   <TableCell intent="stacked">
+                    <TableCellContent primary="Cell" secondary="Secondary line" />
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell intent="sideLabel">Cell + info (legacy)</TableCell>
+                  <TableCell intent="stacked">
                     <TableStackedText title="Cell" subtitle="Secondary line" />
                   </TableCell>
                 </TableRow>
@@ -267,23 +427,20 @@ export const CellVariants: Story = {
                   <TableCell cellVariant="chip">
                     <TableCellGroup>
                       <Chip>Chip</Chip>
-                      <ChevronDownIcon className="size-5 shrink-0" aria-hidden />
+                      <ChevronDownIcon className="size-4 shrink-0" aria-hidden />
                     </TableCellGroup>
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell intent="sideLabel">Pill</TableCell>
+                  <TableCell>
+                    <Pill variant="green">Active</Pill>
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell intent="sideLabel">Badge</TableCell>
                   <TableCell>
                     <Badge variant="info">Badge</Badge>
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell intent="sideLabel">Badge + chevron</TableCell>
-                  <TableCell>
-                    <TableCellGroup>
-                      <Badge variant="info">Badge</Badge>
-                      <ChevronDownIcon className="size-5 shrink-0" aria-hidden />
-                    </TableCellGroup>
                   </TableCell>
                 </TableRow>
                 <TableRow>
@@ -302,7 +459,7 @@ export const CellVariants: Story = {
                   </TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell intent="sideLabel">Media (md)</TableCell>
+                  <TableCell intent="sideLabel">Media</TableCell>
                   <TableCell>
                     <TableMediaThumbnail src={TABLE_MEDIA_SRC} alt="" />
                   </TableCell>
@@ -325,15 +482,15 @@ export const CellVariants: Story = {
                 <TableRow>
                   <TableCell intent="sideLabel">Share</TableCell>
                   <TableCell>
-                    <ShareIcon className="size-5 text-content-primary" aria-hidden />
+                    <ShareIcon className="size-4 text-content-primary" aria-hidden />
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell intent="sideLabel">More</TableCell>
                   <TableCell>
                     <TableCellGroup>
-                      <MoreIcon className="size-5 text-content-primary" aria-hidden />
-                      <MoreVerticalIcon className="size-5 text-content-primary" aria-hidden />
+                      <MoreIcon className="size-4 text-content-primary" aria-hidden />
+                      <MoreVerticalIcon className="size-4 text-content-primary" aria-hidden />
                     </TableCellGroup>
                   </TableCell>
                 </TableRow>
@@ -354,18 +511,122 @@ export const CellVariants: Story = {
   ),
 };
 
+export const AllStatesV2: Story = {
+  name: "All states (v2)",
+  render: function AllStatesV2Story() {
+    const [page, setPage] = React.useState(2);
+    return (
+      <TableCard className="max-w-5xl">
+        <TableToolbar>
+          <span className="typography-regular-body-sm text-content-primary">2 selected</span>
+          <div className="flex flex-wrap gap-1">
+            <Button variant="tertiary" size="32" leftIcon={<UsersIcon className="size-3.5" />}>
+              Assign
+            </Button>
+            <Button
+              variant="tertiaryDestructive"
+              size="32"
+              leftIcon={<TrashBinIcon className="size-3.5" />}
+            >
+              Delete
+            </Button>
+          </div>
+        </TableToolbar>
+        <TableScrollArea>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead intent="checkbox">
+                  <Checkbox aria-label="Select all rows" />
+                </TableHead>
+                <TableHead>
+                  <TableSortLabel direction="asc">Product</TableSortLabel>
+                </TableHead>
+                <TableHead>Owner</TableHead>
+                <TableHead>Thumbnail</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Progress</TableHead>
+                <TableHead>
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+                <TableHead intent="checkbox">
+                  <span className="sr-only">More</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[
+                { status: "Active" as const, variant: "green" as const, progress: 80 },
+                { status: "Warning" as const, variant: "gold" as const, progress: 40 },
+                { status: "Inactive" as const, variant: "error" as const, progress: 10 },
+              ].map((row, idx) => (
+                <TableRow key={row.status}>
+                  <TableCell intent="checkbox">
+                    <Checkbox aria-label={`Select ${row.status}`} />
+                  </TableCell>
+                  <TableCell intent="stacked">
+                    <TableCellContent primary="Product Name" secondary="SKU-00321" />
+                  </TableCell>
+                  <TableCell>
+                    <TableCellGroup>
+                      <Avatar src={TABLE_MEDIA_SRC} alt="" fallback={`U${idx}`} size={32} />
+                      <span>@jane_doe</span>
+                    </TableCellGroup>
+                  </TableCell>
+                  <TableCell>
+                    <TableCellGroup>
+                      <TableMediaThumbnail src={TABLE_MEDIA_SRC} alt="" />
+                      <ChevronDownIcon
+                        className="size-4 shrink-0 text-content-primary"
+                        aria-hidden
+                      />
+                    </TableCellGroup>
+                  </TableCell>
+                  <TableCell>16 May, 01:15 AM</TableCell>
+                  <TableCell>
+                    <Pill variant={row.variant}>{row.status}</Pill>
+                  </TableCell>
+                  <TableCell cellVariant="pillProgress">
+                    <TablePillProgressLayout>
+                      <Badge variant="special">{row.progress}%</Badge>
+                      <TableProgressTrack value={row.progress} />
+                    </TablePillProgressLayout>
+                  </TableCell>
+                  <TableCell>
+                    <Button variant="secondary" size="32">
+                      Copy
+                    </Button>
+                  </TableCell>
+                  <TableCell intent="checkbox">
+                    <MoreVerticalIcon
+                      className="size-4 text-content-primary"
+                      aria-label="Row actions"
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableScrollArea>
+        <TablePagination
+          leadingSlot={<TableRowsPerPageSelect id="v2-rows" />}
+          paginationSlot={
+            <Pagination className="pb-0" totalPages={5} currentPage={page} onPageChange={setPage} />
+          }
+          summary="20–30 of 100 rows"
+        />
+      </TableCard>
+    );
+  },
+};
+
 export const PaginationDesktop: Story = {
   name: "Pagination — desktop",
-  parameters: {
-    design: {
-      type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=10637-2872",
-    },
-  },
   render: function PaginationDesktopStory() {
     const [page, setPage] = React.useState(2);
     return (
-      <div className="w-full max-w-[628px] rounded-md bg-bg-primary py-4">
+      <div className="w-full max-w-[628px] rounded-3xl border border-border-strong">
         <TablePagination
           leadingSlot={<TableRowsPerPageSelect id="desk-rows" />}
           paginationSlot={
@@ -380,18 +641,12 @@ export const PaginationDesktop: Story = {
 
 export const PaginationMobile: Story = {
   name: "Pagination — mobile",
-  parameters: {
-    design: {
-      type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=10637-2872",
-    },
-  },
   render: function PaginationMobileStory() {
     const [page, setPage] = React.useState(2);
     return (
       <TablePagination
         layout="mobile"
-        className="max-w-sm rounded-md bg-bg-primary py-4"
+        className="max-w-sm rounded-3xl border border-border-strong"
         leadingSlot={<TableRowsPerPageSelect id="mob-rows" />}
         paginationSlot={
           <Pagination className="pb-0" totalPages={5} currentPage={page} onPageChange={setPage} />

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -6,10 +6,12 @@ import {
   TableBody,
   TableCard,
   TableCell,
+  TableCellContent,
   TableHead,
   TableHeader,
   TableRow,
   TableScrollArea,
+  TableSortLabel,
 } from "./Table";
 
 describe("Table", () => {
@@ -28,10 +30,32 @@ describe("Table", () => {
           </TableScrollArea>
         </TableCard>,
       );
-      expect(screen.getByTestId("card")).toHaveClass("table-surface");
+      const card = screen.getByTestId("card");
+      expect(card).toHaveClass("table-surface");
+      expect(card).toHaveClass("rounded-3xl");
+      expect(card).toHaveClass("border-border-strong");
     });
 
-    it("applies lg min-height class to body cells when TableCard size is lg", () => {
+    it("renders body cells at the v2 default 64px height", () => {
+      const { container } = render(
+        <TableCard>
+          <TableScrollArea>
+            <Table>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Value</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableScrollArea>
+        </TableCard>,
+      );
+      const cell = container.querySelector("td");
+      expect(cell).toHaveClass("h-16");
+      expect(cell).toHaveClass("min-h-16");
+    });
+
+    it("renders body cells at 80px when TableCard size is lg", () => {
       const { container } = render(
         <TableCard size="lg">
           <TableScrollArea>
@@ -46,25 +70,49 @@ describe("Table", () => {
         </TableCard>,
       );
       const cell = container.querySelector("td");
-      expect(cell).toHaveClass("min-h-[80px]");
+      expect(cell).toHaveClass("h-20");
+      expect(cell).toHaveClass("min-h-20");
     });
 
-    it("applies chip cell border preset when cellVariant is chip", () => {
+    it("uses a transparent, tertiary-text header in v2 (no surface fill)", () => {
+      const { container } = render(
+        <TableCard>
+          <TableScrollArea>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Column</TableHead>
+                </TableRow>
+              </TableHeader>
+            </Table>
+          </TableScrollArea>
+        </TableCard>,
+      );
+      const th = container.querySelector("th");
+      expect(th).not.toHaveClass("bg-surface-secondary");
+      expect(th).toHaveClass("text-content-tertiary");
+      expect(th).toHaveClass("min-h-12");
+    });
+
+    it("zeroes the bottom border on cells in the final body row", () => {
       const { container } = render(
         <TableCard>
           <TableScrollArea>
             <Table>
               <TableBody>
                 <TableRow>
-                  <TableCell cellVariant="chip">Chip row</TableCell>
+                  <TableCell>First</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Last</TableCell>
                 </TableRow>
               </TableBody>
             </Table>
           </TableScrollArea>
         </TableCard>,
       );
-      const cell = container.querySelector("td");
-      expect(cell).toHaveClass("border-border-primary");
+      const tbody = container.querySelector("tbody");
+      expect(tbody).toHaveClass("[&_tr:last-child_td]:border-b-0");
     });
 
     it("applies checkbox column preset on TableHead when intent is checkbox", () => {
@@ -82,8 +130,25 @@ describe("Table", () => {
         </TableCard>,
       );
       const th = container.querySelector("th");
-      expect(th).toHaveClass("w-8");
+      expect(th).toHaveClass("w-12");
       expect(th).toHaveClass("text-center");
+    });
+
+    it("renders the underline accent only when TableSortLabel is sorted", () => {
+      const { rerender } = render(<TableSortLabel>Title</TableSortLabel>);
+      let label = screen.getByText("Title");
+      expect(label).not.toHaveClass("border-b");
+
+      rerender(<TableSortLabel direction="asc">Title</TableSortLabel>);
+      label = screen.getByText("Title");
+      expect(label).toHaveClass("border-b");
+      expect(label).toHaveClass("border-content-primary");
+    });
+
+    it("renders TableCellContent primary + secondary lines", () => {
+      render(<TableCellContent primary="Product Name" secondary="SKU-00321" />);
+      expect(screen.getByText("Product Name")).toHaveClass("typography-semibold-body-sm");
+      expect(screen.getByText("SKU-00321")).toHaveClass("typography-regular-body-sm");
     });
   });
 
@@ -96,11 +161,15 @@ describe("Table", () => {
               <TableHeader>
                 <TableRow>
                   <TableHead>Column</TableHead>
+                  <TableHead>
+                    <TableSortLabel direction="asc">Sortable</TableSortLabel>
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 <TableRow>
-                  <TableCell>Cell</TableCell>
+                  <TableCell>Cell A</TableCell>
+                  <TableCell>Cell B</TableCell>
                 </TableRow>
               </TableBody>
             </Table>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -89,14 +89,22 @@ export const TableToolbar = React.forwardRef<HTMLDivElement, TableToolbarProps>(
 );
 TableToolbar.displayName = "TableToolbar";
 
-export interface TableScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {}
+export interface TableScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * No longer needed in v2 — {@link TableCard} handles corner rounding via
+   * its own `overflow-hidden rounded-3xl`. Accepted for back-compat.
+   *
+   * @deprecated v2 ignores this prop; safe to remove.
+   */
+  roundTop?: boolean;
+}
 
 /**
  * Horizontal scroll container for wide tables. The inner scrollport keeps
  * `border-collapse` styles intact when the table wraps.
  */
 export const TableScrollArea = React.forwardRef<HTMLDivElement, TableScrollAreaProps>(
-  ({ className, children, ...props }, ref) => {
+  ({ className, children, roundTop: _roundTop, ...props }, ref) => {
     return (
       <div
         ref={ref}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,9 +1,19 @@
 import * as React from "react";
 import { cn } from "@/utils/cn";
+import { ArrowDownIcon } from "../Icons/ArrowDownIcon";
+import { ArrowUpIcon } from "../Icons/ArrowUpIcon";
 import { Select, SelectContent, SelectItem } from "../Select/Select";
 
-/** Row density for body cells — `md` (60px min height) or `lg` (80px). */
-export type TableSize = "md" | "lg";
+/**
+ * Row density for body cells.
+ *
+ * - `"md"` (default) → 64px Figma `V2 Table Cell` Small.
+ * - `"lg"` → 80px Figma `V2 Table Cell` Large.
+ *
+ * `"default"` is the v2 numeric-token equivalent of `"md"` and is preferred
+ * for new code.
+ */
+export type TableSize = "md" | "lg" | "default";
 
 export interface TableCardProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Row density applied to {@link TableCell} descendants. @default "md" */
@@ -17,14 +27,15 @@ function useTableSize(): TableSize {
 }
 
 /**
- * Surface wrapper for data tables: rounded container, spacing, and size
- * context for {@link TableCell} descendants. Compose with {@link TableScrollArea},
- * {@link Table}, {@link TableHeader}, {@link TableBody}, {@link TableRow},
+ * Surface wrapper for data tables: rounded 24px container with a strong
+ * outer border, inner spacing, and size context for {@link TableCell}
+ * descendants. Compose with {@link TableScrollArea}, {@link Table},
+ * {@link TableHeader}, {@link TableBody}, {@link TableRow},
  * {@link TableHead}, and {@link TableCell}.
  *
  * @example
  * ```tsx
- * <TableCard size="md">
+ * <TableCard>
  *   <TableScrollArea>
  *     <Table>
  *       <TableHeader>
@@ -49,7 +60,7 @@ export const TableCard = React.forwardRef<HTMLDivElement, TableCardProps>(
         <div
           ref={ref}
           className={cn(
-            "isolate flex flex-col gap-4 overflow-hidden rounded-md bg-bg-primary pb-4",
+            "isolate flex flex-col gap-2 overflow-hidden rounded-3xl border border-border-strong px-3 py-1",
             className,
           )}
           {...props}
@@ -70,10 +81,7 @@ export const TableToolbar = React.forwardRef<HTMLDivElement, TableToolbarProps>(
     return (
       <div
         ref={ref}
-        className={cn(
-          "flex flex-wrap items-center gap-4 rounded-t-md bg-bg-primary px-6",
-          className,
-        )}
+        className={cn("flex flex-wrap items-center gap-4 px-4 py-3", className)}
         {...props}
       />
     );
@@ -81,26 +89,18 @@ export const TableToolbar = React.forwardRef<HTMLDivElement, TableToolbarProps>(
 );
 TableToolbar.displayName = "TableToolbar";
 
-export interface TableScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Rounds the top of the table block to match {@link TableCard}. Set `false` when {@link TableToolbar} is above this scroll area. @default true */
-  roundTop?: boolean;
-}
+export interface TableScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 /**
- * Horizontal scroll container for wide tables. Uses an inner scrollport so the
- * table respects the card radius (plain `overflow-x-auto` on the table
- * wrapper often loses rounded corners with `border-collapse`).
+ * Horizontal scroll container for wide tables. The inner scrollport keeps
+ * `border-collapse` styles intact when the table wraps.
  */
 export const TableScrollArea = React.forwardRef<HTMLDivElement, TableScrollAreaProps>(
-  ({ className, roundTop = true, children, ...props }, ref) => {
+  ({ className, children, ...props }, ref) => {
     return (
       <div
         ref={ref}
-        className={cn(
-          "relative w-full min-w-0 overflow-hidden",
-          roundTop && "rounded-t-md",
-          className,
-        )}
+        className={cn("relative w-full min-w-0 overflow-hidden", className)}
         {...props}
       >
         <div className="overflow-x-auto">{children}</div>
@@ -135,25 +135,22 @@ export interface TableHeaderProps extends React.HTMLAttributes<HTMLTableSectionE
 
 export const TableHeader = React.forwardRef<HTMLTableSectionElement, TableHeaderProps>(
   ({ className, ...props }, ref) => {
-    return (
-      <thead
-        ref={ref}
-        className={cn(
-          "[&_tr:first-child_th:first-child]:rounded-tl-md [&_tr:first-child_th:last-child]:rounded-tr-md",
-          className,
-        )}
-        {...props}
-      />
-    );
+    return <thead ref={ref} className={cn(className)} {...props} />;
   },
 );
 TableHeader.displayName = "TableHeader";
 
 export interface TableBodyProps extends React.HTMLAttributes<HTMLTableSectionElement> {}
 
+/**
+ * `<tbody>` wrapper. Removes the bottom border on cells in the final row to
+ * match the Figma `V2 Table Final Row` treatment.
+ */
 export const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
   ({ className, ...props }, ref) => {
-    return <tbody ref={ref} className={cn(className)} {...props} />;
+    return (
+      <tbody ref={ref} className={cn("[&_tr:last-child_td]:border-b-0", className)} {...props} />
+    );
   },
 );
 TableBody.displayName = "TableBody";
@@ -181,7 +178,7 @@ export type TableHeadIntent = "default" | "checkbox" | "sort" | "leading";
 
 const HEAD_INTENT_CLASSES: Record<TableHeadIntent, string> = {
   default: "text-left",
-  checkbox: "w-8 min-w-8 max-w-8 text-center",
+  checkbox: "w-12 min-w-12 max-w-12 text-center",
   sort: "text-right",
   leading: "min-w-0 w-2/5 text-left",
 };
@@ -191,6 +188,10 @@ export interface TableHeadProps extends React.ThHTMLAttributes<HTMLTableCellElem
   intent?: TableHeadIntent;
 }
 
+/**
+ * Header cell. v2: transparent background, 48px min height, tertiary text,
+ * `border-border-primary` bottom rule.
+ */
 export const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
   ({ className, intent = "default", scope = "col", ...props }, ref) => {
     return (
@@ -198,7 +199,7 @@ export const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
         ref={ref}
         scope={scope}
         className={cn(
-          "typography-semibold-body-sm box-border h-8 min-h-8 bg-surface-secondary px-2 py-2 align-middle text-content-primary",
+          "typography-semibold-body-sm box-border min-h-12 border-b border-border-primary px-4 py-3 align-middle text-content-tertiary",
           HEAD_INTENT_CLASSES[intent],
           className,
         )}
@@ -210,17 +211,18 @@ export const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
 TableHead.displayName = "TableHead";
 
 const CELL_MIN_HEIGHT: Record<TableSize, string> = {
-  md: "min-h-[60px]",
-  lg: "min-h-[80px]",
+  md: "h-16 min-h-16",
+  default: "h-16 min-h-16",
+  lg: "h-20 min-h-20",
 };
 
 /** Bottom border and padding preset for body cells (Figma table cell component). */
 export type TableCellVariant = "default" | "chip" | "pillProgress";
 
 const CELL_VARIANT_CLASSES: Record<TableCellVariant, string> = {
-  default: "border-border-primary border-b px-2 py-2",
-  chip: "border-border-primary border-b px-2 py-2",
-  pillProgress: "border-border-primary border-b px-4 py-2",
+  default: "border-b border-border-primary px-4 py-3",
+  chip: "border-b border-border-primary px-4 py-3",
+  pillProgress: "border-b border-border-primary px-4 py-3",
 };
 
 /** Layout / typography preset for {@link TableCell} (orthogonal to {@link TableCellVariant}). */
@@ -228,24 +230,30 @@ export type TableCellIntent = "default" | "checkbox" | "stacked" | "multiline" |
 
 const CELL_INTENT_CLASSES: Record<TableCellIntent, string> = {
   default: "",
-  checkbox: "text-center",
+  checkbox: "w-12 min-w-12 max-w-12 text-center",
   stacked: "align-top",
   multiline: "max-w-[240px]",
   sideLabel: "",
 };
 
 export interface TableCellProps extends React.TdHTMLAttributes<HTMLTableCellElement> {
-  /** `pillProgress` uses wider horizontal padding; row dividers match the default weight for visibility. @default "default" */
+  /** Padding preset for the cell. v2 uses identical padding across variants; values are kept for back-compat. @default "default" */
   cellVariant?: TableCellVariant;
   /** Alignment and typography preset for common cell types. @default "default" */
   intent?: TableCellIntent;
 }
 
+/**
+ * Body cell. v2: `h-16` (or `h-20` when the parent {@link TableCard} uses
+ * `size="lg"`), `px-4 py-3` padding, body-sm typography, and a single
+ * `border-border-primary` rule that is zeroed by {@link TableBody} for the
+ * final row.
+ */
 export const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
   ({ className, cellVariant = "default", intent = "default", ...props }, ref) => {
     const size = useTableSize();
     const typo =
-      intent === "sideLabel" ? "typography-semibold-body-md" : "typography-regular-body-md";
+      intent === "sideLabel" ? "typography-semibold-body-sm" : "typography-regular-body-sm";
     return (
       <td
         ref={ref}
@@ -267,14 +275,59 @@ TableCell.displayName = "TableCell";
 export interface TableCellGroupProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 /**
- * Horizontal group for icons, chips, and metadata inside a {@link TableCell} (Figma `gap-[10px]`).
+ * Horizontal group for icons, chips, and metadata inside a {@link TableCell}
+ * (Figma `gap-[4px]`).
  */
 export const TableCellGroup = React.forwardRef<HTMLDivElement, TableCellGroupProps>(
   ({ className, ...props }, ref) => {
-    return <div ref={ref} className={cn("flex items-center gap-2.5", className)} {...props} />;
+    return <div ref={ref} className={cn("flex items-center gap-1", className)} {...props} />;
   },
 );
 TableCellGroup.displayName = "TableCellGroup";
+
+export interface TableCellContentProps {
+  /** Primary line (semibold body-sm). */
+  primary: React.ReactNode;
+  /** Optional secondary line (regular body-sm, secondary color). */
+  secondary?: React.ReactNode;
+  /** Inline node rendered next to the primary line (icon, chip). */
+  primaryAdornment?: React.ReactNode;
+  /** Inline node rendered next to the secondary line. */
+  secondaryAdornment?: React.ReactNode;
+  /** Class for the outer wrapper. */
+  className?: string;
+}
+
+/**
+ * Two-line content slot matching Figma `V2 Table Content` — primary line
+ * (semibold) over an optional secondary line (regular, muted) with a 2px
+ * gap. Use inside {@link TableCell} for the common stacked-text pattern.
+ */
+export function TableCellContent({
+  primary,
+  secondary,
+  primaryAdornment,
+  secondaryAdornment,
+  className,
+}: TableCellContentProps) {
+  return (
+    <div className={cn("flex flex-col gap-0.5", className)}>
+      <div className="flex items-center gap-1">
+        <span className="typography-semibold-body-sm text-content-primary">{primary}</span>
+        {primaryAdornment}
+      </div>
+      {(secondary != null || secondaryAdornment != null) && (
+        <div className="flex items-center gap-1">
+          {secondary != null && (
+            <span className="typography-regular-body-sm text-content-secondary">{secondary}</span>
+          )}
+          {secondaryAdornment}
+        </div>
+      )}
+    </div>
+  );
+}
+TableCellContent.displayName = "TableCellContent";
 
 export interface TableMediaThumbnailProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
@@ -282,22 +335,19 @@ export interface TableMediaThumbnailProps
   src: string;
   /** Alt text for the image. @default "" */
   alt?: string;
-  /** Applies the table’s blurred-media treatment. @default false */
+  /** Applies the table's blurred-media treatment. @default false */
   blurred?: boolean;
   /** `center` uses the fixed media column width from the lg spec. @default "start" */
   align?: "start" | "center";
 }
 
 /**
- * Rounded thumbnail sized from {@link TableCard} `size` (`md` vs `lg`).
+ * Square 48px thumbnail used inside {@link TableCell} for media columns
+ * (Figma `V2 Media Thumbnail Item`).
  */
 export const TableMediaThumbnail = React.forwardRef<HTMLDivElement, TableMediaThumbnailProps>(
   ({ className, src, alt = "", blurred, align = "start", ...props }, ref) => {
-    const tableSize = useTableSize();
-    const frame =
-      tableSize === "lg"
-        ? "h-[62px] w-11 overflow-hidden rounded-xs bg-neutral-alphas-200"
-        : "h-10 w-[29px] overflow-hidden rounded-xs bg-neutral-alphas-200";
+    const frame = "size-12 overflow-hidden rounded-sm bg-neutral-alphas-200";
     return (
       <div
         ref={ref}
@@ -383,28 +433,48 @@ export const TablePillProgressLayout = React.forwardRef<
   return (
     <div
       ref={ref}
-      className={cn("flex min-w-[120px] flex-col items-center gap-3", className)}
+      className={cn("flex min-w-[120px] flex-col items-start gap-2", className)}
       {...props}
     />
   );
 });
 TablePillProgressLayout.displayName = "TablePillProgressLayout";
 
+/** Current sort direction of a {@link TableSortLabel}. `null` means unsorted. */
+export type TableSortDirection = "asc" | "desc" | null;
+
 export interface TableSortLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
   children: React.ReactNode;
+  /**
+   * Visual indicator of the column's sort state. When set to `"asc"` or
+   * `"desc"`, a 1px underline accent appears beneath the label and a small
+   * directional arrow is shown next to it. @default null
+   */
+  direction?: TableSortDirection;
 }
 
 /**
- * Sortable column label with caption typography and a sort affordance.
+ * Sortable column label. v2 expresses the sort state with a 1px underline
+ * beneath the label plus a directional arrow when sorted.
  */
 export const TableSortLabel = React.forwardRef<HTMLSpanElement, TableSortLabelProps>(
-  ({ className, children, ...props }, ref) => {
+  ({ className, children, direction = null, ...props }, ref) => {
+    const Icon = direction === "desc" ? ArrowDownIcon : ArrowUpIcon;
     return (
-      <span ref={ref} className={cn("inline-flex items-center gap-2.5", className)} {...props}>
-        <span className="typography-semibold-body-sm">{children}</span>
-        <span className="text-content-secondary" aria-hidden>
-          ↕
+      <span
+        ref={ref}
+        className={cn("inline-flex items-center gap-1 text-content-primary", className)}
+        {...props}
+      >
+        <span
+          className={cn(
+            "typography-semibold-body-sm",
+            direction != null && "border-b border-content-primary pb-px",
+          )}
+        >
+          {children}
         </span>
+        {direction != null && <Icon className="size-4 shrink-0" aria-hidden />}
       </span>
     );
   },
@@ -419,15 +489,13 @@ export interface TableStackedTextProps {
 }
 
 /**
- * Two-line primary + secondary text block for “cell + info” patterns.
+ * Two-line primary + secondary text block for "cell + info" patterns.
+ *
+ * @deprecated Prefer {@link TableCellContent} which supports adornments and
+ * matches the Figma `V2 Table Content` slot.
  */
 export function TableStackedText({ title, subtitle }: TableStackedTextProps) {
-  return (
-    <div className="flex flex-col gap-1">
-      <span className="typography-semibold-body-md">{title}</span>
-      <span className="typography-regular-body-sm text-content-secondary">{subtitle}</span>
-    </div>
-  );
+  return <TableCellContent primary={title} secondary={subtitle} />;
 }
 
 TableStackedText.displayName = "TableStackedText";
@@ -466,7 +534,8 @@ export interface TableRowsPerPageSelectProps {
 }
 
 /**
- * Rows-per-page {@link Select} styled for {@link TablePagination} (Figma field).
+ * Rows-per-page {@link Select} styled for {@link TablePagination}. v2 uses a
+ * subtle pill trigger with the table's secondary-surface background.
  */
 export function TableRowsPerPageSelect(props: TableRowsPerPageSelectProps) {
   const { id, "aria-label": ariaLabel = "Rows per page" } = props;
@@ -475,7 +544,7 @@ export function TableRowsPerPageSelect(props: TableRowsPerPageSelectProps) {
       defaultValue="10"
       size="32"
       aria-label={ariaLabel}
-      className="w-[154px] [&_button]:rounded-xs [&_button]:border-transparent [&_button]:bg-transparent"
+      className="w-[154px] [&_button]:rounded-sm [&_button]:border-transparent [&_button]:bg-surface-inputs"
       id={id}
     >
       <SelectContent>

--- a/src/components/Table/TablePagination.test.tsx
+++ b/src/components/Table/TablePagination.test.tsx
@@ -25,7 +25,7 @@ describe("TablePagination", () => {
 
     it("applies horizontal inset padding by default", () => {
       const { container } = render(<TablePagination summary="Summary" />);
-      expect(container.firstChild).toHaveClass("px-4");
+      expect(container.firstChild).toHaveClass("px-3");
     });
   });
 

--- a/src/components/Table/TablePagination.tsx
+++ b/src/components/Table/TablePagination.tsx
@@ -16,13 +16,18 @@ export interface TablePaginationProps extends React.HTMLAttributes<HTMLDivElemen
 }
 
 /**
- * Footer bar for data tables: rows-per-page control, page navigation, and range
- * summary. Pair `paginationSlot` with {@link Pagination} for numbered controls.
+ * Footer bar for data tables: rows-per-page control, page navigation, and
+ * range summary. Pair `paginationSlot` with {@link Pagination} for numbered
+ * controls.
+ *
+ * v2 sits flush inside {@link TableCard} (`px-3` matches the card's inner
+ * gutter); the chip styling now lives on the {@link TableRowsPerPageSelect}
+ * trigger itself.
  *
  * @example
  * ```tsx
  * <TablePagination
- *   leadingSlot={<Select size="32" aria-label="Rows per page">…</Select>}
+ *   leadingSlot={<TableRowsPerPageSelect />}
  *   paginationSlot={<Pagination totalPages={5} currentPage={2} onPageChange={setPage} />}
  *   summary="20–30 of 100 rows"
  * />
@@ -34,18 +39,16 @@ export const TablePagination = React.forwardRef<HTMLDivElement, TablePaginationP
       return (
         <div
           ref={ref}
-          className={cn("flex w-full max-w-full flex-col gap-3 px-4", className)}
+          className={cn("flex w-full max-w-full flex-col gap-4 px-3 py-3", className)}
           {...props}
         >
-          <div className="flex w-full items-center gap-2.5">
+          <div className="flex w-full items-center gap-2">
             {leadingSlot != null ? (
-              <div className="flex min-w-0 shrink-0 items-center rounded-xs bg-surface-secondary">
-                {leadingSlot}
-              </div>
+              <div className="flex min-w-0 shrink-0 items-center">{leadingSlot}</div>
             ) : null}
             <div
               className={cn(
-                "typography-regular-body-md min-w-0 flex-1 text-content-secondary",
+                "typography-regular-body-sm min-w-0 flex-1 text-content-secondary",
                 leadingSlot == null && "text-left",
                 leadingSlot != null && "text-right",
               )}
@@ -63,18 +66,14 @@ export const TablePagination = React.forwardRef<HTMLDivElement, TablePaginationP
     return (
       <div
         ref={ref}
-        className={cn("flex w-full flex-wrap items-center gap-3 px-4", className)}
+        className={cn("flex w-full flex-wrap items-center gap-3 px-3 py-3", className)}
         {...props}
       >
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col items-start justify-center">
-          {leadingSlot != null ? (
-            <div className="inline-flex min-w-0 rounded-xs bg-surface-secondary">{leadingSlot}</div>
-          ) : null}
-        </div>
+        <div className="flex min-h-0 min-w-0 flex-1 items-center">{leadingSlot}</div>
         {paginationSlot != null ? (
           <div className="flex shrink-0 items-center justify-center">{paginationSlot}</div>
         ) : null}
-        <div className="typography-regular-body-md min-w-0 flex-1 text-right text-content-secondary">
+        <div className="typography-regular-body-sm min-w-0 flex-1 text-right text-content-secondary">
           {summary}
         </div>
       </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -630,6 +630,7 @@ export { SwitchToggle } from "./components/SwitchToggle/SwitchToggle";
 export type {
   TableBodyProps,
   TableCardProps,
+  TableCellContentProps,
   TableCellGroupProps,
   TableCellIntent,
   TableCellProps,
@@ -647,6 +648,7 @@ export type {
   TableRowsPerPageSelectProps,
   TableScrollAreaProps,
   TableSize,
+  TableSortDirection,
   TableSortLabelProps,
   TableStackedTextProps,
   TableStatusDotProps,
@@ -657,6 +659,7 @@ export {
   TableBody,
   TableCard,
   TableCell,
+  TableCellContent,
   TableCellGroup,
   TableFooter,
   TableHead,


### PR DESCRIPTION
## Summary

Evolves the `Table` building blocks to the v2 Figma design, following the in-place pattern used for [Button v2 (ENG-9997)](https://github.com/fanvue/fanv-ui/pull/480) and DropdownMenu v2 (ENG-10966). Same exports, additive helpers, deprecated aliases where v1 props no longer map cleanly.

Figma: [Table v2 — node 18411:85630](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18411-85630)

Linear: [ENG-10971](https://linear.app/fanvue/issue/ENG-10971/v2-table-in-fanvueui)

### Visual deltas

- `TableCard` — `rounded-3xl` + outer `border-border-strong` + `px-3 py-1` + `gap-2`.
- `TableHead` — transparent background, `min-h-12`, `px-4 py-3`, `text-content-tertiary`.
- `TableCell` — `h-16` (md) / `h-20` (lg), `px-4 py-3`, body-sm typography.
- `TableBody` — zeroes the bottom border on the final row's cells (`[&_tr:last-child_td]:border-b-0`).
- `TableMediaThumbnail` — square 48px to match V2 Media Thumbnail Item.
- `TableSortLabel` — replaces the ASCII glyph with a 1px underline accent + `ArrowUpIcon`/`ArrowDownIcon` driven by a new `direction` prop.
- `TableRowsPerPageSelect` — v2 chip styling (`bg-surface-inputs`).
- `TablePagination` — `px-3` padding so it sits flush inside the new card; secondary surface wrappers removed.

### API additions

- New `TableCellContent` helper mirroring Figma `V2 Table Content` (primary + optional secondary line, with adornment slots).
- `TableStackedText` now wraps `TableCellContent` and is marked `@deprecated`.
- New `TableSortDirection` type and `direction` prop on `TableSortLabel`.
- `TableSize` adds `"default"` as a v2 alias for `"md"`. Both `"md"` and `"lg"` remain first-class (Figma keeps both densities).
- All new types exported from `src/index.ts`.

### Out of scope

- No headless selection / sorting behaviour — Table stays presentational, consumers wire their own state.
- No Pagination component v2 audit (separate ticket if needed).
- No Code Connect file (follow-up once Chromatic publishes Storybook).

### Learnings from DropdownMenu v2 applied here

1. All colours use semantic content tokens (`text-content-primary/secondary/tertiary`) so dark mode flips correctly first pass.
2. Spacing taken straight from Figma `--spacing/global/*` tokens (12/16/4/8) rather than eyeballed.
3. Comprehensive `AllStatesV2` story exercises every variant in one screen so visual regressions surface during review.
4. Numeric/v2 tokens (`"default"`) added alongside deprecated `"md"` aliases so consumers can migrate at their pace.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:fix` — clean (no new warnings)
- [x] `pnpm vitest run --project unit` — 2616 / 2616 passing
- [ ] CI runs Storybook browser tests (Playwright provider)
- [ ] Spot-check the `AllStatesV2` story in Chromatic against [Figma node 18411:85630](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18411-85630)
- [ ] Verify dark mode swap on `TableCard`, `TableHead`, `TableCellContent`

Made with [Cursor](https://cursor.com)