### PR TITLE
feat: add AgentPanelFlair component

### DIFF
--- a/src/components/AgentPanelFlair/AgentPanelFlair.stories.tsx
+++ b/src/components/AgentPanelFlair/AgentPanelFlair.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { cn } from "@/utils/cn";
+import { AgentPanelFlair } from "./AgentPanelFlair";
+
+const meta = {
+  title: "Components/AgentPanelFlair",
+  component: AgentPanelFlair,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof AgentPanelFlair>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const PanelPreview = ({ dark }: { dark?: boolean }) => (
+  <div
+    className={cn(
+      "relative h-[560px] w-[420px] overflow-hidden rounded-md bg-bg-primary",
+      dark && "dark",
+    )}
+  >
+    <AgentPanelFlair />
+    <div className="relative z-10 flex flex-col gap-1 p-6">
+      <h2 className="typography-bold-heading-sm text-content-primary">Creator Agent</h2>
+      <p className="typography-regular-body-md text-content-secondary">How can I help today?</p>
+    </div>
+  </div>
+);
+
+export const Default: Story = {
+  render: () => <PanelPreview />,
+};
+
+export const DarkMode: Story = {
+  render: () => <PanelPreview dark />,
+};

--- a/src/components/AgentPanelFlair/AgentPanelFlair.test.tsx
+++ b/src/components/AgentPanelFlair/AgentPanelFlair.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { AgentPanelFlair } from "./AgentPanelFlair";
+
+describe("AgentPanelFlair", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      render(<AgentPanelFlair className="custom" data-testid="flair" />);
+      expect(screen.getByTestId("flair")).toHaveClass("custom");
+    });
+
+    it("forwards ref to the root element", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<AgentPanelFlair ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("is decorative and non-interactive", () => {
+      render(<AgentPanelFlair data-testid="flair" />);
+      const element = screen.getByTestId("flair");
+      expect(element).toHaveAttribute("aria-hidden", "true");
+      expect(element).toHaveClass("pointer-events-none");
+    });
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AgentPanelFlair data-testid="flair" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/src/components/AgentPanelFlair/AgentPanelFlair.tsx
+++ b/src/components/AgentPanelFlair/AgentPanelFlair.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+
+export interface AgentPanelFlairProps extends React.ComponentPropsWithoutRef<"div"> {}
+
+/**
+ * Decorative background for the Creator Agent panel: an animated green aurora
+ * glowing in from the top-right corner, behind a theme-aware frosted-glass layer.
+ *
+ * Purely presentational — it is `aria-hidden` and `pointer-events-none`, and
+ * renders no interactive or textual content. Position it behind your content by
+ * placing it as the first child of a `relative` container (optionally lowering
+ * its stacking order with a `-z-*` className). The frosted glass uses the
+ * `bg-primary` token, so it adapts to light and dark themes automatically.
+ *
+ * @example
+ * ```tsx
+ * <div className="relative overflow-hidden">
+ *   <AgentPanelFlair className="-z-10" />
+ *   <YourPanelContent />
+ * </div>
+ * ```
+ */
+export const AgentPanelFlair = React.forwardRef<HTMLDivElement, AgentPanelFlairProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      aria-hidden
+      className={cn("pointer-events-none absolute inset-0 overflow-hidden", className)}
+      {...props}
+    >
+      {/* Animated green aurora glowing from the top-right corner */}
+      <div className="agent-panel-flair-aurora absolute inset-0 blur-[30px]" />
+      {/* Frosted glass softens the aurora and keeps content legible (theme-aware) */}
+      <div className="absolute inset-0 bg-bg-primary/45 backdrop-blur-[110px]" />
+    </div>
+  ),
+);
+
+AgentPanelFlair.displayName = "AgentPanelFlair";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export type { AccordionItemProps } from "./components/Accordion/AccordionItem";
 export { AccordionItem } from "./components/Accordion/AccordionItem";
 export type { AccordionTriggerProps } from "./components/Accordion/AccordionTrigger";
 export { AccordionTrigger } from "./components/Accordion/AccordionTrigger";
+export type { AgentPanelFlairProps } from "./components/AgentPanelFlair/AgentPanelFlair";
+export { AgentPanelFlair } from "./components/AgentPanelFlair/AgentPanelFlair";
 export type { AlertProps, AlertVariant } from "./components/Alert/Alert";
 export { Alert } from "./components/Alert/Alert";
 export type {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -120,6 +120,43 @@
   animation: accordion-collapse 200ms ease-out;
 }
 
+/*
+ * Creator Agent panel flair: a green aurora anchored to the top-right corner
+ * that gently drifts. Used by the AgentPanelFlair component. The motion is a
+ * subtle transform so no `@property` registration is required, and it is
+ * disabled under prefers-reduced-motion.
+ */
+@keyframes fv-aurora {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.05);
+  }
+  45% {
+    transform: translate3d(-3%, 2%, 0) scale(1.1);
+  }
+  72% {
+    transform: translate3d(2%, -2%, 0) scale(1.07);
+  }
+}
+
+@utility agent-panel-flair-aurora {
+  background-image: radial-gradient(
+    ellipse 125% 95% at 100% -5%,
+    rgba(73, 242, 100, 0.64) 0%,
+    rgba(73, 242, 100, 0.33) 30%,
+    rgba(73, 242, 100, 0.115) 52%,
+    transparent 72%
+  );
+  animation: fv-aurora 8s ease-in-out infinite;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-panel-flair-aurora {
+    animation: none;
+  }
+}
+
 /* Static tokens not in Figma — manually maintained for now */
 @utility typography-medium-caption-xs {
   font-size: 0.625rem;


### PR DESCRIPTION
## What

Adds a decorative **`AgentPanelFlair`** component: an animated green aurora glowing from the top-right corner behind a theme-aware frosted-glass layer. Purely presentational (`aria-hidden`, `pointer-events-none`); the glass uses the `bg-primary` token so it adapts to light/dark automatically.

## Why

Moves the Creator Agent panel flair **out of Eden and into the design library**, per the guidance to build V2 components in `fanv-ui` rather than leaking designs into apps. It replaces a one-off `AgentFlairBackground` + raw CSS currently living in Eden (to be removed once this publishes).

## Includes

- `AgentPanelFlair.tsx` — `forwardRef`, accepts `className`, JSDoc + `@example`
- Storybook stories — Default + DarkMode
- Unit tests — className merge, ref forwarding, decorative/`aria-hidden`, `vitest-axe`
- `fv-aurora` keyframe + `agent-panel-flair-aurora` utility in `base.css` — transform-based drift, `prefers-reduced-motion` safe

## Notes for reviewers

- Local: typecheck, unit tests (4/4), and `biome` are green. Storybook/browser tests + Chromatic will run in CI here.
- Open question for @andre / @simon: happy with the name `AgentPanelFlair` and bundling the frosted glass into the component (vs. exposing aurora-only)? Easy to split if preferred.