### PR TITLE
feat(Autocomplete): add native grouping and pinned options (ENG-10991)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2284,6 +2284,22 @@ function AutocompleteDemo() {
           options={AUTOCOMPLETE_OPTIONS}
           emptyText="No results"
         />
+        <Autocomplete
+          label="Grouped with pinned"
+          placeholder="Find or add a product\u2026"
+          options={[
+            { value: "__new__", label: "+ Create new product", pinned: true },
+            { value: "product:abc", label: "Demo Product", groupId: "recent" },
+            { value: "product:def", label: "Pro Plan", groupId: "recent" },
+            { value: "product:ghi", label: "Starter Plan", groupId: "all" },
+            { value: "product:jkl", label: "Enterprise Suite", groupId: "all" },
+          ]}
+          groups={[
+            { id: "recent", label: "Recent products" },
+            { id: "all", label: "All products" },
+          ]}
+          emptyText="No products match"
+        />
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2286,18 +2286,25 @@ function AutocompleteDemo() {
         />
         <Autocomplete
           label="Grouped with pinned"
-          placeholder="Find or add a product\u2026"
+          placeholder="Find a product or price..."
           options={[
             { value: "__new__", label: "+ Create new product", pinned: true },
-            { value: "product:abc", label: "Demo Product", groupId: "recent" },
-            { value: "product:def", label: "Pro Plan", groupId: "recent" },
-            { value: "product:ghi", label: "Starter Plan", groupId: "all" },
-            { value: "product:jkl", label: "Enterprise Suite", groupId: "all" },
+            { value: "price:demo-1", label: "$19.99 (one-off)", groupId: "demo-product" },
+            { value: "price:demo-2", label: "$9.99 / month", groupId: "demo-product" },
+            { value: "price:pro-1", label: "$99.00 / year", groupId: "pro-plan" },
+            { value: "price:pro-2", label: "$29.00 / month", groupId: "pro-plan" },
           ]}
           groups={[
-            { id: "recent", label: "Recent products" },
-            { id: "all", label: "All products" },
+            { id: "demo-product", label: "Demo Product" },
+            { id: "pro-plan", label: "Pro Plan" },
           ]}
+          renderOption={(opt) =>
+            opt.pinned ? (
+              <span>{opt.label}</span>
+            ) : (
+              <span className="pl-4 text-content-secondary">{opt.label}</span>
+            )
+          }
           emptyText="No products match"
         />
       </div>

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -369,35 +369,44 @@ export const GroupedWithPinned: Story = {
   },
 };
 
-const INDENTED_OPTIONS: AutocompleteOption[] = [
+const PRODUCT_PRICE_GROUPS: AutocompleteGroup[] = [
+  { id: "demo-product", label: "Demo Product" },
+  { id: "pro-plan", label: "Pro Plan" },
+  { id: "enterprise", label: "Enterprise Suite" },
+];
+
+const PRODUCT_PRICE_OPTIONS: AutocompleteOption[] = [
   { value: "__new__", label: "+ Create new product", pinned: true },
-  { value: "product:abc", label: "Demo Product", groupId: "recent" },
-  { value: "price:p1", label: "Demo Product \u2014 $19.99", groupId: "recent" },
-  { value: "price:p2", label: "Demo Product \u2014 $9.99 / month", groupId: "recent" },
-  { value: "product:def", label: "Pro Plan", groupId: "recent" },
-  { value: "price:p3", label: "Pro Plan \u2014 $99.00 / year", groupId: "recent" },
+  { value: "price:demo-1", label: "$19.99 (one-off)", groupId: "demo-product" },
+  { value: "price:demo-2", label: "$9.99 / month", groupId: "demo-product" },
+  { value: "price:pro-1", label: "$99.00 / year", groupId: "pro-plan" },
+  { value: "price:pro-2", label: "$29.00 / month", groupId: "pro-plan" },
+  { value: "price:ent-1", label: "Custom (contact sales)", groupId: "enterprise" },
 ];
 
 export const GroupedWithIndentedRows: Story = {
+  name: "Grouped With Indented Rows (heading is searchable)",
   args: {
     label: "Product",
-    placeholder: "Find or add a product\u2026",
-    options: INDENTED_OPTIONS,
-    groups: [{ id: "recent", label: "Recent products" }],
+    placeholder: "Find a product or price\u2026",
+    options: PRODUCT_PRICE_OPTIONS,
+    groups: PRODUCT_PRICE_GROUPS,
     emptyText: "No products match",
   },
   render: (args: AutocompleteProps) => (
     <Autocomplete
       {...args}
-      renderOption={(opt) => {
-        if (opt.value.startsWith("price:")) {
-          const price = opt.label?.split(" \u2014 ")[1] ?? opt.label;
-          return <span className="pl-4 text-content-secondary">{price}</span>;
-        }
-        return <span>{opt.label}</span>;
-      }}
+      renderOption={(opt) => <span className="pl-4 text-content-secondary">{opt.label}</span>}
     />
   ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The Stripe-style product picker shape: each product is its own group, prices are the items. Searching the product name (e.g. "Demo" or "Pro") matches the group heading and keeps every price under it visible. Searching a price (e.g. "19.99") matches the individual item and shows it under its parent heading.',
+      },
+    },
+  },
 };
 
 function GroupedFilteredEmptyExample() {

--- a/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
 import { HomeIcon } from "../Icons/HomeIcon";
-import { Autocomplete, type AutocompleteOption, type AutocompleteProps } from "./Autocomplete";
+import {
+  Autocomplete,
+  type AutocompleteGroup,
+  type AutocompleteOption,
+  type AutocompleteProps,
+} from "./Autocomplete";
 
 const COUNTRIES: AutocompleteOption[] = [
   { value: "us", label: "United States" },
@@ -324,4 +329,119 @@ export const TruncatedNarrow: Story = {
     defaultValue: "png",
     emptyText: "No results",
   },
+};
+
+const PRODUCT_GROUPS: AutocompleteGroup[] = [
+  { id: "recent", label: "Recent products" },
+  { id: "all", label: "All products" },
+];
+
+const PRODUCT_OPTIONS: AutocompleteOption[] = [
+  { value: "product:abc", label: "Demo Product", groupId: "recent" },
+  { value: "product:def", label: "Pro Plan", groupId: "recent" },
+  { value: "product:ghi", label: "Starter Plan", groupId: "all" },
+  { value: "product:jkl", label: "Enterprise Suite", groupId: "all" },
+  { value: "product:mno", label: "Team Workspace", groupId: "all" },
+];
+
+export const Grouped: Story = {
+  args: {
+    label: "Product",
+    placeholder: "Find a product\u2026",
+    options: PRODUCT_OPTIONS,
+    groups: PRODUCT_GROUPS,
+    emptyText: "No products match",
+  },
+};
+
+const PRODUCT_OPTIONS_WITH_PINNED: AutocompleteOption[] = [
+  { value: "__new__", label: "+ Create new product", pinned: true },
+  ...PRODUCT_OPTIONS,
+];
+
+export const GroupedWithPinned: Story = {
+  args: {
+    label: "Product",
+    placeholder: "Find or add a product\u2026",
+    options: PRODUCT_OPTIONS_WITH_PINNED,
+    groups: PRODUCT_GROUPS,
+    emptyText: "No products match",
+  },
+};
+
+const INDENTED_OPTIONS: AutocompleteOption[] = [
+  { value: "__new__", label: "+ Create new product", pinned: true },
+  { value: "product:abc", label: "Demo Product", groupId: "recent" },
+  { value: "price:p1", label: "Demo Product \u2014 $19.99", groupId: "recent" },
+  { value: "price:p2", label: "Demo Product \u2014 $9.99 / month", groupId: "recent" },
+  { value: "product:def", label: "Pro Plan", groupId: "recent" },
+  { value: "price:p3", label: "Pro Plan \u2014 $99.00 / year", groupId: "recent" },
+];
+
+export const GroupedWithIndentedRows: Story = {
+  args: {
+    label: "Product",
+    placeholder: "Find or add a product\u2026",
+    options: INDENTED_OPTIONS,
+    groups: [{ id: "recent", label: "Recent products" }],
+    emptyText: "No products match",
+  },
+  render: (args: AutocompleteProps) => (
+    <Autocomplete
+      {...args}
+      renderOption={(opt) => {
+        if (opt.value.startsWith("price:")) {
+          const price = opt.label?.split(" \u2014 ")[1] ?? opt.label;
+          return <span className="pl-4 text-content-secondary">{price}</span>;
+        }
+        return <span>{opt.label}</span>;
+      }}
+    />
+  ),
+};
+
+function GroupedFilteredEmptyExample() {
+  const [inputValue, setInputValue] = React.useState("xyz");
+  return (
+    <div className="flex flex-col gap-2">
+      <Autocomplete
+        label="Product"
+        placeholder="Find a product\u2026"
+        options={PRODUCT_OPTIONS_WITH_PINNED}
+        groups={PRODUCT_GROUPS}
+        inputValue={inputValue}
+        onInputChange={setInputValue}
+        emptyText="No products match"
+        defaultOpen
+      />
+      <p className="typography-regular-body-sm text-content-secondary">
+        Edit the input above to see groups collapse. The pinned row always stays visible.
+      </p>
+    </div>
+  );
+}
+
+export const GroupedFilteredEmpty: Story = {
+  render: () => <GroupedFilteredEmptyExample />,
+};
+
+export const CustomGroupHeading: Story = {
+  args: {
+    label: "Product",
+    placeholder: "Find a product\u2026",
+    options: PRODUCT_OPTIONS,
+    groups: PRODUCT_GROUPS,
+    emptyText: "No products match",
+  },
+  render: (args: AutocompleteProps) => (
+    <Autocomplete
+      {...args}
+      renderGroupHeading={(group) => (
+        <span className="typography-semibold-body-md flex items-center gap-2 px-3 pt-2 pb-1 text-content-primary">
+          <HomeIcon className="size-4 text-content-secondary" />
+          {group.label}
+        </span>
+      )}
+    />
+  ),
 };

--- a/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/Autocomplete.test.tsx
@@ -814,5 +814,73 @@ describe("Autocomplete", () => {
       const { container } = renderGrouped({ label: "Product" });
       expect(await axe(container)).toHaveNoViolations();
     });
+
+    describe("group-heading matching", () => {
+      const productPriceGroups = [
+        { id: "demo-product", label: "Demo Product" },
+        { id: "pro-plan", label: "Pro Plan" },
+      ];
+      const productPriceOptions: AutocompleteOption[] = [
+        { value: "price:demo-1", label: "$19.99 (one-off)", groupId: "demo-product" },
+        { value: "price:demo-2", label: "$9.99 / month", groupId: "demo-product" },
+        { value: "price:pro-1", label: "$99.00 / year", groupId: "pro-plan" },
+        { value: "price:pro-2", label: "$29.00 / month", groupId: "pro-plan" },
+      ];
+
+      it("keeps every option under a group whose heading matches the query, even when no item label matches", () => {
+        render(
+          <Autocomplete
+            aria-label="Product"
+            options={productPriceOptions}
+            groups={productPriceGroups}
+            inputValue="demo"
+            defaultOpen
+          />,
+        );
+        expect(screen.getByText("Demo Product")).toBeInTheDocument();
+        expect(screen.getByText("$19.99 (one-off)")).toBeInTheDocument();
+        expect(screen.getByText("$9.99 / month")).toBeInTheDocument();
+        expect(screen.queryByText("Pro Plan")).not.toBeInTheDocument();
+        expect(screen.queryByText("$99.00 / year")).not.toBeInTheDocument();
+      });
+
+      it("falls back to per-option filter when the heading doesn't match", () => {
+        render(
+          <Autocomplete
+            aria-label="Product"
+            options={productPriceOptions}
+            groups={productPriceGroups}
+            inputValue="19.99"
+            defaultOpen
+          />,
+        );
+        expect(screen.getByText("Demo Product")).toBeInTheDocument();
+        expect(screen.getByText("$19.99 (one-off)")).toBeInTheDocument();
+        expect(screen.queryByText("$9.99 / month")).not.toBeInTheDocument();
+        expect(screen.queryByText("Pro Plan")).not.toBeInTheDocument();
+      });
+
+      it("a query that matches one group's heading AND an item in another group keeps both groups visible", () => {
+        render(
+          <Autocomplete
+            aria-label="Product"
+            options={[
+              ...productPriceOptions,
+              { value: "price:legacy", label: "Demo legacy bundle", groupId: "pro-plan" },
+            ]}
+            groups={productPriceGroups}
+            inputValue="demo"
+            defaultOpen
+          />,
+        );
+        expect(screen.getByText("Demo Product")).toBeInTheDocument();
+        expect(screen.getByText("$19.99 (one-off)")).toBeInTheDocument();
+        expect(screen.getByText("$9.99 / month")).toBeInTheDocument();
+        expect(screen.getByText("Pro Plan")).toBeInTheDocument();
+        expect(screen.getByText("Demo legacy bundle")).toBeInTheDocument();
+        expect(screen.queryByText("$99.00 / year")).not.toBeInTheDocument();
+        expect(screen.queryByText("$29.00 / month")).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/Autocomplete.test.tsx
@@ -565,4 +565,254 @@ describe("Autocomplete", () => {
       expect(opts[1]).toHaveAttribute("aria-selected", "false");
     });
   });
+
+  describe("groups and pinned options", () => {
+    const groupedOptions: AutocompleteOption[] = [
+      { value: "__new__", label: "+ Create new product", pinned: true },
+      { value: "product:abc", label: "Demo Product", groupId: "recent" },
+      { value: "price:p1", label: "Demo Product — $19.99", groupId: "recent" },
+      { value: "price:p2", label: "Demo Product — $9.99 / month", groupId: "recent" },
+      { value: "product:def", label: "Other Product", groupId: "all" },
+      { value: "product:ghi", label: "Yet Another", groupId: "all" },
+    ];
+    const groups = [
+      { id: "recent", label: "Recent products" },
+      { id: "all", label: "All products" },
+    ];
+
+    function renderGrouped(props: Partial<React.ComponentProps<typeof Autocomplete>> = {}) {
+      const merged = {
+        "aria-label": "Grouped",
+        options: groupedOptions,
+        groups,
+        defaultOpen: true,
+        ...props,
+      } as React.ComponentProps<typeof Autocomplete>;
+      return render(<Autocomplete {...merged} />);
+    }
+
+    it("back-compat: flat options without groups/groupId/pinned render no group wrappers, headings or dividers", () => {
+      const flatOptions: AutocompleteOption[] = [
+        { value: "a", label: "Apple" },
+        { value: "b", label: "Banana" },
+      ];
+      const { container } = render(
+        <Autocomplete aria-label="Flat" options={flatOptions} defaultOpen />,
+      );
+      const listbox = within(container.ownerDocument.body).getByRole("listbox");
+      expect(within(listbox).queryAllByRole("group")).toHaveLength(0);
+      expect(listbox.querySelector(".border-t")).toBeNull();
+      expect(within(listbox).getAllByRole("option")).toHaveLength(2);
+    });
+
+    it("renders one role=group per declared group with aria-labelledby resolving to the heading text", () => {
+      renderGrouped();
+      const groupWrappers = screen.getAllByRole("group");
+      expect(groupWrappers).toHaveLength(2);
+
+      for (const wrapper of groupWrappers) {
+        const labelledBy = wrapper.getAttribute("aria-labelledby");
+        expect(labelledBy).toBeTruthy();
+        const heading = document.getElementById(labelledBy as string);
+        expect(heading).not.toBeNull();
+        expect(heading?.textContent).toMatch(/Recent products|All products/);
+      }
+    });
+
+    it("renders groups in declaration order regardless of options array order", () => {
+      render(
+        <Autocomplete
+          aria-label="Reordered"
+          options={groupedOptions}
+          groups={[
+            { id: "all", label: "All products" },
+            { id: "recent", label: "Recent products" },
+          ]}
+          defaultOpen
+        />,
+      );
+      const groupWrappers = screen.getAllByRole("group");
+      const firstHeading = document.getElementById(
+        groupWrappers[0]?.getAttribute("aria-labelledby") ?? "",
+      );
+      const secondHeading = document.getElementById(
+        groupWrappers[1]?.getAttribute("aria-labelledby") ?? "",
+      );
+      expect(firstHeading?.textContent).toMatch(/All products/);
+      expect(secondHeading?.textContent).toMatch(/Recent products/);
+    });
+
+    it("collapses an empty group's heading when its options are filtered out", async () => {
+      const user = userEvent.setup();
+      renderGrouped();
+      const input = screen.getByRole("combobox");
+      await user.type(input, "demo");
+
+      expect(screen.queryByText("All products")).not.toBeInTheDocument();
+      expect(screen.getByText("Recent products")).toBeInTheDocument();
+    });
+
+    it("shows only emptyText (no headings) when all non-pinned options are filtered out and there are no pinned", () => {
+      render(
+        <Autocomplete
+          aria-label="Empty"
+          options={[
+            { value: "a", label: "Apple", groupId: "recent" },
+            { value: "b", label: "Banana", groupId: "all" },
+          ]}
+          groups={groups}
+          inputValue="zzz"
+          defaultOpen
+          emptyText="Nothing here"
+        />,
+      );
+      expect(screen.getByText("Nothing here")).toBeInTheDocument();
+      expect(screen.queryByRole("group")).not.toBeInTheDocument();
+      expect(screen.queryByText("Recent products")).not.toBeInTheDocument();
+    });
+
+    it("keeps pinned options visible regardless of query", () => {
+      renderGrouped({ inputValue: "no-match-at-all" });
+      expect(screen.getByText("+ Create new product")).toBeInTheDocument();
+    });
+
+    it("renders pinned options AND emptyText when only pinned survive a search", () => {
+      renderGrouped({ inputValue: "no-match-at-all", emptyText: "No products match" });
+      expect(screen.getByText("+ Create new product")).toBeInTheDocument();
+      expect(screen.getByText("No products match")).toBeInTheDocument();
+    });
+
+    it("renders ungrouped options above the first group without a heading", () => {
+      const opts: AutocompleteOption[] = [
+        { value: "ungrouped-1", label: "Ungrouped one" },
+        { value: "a", label: "Alpha", groupId: "recent" },
+      ];
+      render(
+        <Autocomplete
+          aria-label="Mixed"
+          options={opts}
+          groups={[{ id: "recent", label: "Recent products" }]}
+          defaultOpen
+        />,
+      );
+      const listbox = screen.getByRole("listbox");
+      const renderedOptions = within(listbox).getAllByRole("option");
+      expect(renderedOptions[0]).toHaveTextContent("Ungrouped one");
+      expect(within(listbox).getAllByRole("group")).toHaveLength(1);
+    });
+
+    it("ArrowDown traversal lands on options only, never on a heading", async () => {
+      const user = userEvent.setup();
+      renderGrouped();
+      const input = screen.getByRole("combobox");
+      await user.click(input);
+
+      await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}");
+
+      const activeId = input.getAttribute("aria-activedescendant");
+      expect(activeId).toBeTruthy();
+      const active = document.getElementById(activeId as string);
+      expect(active).toHaveAttribute("role", "option");
+    });
+
+    it("aria-activedescendant always points at an option id, never at a heading id", async () => {
+      const user = userEvent.setup();
+      renderGrouped();
+      const input = screen.getByRole("combobox");
+      await user.click(input);
+
+      const headings = screen.getAllByRole("group").map((g) => g.getAttribute("aria-labelledby"));
+
+      for (let i = 0; i < 6; i++) {
+        await user.keyboard("{ArrowDown}");
+        const activeId = input.getAttribute("aria-activedescendant");
+        expect(headings).not.toContain(activeId);
+      }
+    });
+
+    it("End lands on the last visible option, Home on the first", async () => {
+      const user = userEvent.setup();
+      renderGrouped();
+      const input = screen.getByRole("combobox");
+      await user.click(input);
+
+      await user.keyboard("{End}");
+      const lastActiveId = input.getAttribute("aria-activedescendant");
+      const lastActive = document.getElementById(lastActiveId ?? "");
+      expect(lastActive).toHaveAttribute("role", "option");
+      expect(lastActive?.textContent).toMatch(/Yet Another/);
+
+      await user.keyboard("{Home}");
+      const firstActiveId = input.getAttribute("aria-activedescendant");
+      const firstActive = document.getElementById(firstActiveId ?? "");
+      expect(firstActive).toHaveAttribute("role", "option");
+      expect(firstActive?.textContent).toMatch(/Create new product/);
+    });
+
+    it("calls renderGroupHeading with the group descriptor; component still wraps it with role=presentation and id", () => {
+      const renderGroupHeading = vi.fn((group: { id: string; label: string }) => (
+        <span data-testid={`heading-${group.id}`}>{group.label.toUpperCase()}</span>
+      ));
+      renderGrouped({ renderGroupHeading });
+      expect(renderGroupHeading).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "recent", label: "Recent products" }),
+      );
+
+      const customHeading = screen.getByTestId("heading-recent");
+      expect(customHeading).toHaveTextContent("RECENT PRODUCTS");
+
+      const groupWrapper = customHeading.closest('[role="group"]');
+      expect(groupWrapper).not.toBeNull();
+      const headingWrapper = document.getElementById(
+        groupWrapper?.getAttribute("aria-labelledby") ?? "",
+      );
+      expect(headingWrapper).toHaveAttribute("role", "presentation");
+      expect(headingWrapper).toContainElement(customHeading);
+    });
+
+    it("renderOption signature is unchanged with groups", () => {
+      const renderOption = vi.fn(
+        (opt: AutocompleteOption, _state: { selected: boolean; active: boolean }) => (
+          <span>RO:{opt.value}</span>
+        ),
+      );
+      renderGrouped({ renderOption });
+
+      expect(renderOption).toHaveBeenCalled();
+      const call = renderOption.mock.calls[0];
+      expect(call?.[0]).toHaveProperty("value");
+      expect(call?.[1]).toHaveProperty("selected");
+      expect(call?.[1]).toHaveProperty("active");
+      expect(screen.getAllByText(/^RO:/).length).toBeGreaterThan(0);
+    });
+
+    it("renders divider between pinned/ungrouped block and the first group", () => {
+      renderGrouped();
+      const groupWrappers = screen.getAllByRole("group");
+      const first = groupWrappers[0] as HTMLElement;
+      expect(first.className).toContain("border-t");
+    });
+
+    it("omits the divider when there is no top block (only groups)", () => {
+      render(
+        <Autocomplete
+          aria-label="Groups only"
+          options={[
+            { value: "a", label: "Alpha", groupId: "recent" },
+            { value: "b", label: "Beta", groupId: "all" },
+          ]}
+          groups={groups}
+          defaultOpen
+        />,
+      );
+      const groupWrappers = screen.getAllByRole("group");
+      const first = groupWrappers[0] as HTMLElement;
+      expect(first.className).not.toContain("border-t");
+    });
+
+    it("has no accessibility violations with groups + pinned", async () => {
+      const { container } = renderGrouped({ label: "Product" });
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
 });

--- a/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/Autocomplete.test.tsx
@@ -454,6 +454,57 @@ describe("Autocomplete", () => {
       const listbox = screen.getByRole("listbox");
       expect(within(listbox).queryByText(/Create/)).not.toBeInTheDocument();
     });
+
+    it("shows create option even when creatableLabel does not contain the raw query", async () => {
+      const user = userEvent.setup();
+      renderAutocomplete({
+        creatable: true,
+        creatableLabel: () => "Add new item",
+      });
+      const input = screen.getByRole("combobox");
+      await user.type(input, "zzz");
+
+      const listbox = screen.getByRole("listbox");
+      expect(within(listbox).getByText("Add new item")).toBeInTheDocument();
+    });
+
+    it("shows create option even when a custom filterFn rejects everything", async () => {
+      const user = userEvent.setup();
+      renderAutocomplete({
+        creatable: true,
+        creatableLabel: (v) => `Create "${v}"`,
+        filterFn: () => false,
+      });
+      const input = screen.getByRole("combobox");
+      await user.type(input, "mango");
+
+      const listbox = screen.getByRole("listbox");
+      expect(within(listbox).getByText(/Create "mango"/)).toBeInTheDocument();
+    });
+
+    it("renders the create option after grouped sections", async () => {
+      const user = userEvent.setup();
+      render(
+        <Autocomplete
+          aria-label="Product"
+          options={[
+            { value: "p1", label: "Price one", groupId: "demo" },
+            { value: "p2", label: "Price two", groupId: "demo" },
+          ]}
+          groups={[{ id: "demo", label: "Demo Product" }]}
+          creatable
+          creatableLabel={(v) => `Create "${v}"`}
+        />,
+      );
+      const input = screen.getByRole("combobox");
+      await user.type(input, "demo");
+
+      const listbox = screen.getByRole("listbox");
+      const optionTexts = within(listbox)
+        .getAllByRole("option")
+        .map((el) => el.textContent);
+      expect(optionTexts).toEqual(["Price one", "Price two", 'Create "demo"']);
+    });
   });
 
   describe("controlled input value", () => {

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -343,6 +343,7 @@ export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps
                 emptyText={emptyText}
                 visibleOptions={ac.visibleOptions}
                 visibleSections={ac.visibleSections}
+                createOption={ac.createOption}
                 listboxId={ac.listboxId}
                 activeIndex={ac.activeIndex}
                 isMulti={ac.isMulti}

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -41,7 +41,14 @@ export interface AutocompleteOption {
 export interface AutocompleteGroup {
   /** Stable identifier referenced by `option.groupId`. */
   id: string;
-  /** Group heading text. Used as the group's accessible name. */
+  /**
+   * Group heading text. Used as the group's accessible name and matched
+   * against the search query: when the query matches a group's `label`,
+   * every option under that group is kept regardless of whether it
+   * individually matches the per-option filter. This supports the common
+   * "heading is the searchable label, items are sub-rows" shape (e.g.
+   * heading = product name, items = prices).
+   */
   label: string;
 }
 

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -12,9 +12,37 @@ import { useAutocomplete } from "./useAutocomplete";
 export type AutocompleteSize = "48" | "40" | "32";
 
 export interface AutocompleteOption {
+  /** Unique value identifying the option. Returned via `onChange`. */
   value: string;
+  /** Visible label. Falls back to `value` when omitted. */
   label?: string;
+  /** When `true`, the option renders but cannot be selected. @default false */
   disabled?: boolean;
+  /**
+   * ID of the group this option belongs to. Must match an entry in the
+   * component's `groups` prop. Options without a `groupId` render in an
+   * implicit "ungrouped" bucket above the first declared group.
+   */
+  groupId?: string;
+  /**
+   * Pinned options bypass the search filter and stay visible at the top of
+   * the list regardless of the current query. Useful for "+ Create new"
+   * affordances. Pinned options ignore `groupId` and render before any
+   * grouped or ungrouped content. @default false
+   */
+  pinned?: boolean;
+}
+
+/**
+ * Describes a single group rendered above its matching options.
+ * Indentation of nested rows (e.g. price under product) is not built in —
+ * consumers control it via `renderOption` styling.
+ */
+export interface AutocompleteGroup {
+  /** Stable identifier referenced by `option.groupId`. */
+  id: string;
+  /** Group heading text. Used as the group's accessible name. */
+  label: string;
 }
 
 interface AutocompleteBaseProps {
@@ -58,6 +86,21 @@ interface AutocompleteBaseProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Ordered list of groups. When provided, options whose `groupId` matches
+   * an entry render under the corresponding heading. Groups with no visible
+   * (post-filter) options collapse silently. Pinned options render above
+   * everything; ungrouped options render between pinned and the first group.
+   * Only one level of grouping is supported.
+   */
+  groups?: AutocompleteGroup[];
+  /**
+   * Custom renderer for group headings. The returned node is wrapped by the
+   * component in an element carrying the `id` referenced by the surrounding
+   * `role="group"` wrapper's `aria-labelledby`, so consumers only need to
+   * return visual content.
+   */
+  renderGroupHeading?: (group: AutocompleteGroup) => React.ReactNode;
 }
 
 interface AutocompleteSingleProps extends AutocompleteBaseProps {
@@ -104,6 +147,31 @@ function warnMissingAccessibleName(label?: string, ariaLabel?: string, ariaLabel
   }
 }
 
+/**
+ * A combobox input with single- or multi-select, optional async loading, and
+ * native support for grouped + pinned options.
+ *
+ * - Pass `groups` plus an `options` array whose entries reference each group
+ *   via `groupId` to render hierarchical lists with proper `role="group"` +
+ *   `aria-labelledby` semantics. Options without a `groupId` render above
+ *   the first group; options marked `pinned` render above everything and
+ *   bypass the search filter.
+ * - Indentation of nested rows (e.g. price under product) is controlled by
+ *   the consumer via `renderOption` styling — there is no built-in indent.
+ *
+ * @example
+ * ```tsx
+ * <Autocomplete
+ *   aria-label="Choose a product"
+ *   options={[
+ *     { value: "__new__", label: "+ Create new product", pinned: true },
+ *     { value: "product:abc", label: "Demo Product", groupId: "recent" },
+ *   ]}
+ *   groups={[{ id: "recent", label: "Recent products" }]}
+ *   onChange={handleSelect}
+ * />
+ * ```
+ */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Conditional JSX branches in the render template
 export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps>((props, ref) => {
   const {
@@ -126,6 +194,7 @@ export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps
     emptyText = "No results",
     renderOption,
     renderTag,
+    renderGroupHeading,
   } = props;
 
   const ac = useAutocomplete(props);
@@ -266,6 +335,7 @@ export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps
                 loadingText={loadingText}
                 emptyText={emptyText}
                 visibleOptions={ac.visibleOptions}
+                visibleSections={ac.visibleSections}
                 listboxId={ac.listboxId}
                 activeIndex={ac.activeIndex}
                 isMulti={ac.isMulti}
@@ -274,6 +344,7 @@ export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps
                 onSelect={ac.handleSelect}
                 onMouseEnter={ac.setActiveIndex}
                 renderOption={renderOption}
+                renderGroupHeading={renderGroupHeading}
               />
             </div>
           </Popover.Content>

--- a/src/components/Autocomplete/AutocompleteDropdownContent.tsx
+++ b/src/components/Autocomplete/AutocompleteDropdownContent.tsx
@@ -11,6 +11,13 @@ interface AutocompleteDropdownContentProps {
   emptyText?: string;
   visibleOptions: AutocompleteOption[];
   visibleSections: AutocompleteVisibleSections;
+  /**
+   * Synthetic "Create new …" row, when `creatable` is on and the search
+   * doesn't already match an existing option. Rendered as a trailing row,
+   * always shown regardless of filter, and indexed last in
+   * `visibleOptions` so keyboard navigation works.
+   */
+  createOption?: AutocompleteOption | null;
   listboxId: string;
   activeIndex: number;
   isMulti: boolean;
@@ -39,6 +46,7 @@ export function AutocompleteDropdownContent({
   emptyText,
   visibleOptions,
   visibleSections,
+  createOption,
   listboxId,
   activeIndex,
   isMulti,
@@ -66,7 +74,8 @@ export function AutocompleteDropdownContent({
   const { pinned, ungrouped, groups } = visibleSections;
   const hasTopBlock = pinned.length > 0 || ungrouped.length > 0;
   const hasGroups = groups.length > 0;
-  const nonPinnedVisibleCount = ungrouped.length + groups.reduce((n, g) => n + g.options.length, 0);
+  const nonPinnedVisibleCount =
+    ungrouped.length + groups.reduce((n, g) => n + g.options.length, 0) + (createOption ? 1 : 0);
 
   if (visibleOptions.length === 0) {
     return (
@@ -130,6 +139,7 @@ export function AutocompleteDropdownContent({
           </div>
         );
       })}
+      {createOption && renderOptionRow(createOption)}
       {emptyAfterPinned && (
         <div className="typography-regular-body-md block px-3 py-4 text-center text-content-secondary">
           {emptyText}

--- a/src/components/Autocomplete/AutocompleteDropdownContent.tsx
+++ b/src/components/Autocomplete/AutocompleteDropdownContent.tsx
@@ -1,26 +1,16 @@
 import type * as React from "react";
+import { cn } from "@/utils/cn";
 import { SpinnerIcon } from "../Icons/SpinnerIcon";
-import type { AutocompleteOption } from "./Autocomplete";
+import type { AutocompleteGroup, AutocompleteOption } from "./Autocomplete";
 import { AutocompleteOptionItem } from "./AutocompleteOptionItem";
+import type { AutocompleteVisibleSections } from "./constants";
 
-export function AutocompleteDropdownContent({
-  loading,
-  loadingText,
-  emptyText,
-  visibleOptions,
-  listboxId,
-  activeIndex,
-  isMulti,
-  selectedMultiValues,
-  selectedValue,
-  onSelect,
-  onMouseEnter,
-  renderOption,
-}: {
+interface AutocompleteDropdownContentProps {
   loading: boolean;
   loadingText?: string;
   emptyText?: string;
   visibleOptions: AutocompleteOption[];
+  visibleSections: AutocompleteVisibleSections;
   listboxId: string;
   activeIndex: number;
   isMulti: boolean;
@@ -32,7 +22,33 @@ export function AutocompleteDropdownContent({
     option: AutocompleteOption,
     state: { selected: boolean; active: boolean },
   ) => React.ReactNode;
-}) {
+  renderGroupHeading?: (group: AutocompleteGroup) => React.ReactNode;
+}
+
+function DefaultGroupHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="typography-semibold-body-sm block px-3 pt-2 pb-1 text-content-secondary uppercase tracking-wide">
+      {children}
+    </span>
+  );
+}
+
+export function AutocompleteDropdownContent({
+  loading,
+  loadingText,
+  emptyText,
+  visibleOptions,
+  visibleSections,
+  listboxId,
+  activeIndex,
+  isMulti,
+  selectedMultiValues,
+  selectedValue,
+  onSelect,
+  onMouseEnter,
+  renderOption,
+  renderGroupHeading,
+}: AutocompleteDropdownContentProps) {
   if (loading) {
     return (
       // biome-ignore lint/a11y/useSemanticElements: <output> is not appropriate here; using role="status" for live region announcements
@@ -47,6 +63,11 @@ export function AutocompleteDropdownContent({
     );
   }
 
+  const { pinned, ungrouped, groups } = visibleSections;
+  const hasTopBlock = pinned.length > 0 || ungrouped.length > 0;
+  const hasGroups = groups.length > 0;
+  const nonPinnedVisibleCount = ungrouped.length + groups.reduce((n, g) => n + g.options.length, 0);
+
   if (visibleOptions.length === 0) {
     return (
       <div className="typography-regular-body-md block px-3 py-4 text-center text-content-secondary">
@@ -55,27 +76,65 @@ export function AutocompleteDropdownContent({
     );
   }
 
+  let cursor = 0;
+  const renderOptionRow = (option: AutocompleteOption) => {
+    const index = cursor++;
+    const isSelected = isMulti
+      ? selectedMultiValues.includes(option.value)
+      : option.value === selectedValue;
+    return (
+      <AutocompleteOptionItem
+        key={option.value}
+        option={option}
+        optionId={`${listboxId}-option-${index}`}
+        index={index}
+        isSelected={isSelected}
+        isActive={index === activeIndex}
+        onSelect={() => onSelect(option)}
+        onMouseEnter={() => onMouseEnter(index)}
+        renderOption={renderOption}
+      />
+    );
+  };
+
+  const showDivider = hasTopBlock && hasGroups;
+  const emptyAfterPinned = nonPinnedVisibleCount === 0 && pinned.length > 0;
+
   return (
     <>
-      {visibleOptions.map((option, index) => {
-        const isSelected = isMulti
-          ? selectedMultiValues.includes(option.value)
-          : option.value === selectedValue;
-
+      {pinned.map(renderOptionRow)}
+      {ungrouped.map(renderOptionRow)}
+      {groups.map((section, sectionIndex) => {
+        const headingId = `${listboxId}-group-${section.group.id}`;
+        const headingNode = renderGroupHeading
+          ? renderGroupHeading(section.group)
+          : section.group.label;
         return (
-          <AutocompleteOptionItem
-            key={option.value}
-            option={option}
-            optionId={`${listboxId}-option-${index}`}
-            index={index}
-            isSelected={isSelected}
-            isActive={index === activeIndex}
-            onSelect={() => onSelect(option)}
-            onMouseEnter={() => onMouseEnter(index)}
-            renderOption={renderOption}
-          />
+          // biome-ignore lint/a11y/useSemanticElements: <fieldset> carries form semantics and default styling we don't want inside a listbox; role="group" is the correct ARIA pattern here
+          <div
+            key={section.group.id}
+            role="group"
+            aria-labelledby={headingId}
+            className={cn(
+              showDivider && sectionIndex === 0 && "mt-1 border-neutral-alphas-200 border-t pt-1",
+            )}
+          >
+            <div role="presentation" id={headingId}>
+              {renderGroupHeading ? (
+                headingNode
+              ) : (
+                <DefaultGroupHeading>{headingNode}</DefaultGroupHeading>
+              )}
+            </div>
+            {section.options.map(renderOptionRow)}
+          </div>
         );
       })}
+      {emptyAfterPinned && (
+        <div className="typography-regular-body-md block px-3 py-4 text-center text-content-secondary">
+          {emptyText}
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/Autocomplete/constants.ts
+++ b/src/components/Autocomplete/constants.ts
@@ -1,4 +1,4 @@
-import type { AutocompleteOption } from "./Autocomplete";
+import type { AutocompleteGroup, AutocompleteOption } from "./Autocomplete";
 
 export const CREATE_PREFIX = "__create__";
 
@@ -9,4 +9,70 @@ export function defaultFilter(option: AutocompleteOption, query: string): boolea
 
 export function getLabel(option: AutocompleteOption): string {
   return option.label ?? option.value;
+}
+
+/**
+ * Section structure consumed by `AutocompleteDropdownContent` to render the
+ * grouped layout. `pinned` options bypass the filter; `ungrouped` options
+ * have no `groupId`; `groups` preserves the order declared by the consumer's
+ * `groups` prop and omits any group with zero visible options.
+ *
+ * The flat `visibleOptions` list (built in `useAutocomplete`) keeps the same
+ * order as this structure (pinned → ungrouped → groups in order, options in
+ * declaration order within each section) so `aria-activedescendant` and
+ * keyboard navigation work against a single flat index.
+ */
+export interface AutocompleteVisibleSection {
+  group: AutocompleteGroup;
+  options: AutocompleteOption[];
+}
+
+export interface AutocompleteVisibleSections {
+  pinned: AutocompleteOption[];
+  ungrouped: AutocompleteOption[];
+  groups: AutocompleteVisibleSection[];
+}
+
+/**
+ * Splits `options` into pinned / ungrouped / per-group buckets, applies the
+ * provided filter to non-pinned options only, and drops empty groups.
+ */
+export function getVisibleSections(
+  options: AutocompleteOption[],
+  groups: AutocompleteGroup[] | undefined,
+  filter: (option: AutocompleteOption, query: string) => boolean,
+  query: string,
+): AutocompleteVisibleSections {
+  const pinned: AutocompleteOption[] = [];
+  const ungrouped: AutocompleteOption[] = [];
+  const byGroup = new Map<string, AutocompleteOption[]>();
+  const knownGroupIds = new Set(groups?.map((g) => g.id));
+
+  for (const option of options) {
+    if (option.pinned) {
+      pinned.push(option);
+      continue;
+    }
+    if (query && !filter(option, query)) continue;
+    if (option.groupId && knownGroupIds.has(option.groupId)) {
+      const bucket = byGroup.get(option.groupId) ?? [];
+      bucket.push(option);
+      byGroup.set(option.groupId, bucket);
+    } else {
+      ungrouped.push(option);
+    }
+  }
+
+  const visibleGroups: AutocompleteVisibleSection[] = (groups ?? [])
+    .map((group) => ({ group, options: byGroup.get(group.id) ?? [] }))
+    .filter((section) => section.options.length > 0);
+
+  return { pinned, ungrouped, groups: visibleGroups };
+}
+
+/** Flattens visible sections into the cursor-indexed list. */
+export function flattenVisibleSections(
+  sections: AutocompleteVisibleSections,
+): AutocompleteOption[] {
+  return [...sections.pinned, ...sections.ungrouped, ...sections.groups.flatMap((s) => s.options)];
 }

--- a/src/components/Autocomplete/constants.ts
+++ b/src/components/Autocomplete/constants.ts
@@ -36,6 +36,13 @@ export interface AutocompleteVisibleSections {
 /**
  * Splits `options` into pinned / ungrouped / per-group buckets, applies the
  * provided filter to non-pinned options only, and drops empty groups.
+ *
+ * Group-heading matching: when the query matches a group's `label`
+ * (case-insensitive substring, same as the default option filter), every
+ * option under that group is kept regardless of whether it individually
+ * matches the per-option `filter`. This supports the common "group heading
+ * is the searchable label, items are sub-rows" shape (e.g. group =
+ * product name, items = prices). Pinned options always bypass filtering.
  */
 export function getVisibleSections(
   options: AutocompleteOption[],
@@ -48,12 +55,20 @@ export function getVisibleSections(
   const byGroup = new Map<string, AutocompleteOption[]>();
   const knownGroupIds = new Set(groups?.map((g) => g.id));
 
+  const lowerQuery = query.toLowerCase();
+  const groupMatchedByHeading = new Set<string>(
+    query
+      ? (groups ?? []).filter((g) => g.label.toLowerCase().includes(lowerQuery)).map((g) => g.id)
+      : [],
+  );
+
   for (const option of options) {
     if (option.pinned) {
       pinned.push(option);
       continue;
     }
-    if (query && !filter(option, query)) continue;
+    const inMatchedGroup = !!option.groupId && groupMatchedByHeading.has(option.groupId);
+    if (query && !inMatchedGroup && !filter(option, query)) continue;
     if (option.groupId && knownGroupIds.has(option.groupId)) {
       const bucket = byGroup.get(option.groupId) ?? [];
       bucket.push(option);

--- a/src/components/Autocomplete/useAutocomplete.ts
+++ b/src/components/Autocomplete/useAutocomplete.ts
@@ -1,12 +1,20 @@
 import * as React from "react";
 import type { AutocompleteOption, AutocompleteProps } from "./Autocomplete";
-import { CREATE_PREFIX, defaultFilter, getLabel } from "./constants";
+import {
+  type AutocompleteVisibleSections,
+  CREATE_PREFIX,
+  defaultFilter,
+  flattenVisibleSections,
+  getLabel,
+  getVisibleSections,
+} from "./constants";
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Combobox hook managing interconnected controlled/uncontrolled state
 export function useAutocomplete(props: AutocompleteProps) {
   const {
     id,
     options,
+    groups,
     disabled = false,
     filterFn,
     creatable = false,
@@ -71,24 +79,29 @@ export function useAutocomplete(props: AutocompleteProps) {
   // --- filtering ---
   const filter = filterFn ?? defaultFilter;
 
-  const filteredOptions = React.useMemo(() => {
-    if (!searchText) return options;
-    return options.filter((o) => filter(o, searchText));
-  }, [options, searchText, filter]);
-
   const showCreate =
     creatable &&
     searchText.length > 0 &&
     !options.some((o) => (o.label ?? o.value).toLowerCase() === searchText.toLowerCase());
 
-  const visibleOptions = React.useMemo(() => {
-    if (!showCreate) return filteredOptions;
+  const optionsWithCreate = React.useMemo(() => {
+    if (!showCreate) return options;
     const createOption: AutocompleteOption = {
       value: `${CREATE_PREFIX}${searchText}`,
       label: creatableLabel ? creatableLabel(searchText) : searchText,
     };
-    return [...filteredOptions, createOption];
-  }, [filteredOptions, showCreate, searchText, creatableLabel]);
+    return [...options, createOption];
+  }, [options, showCreate, searchText, creatableLabel]);
+
+  const visibleSections: AutocompleteVisibleSections = React.useMemo(
+    () => getVisibleSections(optionsWithCreate, groups, filter, searchText),
+    [optionsWithCreate, groups, filter, searchText],
+  );
+
+  const visibleOptions = React.useMemo(
+    () => flattenVisibleSections(visibleSections),
+    [visibleSections],
+  );
 
   const prevOptionsLengthRef = React.useRef(visibleOptions.length);
   const prevSearchTextRef = React.useRef(searchText);
@@ -314,6 +327,7 @@ export function useAutocomplete(props: AutocompleteProps) {
     selectedMultiOptions,
     searchText,
     visibleOptions,
+    visibleSections,
     activeIndex,
     activeDescendantId,
     hasClearableValue,

--- a/src/components/Autocomplete/useAutocomplete.ts
+++ b/src/components/Autocomplete/useAutocomplete.ts
@@ -84,24 +84,23 @@ export function useAutocomplete(props: AutocompleteProps) {
     searchText.length > 0 &&
     !options.some((o) => (o.label ?? o.value).toLowerCase() === searchText.toLowerCase());
 
-  const optionsWithCreate = React.useMemo(() => {
-    if (!showCreate) return options;
-    const createOption: AutocompleteOption = {
+  const createOption: AutocompleteOption | null = React.useMemo(() => {
+    if (!showCreate) return null;
+    return {
       value: `${CREATE_PREFIX}${searchText}`,
       label: creatableLabel ? creatableLabel(searchText) : searchText,
     };
-    return [...options, createOption];
-  }, [options, showCreate, searchText, creatableLabel]);
+  }, [showCreate, searchText, creatableLabel]);
 
   const visibleSections: AutocompleteVisibleSections = React.useMemo(
-    () => getVisibleSections(optionsWithCreate, groups, filter, searchText),
-    [optionsWithCreate, groups, filter, searchText],
+    () => getVisibleSections(options, groups, filter, searchText),
+    [options, groups, filter, searchText],
   );
 
-  const visibleOptions = React.useMemo(
-    () => flattenVisibleSections(visibleSections),
-    [visibleSections],
-  );
+  const visibleOptions = React.useMemo(() => {
+    const flat = flattenVisibleSections(visibleSections);
+    return createOption ? [...flat, createOption] : flat;
+  }, [visibleSections, createOption]);
 
   const prevOptionsLengthRef = React.useRef(visibleOptions.length);
   const prevSearchTextRef = React.useRef(searchText);
@@ -328,6 +327,7 @@ export function useAutocomplete(props: AutocompleteProps) {
     searchText,
     visibleOptions,
     visibleSections,
+    createOption,
     activeIndex,
     activeDescendantId,
     hasClearableValue,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export type {
 } from "./components/AudioUpload/useAudioRecorder";
 export { useAudioRecorder } from "./components/AudioUpload/useAudioRecorder";
 export type {
+  AutocompleteGroup,
   AutocompleteOption,
   AutocompleteProps,
   AutocompleteSize,


### PR DESCRIPTION
## Summary

Adds an additive API for hierarchical option lists on `<Autocomplete>`, with proper `role=\"group\"` + `aria-labelledby` ARIA. Removes the need for consumers to fake group headings as `disabled` options + `renderOption` switches (the workaround that breaks ARIA and forces every consumer to re-implement filter logic).

Driven by [ENG-10991](https://linear.app/fanvue/issue/ENG-10991) — `pandora`'s checkout link product picker is the first consumer, but grouped autocompletes will keep coming up (country pickers, creator pickers, etc.).

### New props

- `AutocompleteOption.groupId?: string` — references an entry in the parent's `groups`
- `AutocompleteOption.pinned?: boolean` — always visible regardless of query, renders before everything else
- `Autocomplete.groups?: AutocompleteGroup[]` — ordered list of groups with `{ id, label }`
- `Autocomplete.renderGroupHeading?: (group) => ReactNode` — visual override; component always wraps it in the id-bearing \`role=\"presentation\"\` container so ARIA wiring is guaranteed

### Behaviour

- **Render order**: \`pinned → ungrouped → groups (in declaration order)\`
- **Empty groups collapse** silently under filtering
- **Divider** between top block and first group renders only when both sides are non-empty
- **\`emptyText\`** shows when zero non-pinned options remain; if pinned rows survive a no-match search, \`emptyText\` renders beneath them (the Stripe \"+ Create new product\" shape)
- **Keyboard** walks a flat \`visibleOptions\` list — headings have no \`data-option-index\` and \`aria-activedescendant\` only ever points at options
- **\`filterFn\`** is not called for pinned options or for groups; signature unchanged

### Back-compat

Purely additive. When \`groups\` / \`groupId\` / \`pinned\` are all absent, the rendered DOM is identical to before — no group wrappers, no headings, no dividers. All 59 existing \`Autocomplete\` tests pass without edits.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint:fix\` — clean
- [x] \`pnpm exec vitest run --project=unit\` — 2651 / 2651 passing
- [x] Existing 59 Autocomplete tests pass unchanged
- [x] 16 new tests for: back-compat structural assertion, group ARIA wiring, group ordering, empty-group collapse, pinned-only + emptyText, ungrouped above first group, ArrowDown skips headings, \`aria-activedescendant\` never targets headings, Home/End land on first/last option, custom \`renderGroupHeading\` still wrapped with \`role=\"presentation\"\`, \`renderOption\` signature unchanged, divider on/off, axe
- [ ] Visual review of new stories in Chromatic: \`Grouped\`, \`GroupedWithPinned\`, \`GroupedWithIndentedRows\`, \`GroupedFilteredEmpty\`, \`CustomGroupHeading\`
- [ ] Smoke-test \`pnpm dev\` showcase (grouped demo added next to other Autocomplete examples)

## Notes

- CHANGELOG entry will be produced by release-please from the conventional commit message — not hand-edited here.
- Semver: minor bump (purely additive).
- Nested groups, virtualization, and an alternate button-trigger variant are explicitly out of scope.

Made with [Cursor](https://cursor.com)