### PR TITLE
feat(ChatInput): Allow the select to be disabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -635,6 +635,25 @@ function ChatInputShowcase() {
           autoComplete="off"
         />
         <ChatInput
+          placeholder="Selector disabled"
+          selectOptions={[
+            {
+              value: "fanvue-ai",
+              label: "Fanvue AI",
+              icon: <AIIcon className="size-4" />,
+            },
+            {
+              value: "example",
+              label: "Example",
+              icon: <BulbIcon className="size-4" />,
+            },
+          ]}
+          selectValue="fanvue-ai"
+          selectDisabled
+          name="chat-select-disabled"
+          autoComplete="off"
+        />
+        <ChatInput
           placeholder="File + selector"
           showFileButton
           selectOptions={[

--- a/src/components/ChatInput/ChatInput.stories.tsx
+++ b/src/components/ChatInput/ChatInput.stories.tsx
@@ -5,7 +5,11 @@ import { BulbIcon } from "../Icons/BulbIcon";
 import { ChatInput } from "./ChatInput";
 
 const SELECT_OPTIONS = [
-  { value: "fanvue-ai", label: "Fanvue AI", icon: <AIIcon className="size-4" /> },
+  {
+    value: "fanvue-ai",
+    label: "Fanvue AI",
+    icon: <AIIcon className="size-4" />,
+  },
   { value: "example", label: "Example", icon: <BulbIcon className="size-4" /> },
 ];
 
@@ -19,6 +23,7 @@ const meta = {
   argTypes: {
     placeholder: { control: "text" },
     disabled: { control: "boolean" },
+    selectDisabled: { control: "boolean" },
     loading: { control: "boolean" },
     showFileButton: { control: "boolean" },
     minRows: { control: "number" },
@@ -84,6 +89,15 @@ export const WithModelSelector: Story = {
         onSelectChange={setModel}
       />
     );
+  },
+};
+
+export const WithDisabledModelSelector: Story = {
+  args: {
+    placeholder: "Type a message...",
+    selectOptions: SELECT_OPTIONS,
+    selectValue: "fanvue-ai",
+    selectDisabled: true,
   },
 };
 

--- a/src/components/ChatInput/ChatInput.test.tsx
+++ b/src/components/ChatInput/ChatInput.test.tsx
@@ -330,6 +330,27 @@ describe("ChatInput", () => {
       expect(handleChange).toHaveBeenCalledWith("example");
     });
 
+    it("disables the inline select when selectDisabled is true", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChatInput
+          placeholder="Test"
+          selectOptions={MODEL_OPTIONS}
+          selectValue="fanvue-ai"
+          selectDisabled
+        />,
+      );
+      const textarea = screen.getByRole("textbox");
+      const select = screen.getByRole("combobox", { name: "Select model" });
+
+      expect(screen.getByText("Fanvue AI")).toBeInTheDocument();
+      expect(textarea).not.toBeDisabled();
+      expect(select).toBeDisabled();
+
+      await user.click(select);
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
     it("closes dropdown after selecting an option", async () => {
       const user = userEvent.setup();
       render(

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -72,6 +72,8 @@ export interface ChatInputProps
   selectOptions?: ChatInputSelectOption[];
   /** Currently selected value for the built-in dropdown. Should match one of `selectOptions[].value`. */
   selectValue?: string;
+  /** When `true`, disables only the built-in dropdown selector. @default false */
+  selectDisabled?: boolean;
   /** Callback fired when the user picks a different dropdown option. */
   onSelectChange?: (value: string) => void;
   /**
@@ -205,6 +207,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       toolbarRight,
       selectOptions,
       selectValue,
+      selectDisabled = false,
       onSelectChange,
       attachments,
       onAttachmentRemove,
@@ -298,7 +301,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
           options={selectOptions}
           value={selectValue}
           onChange={onSelectChange}
-          disabled={disabled}
+          disabled={disabled || selectDisabled}
           selectedOption={selectedOption}
         />
       ) : null);


### PR DESCRIPTION
New attribute `selectDisabled` enables disabling just that option without disabling the component

## Summary

Previously, it was not possible to show the select but prevent it being used. When the agent offers a choice of models for threads, the model is locked in once the thread has started. We need to be able to show "This thread uses this option…" but not "…and you can change it"

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<!-- Paste screenshots or a link to the Chromatic/Storybook build. -->
