### PR TITLE
feat(Dialog): upgrade dialog to v2 (ENG-11207)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4261,87 +4261,83 @@ function LoaderDemo() {
 
 function DialogDemo() {
   const [basicOpen, setBasicOpen] = useState(false);
-  const [smOpen, setSmOpen] = useState(false);
-  const [lgOpen, setLgOpen] = useState(false);
+  const [destructiveOpen, setDestructiveOpen] = useState(false);
+  const [upsellOpen, setUpsellOpen] = useState(false);
   const [backOpen, setBackOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const [scrollOpen, setScrollOpen] = useState(false);
 
   return (
     <div id="dialog" className="flex scroll-mt-20 flex-col gap-4">
-      <h2 className="typography-header-heading-xs mb-4">Dialog</h2>
+      <h2 className="typography-header-heading-xs mb-4">Dialog v2</h2>
 
-      {/* Basic */}
-      <h3 className="typography-body-default-16px-semibold">Basic</h3>
+      <h3 className="typography-body-default-16px-semibold">Modal states</h3>
       <div className="flex flex-wrap gap-3">
         <Dialog open={basicOpen} onOpenChange={setBasicOpen}>
           <DialogTrigger asChild>
-            <Button>Open Dialog</Button>
+            <Button>Primary + secondary</Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Dialog Title</DialogTitle>
+              <DialogTitle>Title goes here</DialogTitle>
             </DialogHeader>
             <DialogBody>
               <DialogDescription>
-                Dialog body text goes here. Describe the content or provide information to the user.
+                Dialog content can hold text, forms, lists, or any custom component.
+              </DialogDescription>
+            </DialogBody>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="secondary">CTA</Button>
+              </DialogClose>
+              <Button>CTA</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={destructiveOpen} onOpenChange={setDestructiveOpen}>
+          <DialogTrigger asChild>
+            <Button variant="secondary">Destructive</Button>
+          </DialogTrigger>
+          <DialogContent size="sm">
+            <DialogHeader>
+              <DialogTitle>Remove member?</DialogTitle>
+            </DialogHeader>
+            <DialogBody>
+              <DialogDescription>
+                This will remove the selected member from your team.
               </DialogDescription>
             </DialogBody>
             <DialogFooter>
               <DialogClose asChild>
                 <Button variant="secondary">Cancel</Button>
               </DialogClose>
-              <Button>Accept</Button>
+              <Button variant="destructive">Remove</Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
-      </div>
 
-      {/* Sizes */}
-      <h3 className="typography-body-default-16px-semibold mt-4">Sizes</h3>
-      <div className="flex flex-wrap gap-3">
-        <Dialog open={smOpen} onOpenChange={setSmOpen}>
+        <Dialog open={upsellOpen} onOpenChange={setUpsellOpen}>
           <DialogTrigger asChild>
-            <Button variant="secondary">Small (400px)</Button>
+            <Button variant="secondary">Upsell</Button>
           </DialogTrigger>
           <DialogContent size="sm">
             <DialogHeader>
-              <DialogTitle>Small Dialog</DialogTitle>
+              <DialogTitle>Upgrade plan</DialogTitle>
             </DialogHeader>
             <DialogBody>
-              <DialogDescription>A compact confirmation dialog.</DialogDescription>
+              <DialogDescription>
+                Unlock additional team seats and advanced controls.
+              </DialogDescription>
             </DialogBody>
             <DialogFooter>
-              <DialogClose asChild>
-                <Button variant="secondary">Cancel</Button>
-              </DialogClose>
-              <Button>Confirm</Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        <Dialog open={lgOpen} onOpenChange={setLgOpen}>
-          <DialogTrigger asChild>
-            <Button variant="secondary">Large (600px)</Button>
-          </DialogTrigger>
-          <DialogContent size="lg">
-            <DialogHeader>
-              <DialogTitle>Large Dialog</DialogTitle>
-            </DialogHeader>
-            <DialogBody>
-              <DialogDescription>A wider dialog for complex content.</DialogDescription>
-            </DialogBody>
-            <DialogFooter>
-              <DialogClose asChild>
-                <Button variant="secondary">Cancel</Button>
-              </DialogClose>
-              <Button>Save</Button>
+              <Button variant="brand">Upgrade</Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
       </div>
 
-      {/* With Back Button */}
-      <h3 className="typography-body-default-16px-semibold mt-4">With Back Button</h3>
+      <h3 className="typography-body-default-16px-semibold mt-4">Header states</h3>
       <div className="flex flex-wrap gap-3">
         <Dialog open={backOpen} onOpenChange={setBackOpen}>
           <DialogTrigger asChild>
@@ -4362,14 +4358,29 @@ function DialogDemo() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+
+        <Dialog open={searchOpen} onOpenChange={setSearchOpen}>
+          <DialogTrigger asChild>
+            <Button variant="secondary">Search Header</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <SearchField size="32" placeholder="Search..." fullWidth />
+            </DialogHeader>
+            <DialogBody>
+              <DialogDescription>
+                Search-specific headers compose the existing SearchField component.
+              </DialogDescription>
+            </DialogBody>
+          </DialogContent>
+        </Dialog>
       </div>
 
-      {/* Scrollable */}
-      <h3 className="typography-body-default-16px-semibold mt-4">Scrollable</h3>
+      <h3 className="typography-body-default-16px-semibold mt-4">Sheet and scroll</h3>
       <div className="flex flex-wrap gap-3">
         <Dialog open={scrollOpen} onOpenChange={setScrollOpen}>
           <DialogTrigger asChild>
-            <Button variant="secondary">Scrollable</Button>
+            <Button variant="secondary">Scrollable Sheet</Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4365,6 +4365,7 @@ function DialogDemo() {
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
+              <DialogTitle className="sr-only">Search dialog</DialogTitle>
               <SearchField size="32" placeholder="Search..." fullWidth />
             </DialogHeader>
             <DialogBody>

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -164,6 +164,7 @@ export const AllStatesV2: Story = {
             </DialogTrigger>
             <DialogContent>
               <DialogHeader>
+                <DialogTitle className="sr-only">Search dialog</DialogTitle>
                 <SearchField size="32" placeholder="Search..." fullWidth />
               </DialogHeader>
               <DialogBody>

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -475,7 +475,7 @@ export const WithInputContent: Story = {
         <Button>Open Dialog</Button>
       </DialogTrigger>
       <DialogContent aria-label="Warnings" aria-describedby={undefined}>
-        <DialogBody>
+        <DialogBody className="py-0">
           <p className="typography-header-heading-sm text-content-primary">What are warnings?</p>
           <p className="typography-body-default-16px-semibold mt-1 text-content-primary">
             Dialog title here
@@ -483,7 +483,7 @@ export const WithInputContent: Story = {
           <p className="typography-body-default-16px-regular mt-2 text-content-secondary">
             Dialog body text goes here. Describe the content or provide information to the user.
           </p>
-          <div className="mt-4">
+          <div className="mt-4 px-1 pb-1">
             <TextField label="Label" placeholder="You can choose field variant." fullWidth />
           </div>
         </DialogBody>

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from "../Button/Button";
 import { Chip } from "../Chip/Chip";
 import { ArrowRightIcon } from "../Icons/ArrowRightIcon";
 import { CheckIcon } from "../Icons/CheckIcon";
+import { SearchField } from "../SearchField/SearchField";
 import { TextArea } from "../TextArea/TextArea";
 import { TextField } from "../TextField/TextField";
 import {
@@ -19,6 +20,9 @@ import {
   DialogTrigger,
 } from "./Dialog";
 
+const V2_FIGMA_URL =
+  "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17004-106869&p=f&m=dev";
+
 const meta = {
   title: "Components/Dialog",
   component: DialogContent,
@@ -26,7 +30,7 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=1467-1293",
+      url: V2_FIGMA_URL,
     },
   },
   tags: ["autodocs"],
@@ -63,6 +67,161 @@ export const Default: Story = {
     </Dialog>
   ),
   play: openDialog,
+};
+
+export const AllStatesV2: Story = {
+  name: "All states (v2)",
+  parameters: { design: { type: "figma", url: V2_FIGMA_URL } },
+  render: () => (
+    <div className="flex max-w-3xl flex-col gap-4">
+      <div>
+        <p className="typography-body-default-16px-semibold mb-2 text-content-primary">
+          Modal states
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">Desktop with CTAs</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Title goes here</DialogTitle>
+              </DialogHeader>
+              <DialogBody>
+                <DialogDescription>
+                  Dialog content can hold text, forms, lists, or any custom component.
+                </DialogDescription>
+              </DialogBody>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="secondary">CTA</Button>
+                </DialogClose>
+                <Button>CTA</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">No CTAs</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Title goes here</DialogTitle>
+              </DialogHeader>
+              <DialogBody>
+                <DialogDescription>
+                  Use this pattern when the body contains its own self-contained action flow.
+                </DialogDescription>
+              </DialogBody>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">Destructive</Button>
+            </DialogTrigger>
+            <DialogContent size="sm">
+              <DialogHeader>
+                <DialogTitle>Remove member?</DialogTitle>
+              </DialogHeader>
+              <DialogBody>
+                <DialogDescription>
+                  This will remove the selected member from your team.
+                </DialogDescription>
+              </DialogBody>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="secondary">Cancel</Button>
+                </DialogClose>
+                <Button variant="destructive">Remove</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">Upsell</Button>
+            </DialogTrigger>
+            <DialogContent size="sm">
+              <DialogHeader>
+                <DialogTitle>Upgrade plan</DialogTitle>
+              </DialogHeader>
+              <DialogBody>
+                <DialogDescription>
+                  Unlock additional team seats and advanced controls.
+                </DialogDescription>
+              </DialogBody>
+              <DialogFooter>
+                <Button variant="brand">Upgrade</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">Search header</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <SearchField size="32" placeholder="Search..." fullWidth />
+              </DialogHeader>
+              <DialogBody>
+                <DialogDescription>
+                  Search-specific headers can compose the existing SearchField component.
+                </DialogDescription>
+              </DialogBody>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      <div>
+        <p className="typography-body-default-16px-semibold mb-2 text-content-primary">
+          Sheet states
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">Mobile sheet</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Title goes here</DialogTitle>
+              </DialogHeader>
+              <DialogBody>
+                <DialogDescription>
+                  On mobile viewports, Dialog uses the v2 sheet treatment with a pull handle.
+                </DialogDescription>
+              </DialogBody>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="secondary">CTA</Button>
+                </DialogClose>
+                <Button>CTA</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">No pull handle</Button>
+            </DialogTrigger>
+            <DialogContent showMobileHandle={false}>
+              <DialogHeader>
+                <DialogTitle>Title goes here</DialogTitle>
+              </DialogHeader>
+              <DialogBody>
+                <DialogDescription>
+                  The mobile handle can be hidden for highly custom shell treatments.
+                </DialogDescription>
+              </DialogBody>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+    </div>
+  ),
 };
 
 export const WithTrigger: Story = {

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -152,6 +152,8 @@ describe("Dialog", () => {
       const dialog = screen.getByRole("dialog");
       expect(dialog).toHaveClass("rounded-t-xl");
       expect(dialog).toHaveClass("sm:rounded-xl");
+      expect(dialog).toHaveClass("inset-x-0");
+      expect(dialog).toHaveClass("w-full");
       expect(dialog).toHaveClass("border-modal-stroke");
       expect(dialog).toHaveClass("bg-modal-background");
       expect(dialog).toHaveClass("shadow-blur-menu");

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -152,7 +152,8 @@ describe("Dialog", () => {
       const dialog = screen.getByRole("dialog");
       expect(dialog).toHaveClass("rounded-t-xl");
       expect(dialog).toHaveClass("sm:rounded-xl");
-      expect(dialog).toHaveClass("border-border-primary");
+      expect(dialog).toHaveClass("border-modal-stroke");
+      expect(dialog).toHaveClass("bg-modal-background");
       expect(dialog).toHaveClass("shadow-blur-menu");
       expect(dialog).toHaveClass("backdrop-blur-[4px]");
     });

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -147,6 +147,26 @@ describe("Dialog", () => {
       expect(screen.getByRole("dialog").className).toContain("sm:max-w-[600px]");
     });
 
+    it("applies v2 surface treatment", () => {
+      renderDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveClass("rounded-t-xl");
+      expect(dialog).toHaveClass("sm:rounded-xl");
+      expect(dialog).toHaveClass("border-border-primary");
+      expect(dialog).toHaveClass("shadow-blur-menu");
+      expect(dialog).toHaveClass("backdrop-blur-[4px]");
+    });
+
+    it("renders the mobile sheet handle by default", () => {
+      renderDialog();
+      expect(document.querySelector(".bg-icons-tertiary")).toBeInTheDocument();
+    });
+
+    it("hides the mobile sheet handle when showMobileHandle is false", () => {
+      renderDialog({ showMobileHandle: false });
+      expect(document.querySelector(".bg-icons-tertiary")).not.toBeInTheDocument();
+    });
+
     it("supports controlled open state", async () => {
       const onOpenChange = vi.fn();
       const user = userEvent.setup();

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -83,6 +83,8 @@ export interface DialogContentProps
    * @default true
    */
   portal?: boolean;
+  /** Show the v2 mobile sheet pull handle. @default true */
+  showMobileHandle?: boolean;
 }
 
 const SIZE_CLASSES: Record<NonNullable<DialogContentProps["size"]>, string> = {
@@ -133,6 +135,7 @@ export const DialogContent = React.forwardRef<
       size = "md",
       overlay = true,
       portal = true,
+      showMobileHandle = true,
       style,
       onOpenAutoFocus,
       ...props
@@ -154,13 +157,13 @@ export const DialogContent = React.forwardRef<
             (e.currentTarget as HTMLElement).focus();
           }}
           className={cn(
-            "fixed flex flex-col overflow-hidden bg-background-primary shadow-lg focus:outline-none dark:bg-surface-primary",
-            "inset-x-0 bottom-0 max-h-[85vh] w-full rounded-t-lg",
+            "fixed flex flex-col overflow-hidden border border-border-primary bg-background-primary shadow-blur-menu backdrop-blur-[4px] focus:outline-none",
+            "inset-x-4 bottom-0 max-h-[85vh] w-auto rounded-t-xl p-4 pt-3",
             "data-[state=open]:fade-in-0 data-[state=open]:animate-in",
             "data-[state=closed]:fade-out-0 data-[state=closed]:animate-out",
             "data-[state=open]:slide-in-from-bottom-full",
             "data-[state=closed]:slide-out-to-bottom-full",
-            "sm:inset-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg",
+            "sm:inset-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:w-full sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl sm:p-6",
             "sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:zoom-in-95",
             "sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=closed]:zoom-out-95",
             "duration-200",
@@ -169,6 +172,12 @@ export const DialogContent = React.forwardRef<
           )}
           {...props}
         >
+          {showMobileHandle && (
+            <div
+              aria-hidden="true"
+              className="mb-3 h-1 w-8 shrink-0 self-center rounded-full bg-icons-tertiary sm:hidden"
+            />
+          )}
           {children}
         </DialogPrimitive.Content>
       </>
@@ -226,14 +235,14 @@ export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
     return (
       <div
         ref={ref}
-        className={cn("flex h-16 shrink-0 items-center gap-2 px-6 py-4", className)}
+        className={cn("flex shrink-0 items-center justify-end gap-4 overflow-hidden", className)}
         {...props}
       >
         {shouldShowBack && (
           <IconButton
-            variant="tertiary"
+            variant="secondary"
             size="32"
-            icon={<ArrowLeftIcon />}
+            icon={<ArrowLeftIcon size={16} />}
             onClick={onBack}
             disabled={!onBack}
             aria-label={backLabel}
@@ -242,7 +251,12 @@ export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
         <div className="min-w-0 flex-1">{children}</div>
         {showClose && (
           <DialogPrimitive.Close asChild>
-            <IconButton variant="tertiary" size="32" icon={<CloseIcon />} aria-label={closeLabel} />
+            <IconButton
+              variant="secondary"
+              size="32"
+              icon={<CloseIcon size={16} />}
+              aria-label={closeLabel}
+            />
           </DialogPrimitive.Close>
         )}
       </div>
@@ -264,7 +278,7 @@ export const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("typography-header-heading-xs truncate text-content-primary", className)}
+    className={cn("typography-header-heading-xs text-content-primary", className)}
     {...props}
   />
 ));
@@ -296,7 +310,7 @@ export interface DialogBodyProps extends React.HTMLAttributes<HTMLDivElement> {}
  */
 export const DialogBody = React.forwardRef<HTMLDivElement, DialogBodyProps>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex-1 overflow-y-auto px-6 py-4", className)} {...props} />
+    <div ref={ref} className={cn("flex-1 overflow-y-auto py-4 sm:py-6", className)} {...props} />
   ),
 );
 DialogBody.displayName = "DialogBody";
@@ -311,11 +325,7 @@ export const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>(
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn(
-        "flex shrink-0 items-center gap-3 px-6 pt-3 pb-6",
-        "[&>*]:min-w-0 [&>*]:flex-1",
-        className,
-      )}
+      className={cn("flex shrink-0 items-center gap-2", "[&>*]:min-w-0 [&>*]:flex-1", className)}
       {...props}
     />
   ),

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -158,7 +158,7 @@ export const DialogContent = React.forwardRef<
           }}
           className={cn(
             "fixed flex flex-col overflow-hidden border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[4px] focus:outline-none",
-            "inset-x-4 bottom-0 max-h-[85vh] w-auto rounded-t-xl p-4 pt-3",
+            "inset-x-0 bottom-0 max-h-[85vh] w-full rounded-t-xl p-4 pt-3",
             "data-[state=open]:fade-in-0 data-[state=open]:animate-in",
             "data-[state=closed]:fade-out-0 data-[state=closed]:animate-out",
             "data-[state=open]:slide-in-from-bottom-full",

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -157,7 +157,7 @@ export const DialogContent = React.forwardRef<
             (e.currentTarget as HTMLElement).focus();
           }}
           className={cn(
-            "fixed flex flex-col overflow-hidden border border-border-primary bg-background-primary shadow-blur-menu backdrop-blur-[4px] focus:outline-none",
+            "fixed flex flex-col overflow-hidden border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[4px] focus:outline-none",
             "inset-x-4 bottom-0 max-h-[85vh] w-auto rounded-t-xl p-4 pt-3",
             "data-[state=open]:fade-in-0 data-[state=open]:animate-in",
             "data-[state=closed]:fade-out-0 data-[state=closed]:animate-out",
@@ -235,7 +235,7 @@ export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
     return (
       <div
         ref={ref}
-        className={cn("flex shrink-0 items-center justify-end gap-4 overflow-hidden", className)}
+        className={cn("flex shrink-0 items-center justify-end gap-4", className)}
         {...props}
       >
         {shouldShowBack && (


### PR DESCRIPTION
## Summary
- Upgrade the existing Dialog shell to the v2 modal/sheet treatment from Figma while keeping the compound API stable.
- Add v2 Storybook coverage, including all-states examples for CTAs, no CTAs, destructive, upsell, search header, and mobile sheet handle.
- Refresh the local Dialog demo and add tests for the v2 surface and mobile handle behavior.

## Test plan
- `pnpm --dir /Users/fanvue/Repos/fanv-ui-ENG-11207 test -- src/components/Dialog/Dialog.test.tsx`
- `pnpm --dir /Users/fanvue/Repos/fanv-ui-ENG-11207 typecheck`
- `pnpm --dir /Users/fanvue/Repos/fanv-ui-ENG-11207 exec biome check src/components/Dialog/Dialog.tsx src/components/Dialog/Dialog.stories.tsx src/components/Dialog/Dialog.test.tsx src/App.tsx` (passes with existing unrelated App.tsx warnings)


Made with [Cursor](https://cursor.com)