### PR TITLE
chore: update CODEOWNERS to @alfonsovo-fv @simonstaton

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @SamFanvue @simonstaton
+* @alfonsovo-fv @simonstaton


### PR DESCRIPTION
## Summary
- Swap default CODEOWNER from `@SamFanvue` to `@alfonsovo-fv`, keeping `@simonstaton`.

## Test plan
- [ ] CODEOWNERS lint passes in CI
- [ ] New PRs in this repo request review from `@alfonsovo-fv` and `@simonstaton`

🤖 Generated with [Claude Code](https://claude.com/claude-code)