### PR TITLE
feat(Dialog): allow dialog to render as child

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -471,6 +471,41 @@ export const MobileSheet: Story = {
   play: openDialog,
 };
 
+export const WithoutPortal: Story = {
+  name: "Without Portal",
+  render: () => (
+    <div className="relative h-80 overflow-hidden rounded-lg border border-border-primary p-6">
+      <p className="typography-regular-body-md mb-4 text-content-secondary">
+        Dialog renders inside this box instead of portaling to document.body.
+      </p>
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button>Open Inline Dialog</Button>
+        </DialogTrigger>
+        <DialogContent portal={false} size="sm">
+          <DialogHeader>
+            <DialogTitle>Inline dialog</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <DialogDescription>
+              Use portal=false when the dialog must stay in a specific DOM subtree.
+            </DialogDescription>
+          </DialogBody>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="secondary">Close</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: /open inline dialog/i }));
+  },
+};
+
 export const RemoveMembers: Story = {
   name: "Remove Members",
   render: () => (

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -475,9 +475,9 @@ export const WithoutPortal: Story = {
   name: "Without Portal",
   render: () => (
     <div className="relative h-80 overflow-hidden rounded-lg border border-border-primary p-6">
-      <p className="typography-regular-body-md mb-4 text-content-secondary">
+      <DialogDescription>
         Dialog renders inside this box instead of portaling to document.body.
-      </p>
+      </DialogDescription>
       <Dialog>
         <DialogTrigger asChild>
           <Button>Open Inline Dialog</Button>

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -518,9 +518,9 @@ export const RemoveMembers: Story = {
           <DialogTitle>Are you sure?</DialogTitle>
         </DialogHeader>
         <DialogBody>
-          <p className="typography-body-default-16px-regular text-content-secondary">
+          <DialogDescription>
             The following members will be removed from your team.
-          </p>
+          </DialogDescription>
           <div className="mt-3 flex gap-2">
             <Chip leftIcon={<Avatar size={24} fallback="TC" alt="Talented Chatter" />}>
               Talented Chatter

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -475,9 +475,9 @@ export const WithoutPortal: Story = {
   name: "Without Portal",
   render: () => (
     <div className="relative h-80 overflow-hidden rounded-lg border border-border-primary p-6">
-      <DialogDescription>
+      <p className="typography-body-small-14px-regular mb-4 text-content-secondary">
         Dialog renders inside this box instead of portaling to document.body.
-      </DialogDescription>
+      </p>
       <Dialog>
         <DialogTrigger asChild>
           <Button>Open Inline Dialog</Button>

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -167,8 +167,39 @@ describe("Dialog", () => {
     it("suppresses overlay when overlay={false}", () => {
       const { baseElement } = renderDialog({ overlay: false });
       expect(screen.getByRole("dialog")).toBeInTheDocument();
-      // The overlay element should not be rendered
       expect(baseElement.querySelector(".bg-background-overlay-default")).not.toBeInTheDocument();
+    });
+
+    it("renders inline when portal is false", () => {
+      render(
+        <div data-testid="dialog-host">
+          <Dialog defaultOpen>
+            <DialogContent portal={false}>
+              <DialogHeader>
+                <DialogTitle>Inline Dialog</DialogTitle>
+              </DialogHeader>
+            </DialogContent>
+          </Dialog>
+        </div>,
+      );
+      const host = screen.getByTestId("dialog-host");
+      expect(host).toContainElement(screen.getByRole("dialog"));
+    });
+
+    it("portals to document body by default", () => {
+      render(
+        <div data-testid="dialog-host">
+          <Dialog defaultOpen>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Portaled Dialog</DialogTitle>
+              </DialogHeader>
+            </DialogContent>
+          </Dialog>
+        </div>,
+      );
+      const host = screen.getByTestId("dialog-host");
+      expect(host).not.toContainElement(screen.getByRole("dialog"));
     });
 
     it("shows back button automatically when onBack is provided", () => {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -46,7 +46,7 @@ export interface DialogOverlayProps
 
 /**
  * Semi-transparent backdrop rendered behind the dialog content.
- * Rendered inside a portal automatically by {@link DialogContent}.
+ * Rendered by {@link DialogContent}; portaled to `document.body` when {@link DialogContent} `portal` is true.
  */
 export const DialogOverlay = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Overlay>,
@@ -77,6 +77,12 @@ export interface DialogContentProps
   size?: "sm" | "md" | "lg";
   /** When true, renders overlay automatically. @default true */
   overlay?: boolean;
+  /**
+   * When true, teleports overlay and panel to `document.body`.
+   * When false, renders inline in the React tree (useful inside theme providers or scoped containers).
+   * @default true
+   */
+  portal?: boolean;
 }
 
 const SIZE_CLASSES: Record<NonNullable<DialogContentProps["size"]>, string> = {
@@ -86,7 +92,10 @@ const SIZE_CLASSES: Record<NonNullable<DialogContentProps["size"]>, string> = {
 };
 
 /**
- * The dialog panel rendered inside a portal. Includes the overlay by default.
+ * The dialog panel. Includes the overlay by default and portals to `document.body` by default.
+ *
+ * Set `portal={false}` to keep overlay and content in the DOM subtree of the parent `Dialog`.
+ * `fixed` positioning still applies; ancestors with `transform` or `overflow` may affect layout.
  *
  * On mobile viewports (<640px), the dialog slides up from the bottom as a sheet
  * with top-only border radius. On larger viewports it renders centered with
@@ -116,48 +125,58 @@ const SIZE_CLASSES: Record<NonNullable<DialogContentProps["size"]>, string> = {
 export const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, size = "md", overlay = true, style, onOpenAutoFocus, ...props }, ref) => (
-  <DialogPrimitive.Portal>
-    {overlay && <DialogOverlay />}
-    <DialogPrimitive.Content
-      ref={ref}
-      style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
-      onOpenAutoFocus={(e) => {
-        if (onOpenAutoFocus) {
-          onOpenAutoFocus(e);
-          return;
-        }
-        e.preventDefault();
-        (e.currentTarget as HTMLElement).focus();
-      }}
-      className={cn(
-        // Base
-        "fixed flex flex-col overflow-hidden bg-background-primary shadow-lg focus:outline-none dark:bg-surface-primary",
-        // Mobile: bottom sheet
-        "inset-x-0 bottom-0 max-h-[85vh] w-full rounded-t-lg",
-        // Animation (shared)
-        "data-[state=open]:fade-in-0 data-[state=open]:animate-in",
-        "data-[state=closed]:fade-out-0 data-[state=closed]:animate-out",
-        // Mobile: slide up from bottom
-        "data-[state=open]:slide-in-from-bottom-full",
-        "data-[state=closed]:slide-out-to-bottom-full",
-        // Desktop: centered dialog
-        "sm:inset-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg",
-        // Desktop: scale in/out (cancel mobile slide)
-        "sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:zoom-in-95",
-        "sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=closed]:zoom-out-95",
-        // Duration
-        "duration-200",
-        // Size
-        SIZE_CLASSES[size],
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </DialogPrimitive.Content>
-  </DialogPrimitive.Portal>
-));
+>(
+  (
+    {
+      className,
+      children,
+      size = "md",
+      overlay = true,
+      portal = true,
+      style,
+      onOpenAutoFocus,
+      ...props
+    },
+    ref,
+  ) => {
+    const content = (
+      <>
+        {overlay && <DialogOverlay />}
+        <DialogPrimitive.Content
+          ref={ref}
+          style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
+          onOpenAutoFocus={(e) => {
+            if (onOpenAutoFocus) {
+              onOpenAutoFocus(e);
+              return;
+            }
+            e.preventDefault();
+            (e.currentTarget as HTMLElement).focus();
+          }}
+          className={cn(
+            "fixed flex flex-col overflow-hidden bg-background-primary shadow-lg focus:outline-none dark:bg-surface-primary",
+            "inset-x-0 bottom-0 max-h-[85vh] w-full rounded-t-lg",
+            "data-[state=open]:fade-in-0 data-[state=open]:animate-in",
+            "data-[state=closed]:fade-out-0 data-[state=closed]:animate-out",
+            "data-[state=open]:slide-in-from-bottom-full",
+            "data-[state=closed]:slide-out-to-bottom-full",
+            "sm:inset-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg",
+            "sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:zoom-in-95",
+            "sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=closed]:zoom-out-95",
+            "duration-200",
+            SIZE_CLASSES[size],
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </DialogPrimitive.Content>
+      </>
+    );
+
+    return portal ? <DialogPrimitive.Portal>{content}</DialogPrimitive.Portal> : content;
+  },
+);
 DialogContent.displayName = "DialogContent";
 
 export interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/src/styles/migrationLeftovers.test.ts
+++ b/src/styles/migrationLeftovers.test.ts
@@ -53,14 +53,23 @@ const oldForms: string[] = [
 
 const files = ROOTS.flatMap(walk);
 
+const findHits = (token: string): string[] => {
+  const pattern = anchored(token);
+
+  return files.flatMap((file) =>
+    readFileSync(file, "utf-8")
+      .split("\n")
+      .flatMap((line, index) => (pattern.test(line) ? [`${file}:${index + 1}`] : [])),
+  );
+};
+
 describe("design-token migration leftovers", () => {
   it("scans a non-empty set of source files", () => {
     expect(files.length).toBeGreaterThan(0);
   });
 
   it.each(oldForms)("no source file still references %s", (token) => {
-    const pattern = anchored(token);
-    const hits = files.filter((file) => pattern.test(readFileSync(file, "utf-8")));
+    const hits = findHits(token);
     expect(hits, `${token} still used in: ${hits.join(", ")}`).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link related issues with "Closes #123". -->

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<!-- Paste screenshots or a link to the Chromatic/Storybook build. -->

# tested in pandora like so

added these scripts to package.json
```
"copy:styles": "mkdir -p dist/styles && cp src/styles/theme.css src/styles/base.css dist/styles/",
    "build": "vite build && pnpm copy:styles",
    "build:watch": "pnpm copy:styles && vite build --watch & while true; do pnpm copy:styles; sleep 1; done",
```

in pandora on every change
```
cd eden && pnpm remove @fanvue/ui && pnpm add file:../../fanv-ui
```

would be awesome to have an easy way to do this!