### PR TITLE
feat(CyclingText): Expose activeIndex callback

### DIFF
--- a/src/components/CyclingText/CyclingText.test.tsx
+++ b/src/components/CyclingText/CyclingText.test.tsx
@@ -146,6 +146,60 @@ describe("CyclingText", () => {
     });
   });
 
+  describe("onActiveIndexChange", () => {
+    it("reports the initial index on mount", () => {
+      const onActiveIndexChange = vi.fn();
+      render(<CyclingText items={ITEMS} onActiveIndexChange={onActiveIndexChange} />);
+      expect(onActiveIndexChange).toHaveBeenCalledWith(0);
+    });
+
+    it("reports each settled index as the visible item changes, wrapping around", () => {
+      const onActiveIndexChange = vi.fn();
+      render(
+        <CyclingText
+          items={ITEMS}
+          intervalMs={500}
+          transitionMs={100}
+          onActiveIndexChange={onActiveIndexChange}
+        />,
+      );
+
+      expect(onActiveIndexChange).toHaveBeenLastCalledWith(0);
+
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(100));
+      expect(getVisibleLabel().textContent).toBe("Beta");
+      expect(onActiveIndexChange).toHaveBeenLastCalledWith(1);
+
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(100));
+      expect(onActiveIndexChange).toHaveBeenLastCalledWith(2);
+
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(100));
+      expect(onActiveIndexChange).toHaveBeenLastCalledWith(0);
+    });
+
+    it("does not report the next index until the transition settles", () => {
+      const onActiveIndexChange = vi.fn();
+      render(
+        <CyclingText
+          items={ITEMS}
+          intervalMs={500}
+          transitionMs={1000}
+          onActiveIndexChange={onActiveIndexChange}
+        />,
+      );
+      onActiveIndexChange.mockClear();
+
+      act(() => vi.advanceTimersByTime(500));
+      expect(onActiveIndexChange).not.toHaveBeenCalled();
+
+      act(() => vi.advanceTimersByTime(1000));
+      expect(onActiveIndexChange).toHaveBeenCalledWith(1);
+    });
+  });
+
   describe("accessibility", () => {
     beforeEach(() => {
       vi.useRealTimers();

--- a/src/components/CyclingText/CyclingText.tsx
+++ b/src/components/CyclingText/CyclingText.tsx
@@ -45,6 +45,13 @@ export interface CyclingTextProps extends Omit<React.HTMLAttributes<HTMLSpanElem
    * effects that have to sit on the text element itself, e.g. `background-clip: text`.
    */
   labelClassName?: string;
+  /**
+   * Called with the index of the settled, fully-visible item — once on mount and
+   * again whenever it changes (after each transition completes). Lets a parent
+   * stay in lockstep with what is on screen (e.g. to act on the item the user is
+   * currently looking at) without running a second, drifting timer of its own.
+   */
+  onActiveIndexChange?: (index: number) => void;
 }
 
 /**
@@ -69,6 +76,7 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
       className,
       labelClassName,
       announceChanges = false,
+      onActiveIndexChange,
       ...rest
     },
     ref,
@@ -76,10 +84,27 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
     const docVisible = usePageVisibility();
     const reducedMotion = usePrefersReducedMotion();
     const { sizingLabelRef, trackWidth } = useCyclingTextTrackWidth();
-    const { cycle, currentLabel, incomingLabel, sizingLabel, onOutgoingTransitionEnd } =
-      useCyclingCycle(items, sizing, intervalMs, paused, docVisible, transitionMs);
+    const {
+      cycle,
+      currentIndex,
+      currentLabel,
+      incomingLabel,
+      sizingLabel,
+      onOutgoingTransitionEnd,
+    } = useCyclingCycle(items, sizing, intervalMs, paused, docVisible, transitionMs);
 
     const itemCount = items.length;
+
+    // Notify the parent of the settled active index without re-subscribing when
+    // an inline callback identity changes each render — the latest is always
+    // read from the ref.
+    const onActiveIndexChangeRef = React.useRef(onActiveIndexChange);
+    React.useEffect(() => {
+      onActiveIndexChangeRef.current = onActiveIndexChange;
+    }, [onActiveIndexChange]);
+    React.useEffect(() => {
+      onActiveIndexChangeRef.current?.(currentIndex);
+    }, [currentIndex]);
 
     const outgoingMotionStyle = React.useMemo((): React.CSSProperties => {
       const durMs = reducedMotion ? 0 : transitionMs;

--- a/src/components/CyclingText/useCyclingCycle.ts
+++ b/src/components/CyclingText/useCyclingCycle.ts
@@ -238,6 +238,7 @@ export function useCyclingCycle(
 
   return {
     cycle,
+    currentIndex: safeCurrentIndex,
     currentLabel,
     incomingLabel,
     sizingLabel,


### PR DESCRIPTION
## Summary

Updates the CyclingText component with a callback when the activeIndex changes. This allows external components to know and react to the currently displayed text.

## Changes

- exposes `onActiveIndexChange` attribute

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

No visual change