### PR TITLE
feat(ChatInput): Show the selected element with a tick, not highlight

### DIFF
--- a/src/components/ChatInput/ChatInput.test.tsx
+++ b/src/components/ChatInput/ChatInput.test.tsx
@@ -314,6 +314,33 @@ describe("ChatInput", () => {
       expect(screen.getByRole("option", { name: "Example" })).toBeInTheDocument();
     });
 
+    it("applies the hover background to the select trigger while open", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChatInput placeholder="Test" selectOptions={MODEL_OPTIONS} selectValue="fanvue-ai" />,
+      );
+      const trigger = screen.getByRole("combobox", { name: "Select model" });
+      await user.click(trigger);
+      expect(trigger).toHaveClass("bg-neutral-alphas-50");
+    });
+
+    it("shows a check icon only on the selected option", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChatInput
+          placeholder="Test"
+          selectOptions={[
+            { value: "opus", label: "Opus 4.8" },
+            { value: "sonnet", label: "Sonnet 4.6" },
+          ]}
+          selectValue="opus"
+        />,
+      );
+      await user.click(screen.getByRole("combobox", { name: "Select model" }));
+      expect(screen.getByRole("option", { name: "Opus 4.8" }).querySelector("svg")).toBeTruthy();
+      expect(screen.getByRole("option", { name: "Sonnet 4.6" }).querySelector("svg")).toBeNull();
+    });
+
     it("calls onSelectChange when an option is clicked", async () => {
       const user = userEvent.setup();
       const handleChange = vi.fn();

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -3,6 +3,7 @@ import { cn } from "../../utils/cn";
 import { IconButton } from "../IconButton/IconButton";
 import { AddIcon } from "../Icons/AddIcon";
 import { ArrowUpIcon } from "../Icons/ArrowUpIcon";
+import { CheckIcon } from "../Icons/CheckIcon";
 import { ChevronDownIcon } from "../Icons/ChevronDownIcon";
 import { CloseIcon } from "../Icons/CloseIcon";
 
@@ -432,6 +433,7 @@ function InlineSelect({ options, value, onChange, disabled, selectedOption }: In
           "hover:bg-neutral-alphas-50 focus-visible:shadow-focus-ring focus-visible:outline-none",
           "disabled:cursor-not-allowed disabled:opacity-50",
           "motion-safe:transition-colors",
+          open && "bg-neutral-alphas-50",
         )}
       >
         {selectedOption?.icon && (
@@ -447,8 +449,8 @@ function InlineSelect({ options, value, onChange, disabled, selectedOption }: In
         <div
           role="listbox"
           className={cn(
-            "absolute right-0 bottom-full z-10 mb-1 min-w-[140px]",
-            "overflow-hidden rounded-xs border border-border-primary bg-surface-primary p-1 shadow-lg",
+            "absolute right-0 bottom-full z-10 mb-1 min-w-[180px]",
+            "overflow-hidden rounded-xs border border-border-primary bg-surface-primary p-1.5 shadow-lg",
           )}
         >
           {options.map((option) => (
@@ -458,10 +460,9 @@ function InlineSelect({ options, value, onChange, disabled, selectedOption }: In
               tabIndex={0}
               aria-selected={option.value === value}
               className={cn(
-                "typography-body-small-14px-regular flex cursor-pointer items-center gap-2 rounded-xs px-3 py-1.5",
+                "typography-body-small-14px-regular flex cursor-pointer items-center gap-2 rounded-xs py-2.5 pr-2 pl-3",
                 "text-content-primary hover:bg-neutral-alphas-50",
                 "focus-visible:shadow-focus-ring focus-visible:outline-none",
-                option.value === value && "bg-neutral-alphas-50",
               )}
               onClick={() => {
                 onChange?.(option.value);
@@ -478,7 +479,12 @@ function InlineSelect({ options, value, onChange, disabled, selectedOption }: In
               {option.icon && (
                 <span className="flex shrink-0 items-center [&>svg]:size-4">{option.icon}</span>
               )}
-              {option.label}
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+              {option.value === value && (
+                <span className="ml-auto flex size-4 shrink-0 items-center justify-center">
+                  <CheckIcon className="size-4 text-content-primary" aria-hidden="true" />
+                </span>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Update the UI for the selected state of the ChatInput DropDown. Ready to review. Might change later on future design guidance.

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<img width="401" height="164" alt="image" src="https://github.com/user-attachments/assets/534e80c2-9525-4011-acd7-04aef94b3d54" />
