### PR TITLE
fix(Divider): use border-primary token instead of neutral-alphas-200 (ENG-11024)

### DIFF
--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -34,14 +34,14 @@ export const Divider = React.forwardRef<
         <SeparatorPrimitive.Root
           decorative
           orientation="horizontal"
-          className="h-px flex-1 bg-neutral-alphas-200"
+          className="h-px flex-1 bg-border-primary"
           {...props}
         />
         <span className="typography-regular-body-md shrink-0 text-content-primary">{label}</span>
         <SeparatorPrimitive.Root
           decorative
           orientation="horizontal"
-          className="h-px flex-1 bg-neutral-alphas-200"
+          className="h-px flex-1 bg-border-primary"
         />
       </div>
     );
@@ -52,7 +52,7 @@ export const Divider = React.forwardRef<
       ref={ref}
       decorative
       orientation="horizontal"
-      className={cn(`mx-auto my-2 h-px w-full bg-neutral-alphas-200`, className)}
+      className={cn(`mx-auto my-2 h-px w-full bg-border-primary`, className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- Switches the `Divider` component from `bg-neutral-alphas-200` (a semi-transparent neutral) to `bg-border-primary`, matching the latest Figma spec.
- Affects both the unlabeled divider and the two segments of the labeled variant.

## Why

Current tokens vs. Figma spec:

| Token | Light | Dark |
|---|---|---|
| Before: `--color-neutral-alphas-200` | `#15151533` (black @ ~20% alpha) | `#ffffff33` (white @ ~20% alpha) |
| After: `--color-border-primary` (per Figma) | `#F0F0F0` | `#333333` |

Figma spec: `stroke: var(--Color-Border-Primary, #F0F0F0)` in light mode.

Linear: [ENG-11024](https://linear.app/fanvue/issue/ENG-11024)

## Test plan

- [ ] Storybook ▸ Components/Divider renders with the solid `Border/Primary` colour in both light and dark themes.
- [ ] Labeled variant (`<Divider label="or" />`) shows matching colour on both sides of the label.

Made with [Cursor](https://cursor.com)