### PR TITLE
fix(theme): inset focus ring so it isn't clipped by overflow containers (ENG-11352)

### DIFF
--- a/src/components/Accordion/AccordionTrigger.tsx
+++ b/src/components/Accordion/AccordionTrigger.tsx
@@ -35,7 +35,7 @@ export const AccordionTrigger = React.forwardRef<
           "cursor-pointer",
           "motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-in-out",
           "hover:bg-neutral-alphas-100",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary",
+          "focus-visible:shadow-focus-ring focus-visible:outline-none",
           "data-disabled:pointer-events-none data-disabled:opacity-50",
           className,
         )}

--- a/src/components/BottomNavigation/BottomNavigationAction.tsx
+++ b/src/components/BottomNavigation/BottomNavigationAction.tsx
@@ -49,7 +49,7 @@ export const BottomNavigationAction = React.forwardRef<
           "relative flex min-w-0 flex-1 cursor-pointer flex-col items-center justify-center gap-1",
           isActive ? "text-icons-primary" : "text-icons-tertiary",
           "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary",
+          "focus-visible:shadow-focus-ring focus-visible:outline-none",
           className,
         )}
       >
@@ -85,7 +85,7 @@ export const BottomNavigationAction = React.forwardRef<
         "relative flex min-w-0 flex-1 cursor-pointer flex-col items-center justify-center gap-0.5 overflow-hidden px-2 py-2",
         "text-content-primary",
         "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary",
+        "focus-visible:shadow-focus-ring focus-visible:outline-none",
         className,
       )}
       onClick={handleClick}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -128,7 +128,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             "hover:ring-2 hover:ring-brand-primary-default group-hover:ring-2 group-hover:ring-brand-primary-default",
             "not-disabled:active:ring-2 not-disabled:active:ring-brand-primary-default",
             // Focus state
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary",
+            "focus-visible:shadow-focus-ring focus-visible:outline-none",
             // Disabled state
             "disabled:cursor-not-allowed disabled:border-neutral-alphas-600 disabled:ring-0 disabled:group-hover:ring-0",
             "disabled:data-[state=checked]:border-neutral-alphas-600 disabled:data-[state=checked]:bg-neutral-alphas-600 disabled:data-[state=checked]:text-content-tertiary",

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -40,7 +40,7 @@ export const Radio = React.forwardRef<
         data-testid="radio"
         aria-describedby={helperText ? helperTextId : undefined}
         className={cn(
-          "relative h-4 w-4 shrink-0 cursor-pointer appearance-none rounded-full border border-content-primary bg-transparent transition-colors hover:bg-brand-primary-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary not-disabled:active:bg-brand-primary-muted disabled:cursor-not-allowed disabled:border-neutral-alphas-600 disabled:bg-transparent data-[state=checked]:border-content-primary data-[state=checked]:bg-transparent",
+          "relative h-4 w-4 shrink-0 cursor-pointer appearance-none rounded-full border border-content-primary bg-transparent transition-colors hover:bg-brand-primary-muted focus-visible:shadow-focus-ring focus-visible:outline-none not-disabled:active:bg-brand-primary-muted disabled:cursor-not-allowed disabled:border-neutral-alphas-600 disabled:bg-transparent data-[state=checked]:border-content-primary data-[state=checked]:bg-transparent",
           helperText && "mt-1 self-start",
         )}
         {...props}

--- a/src/components/Slider/SliderThumb.tsx
+++ b/src/components/Slider/SliderThumb.tsx
@@ -47,7 +47,7 @@ export function SliderThumb({
         "transition-shadow duration-150",
         "hover:ring-2 hover:ring-brand-primary-default",
         "not-data-disabled:active:ring-2 not-data-disabled:active:ring-brand-primary-default",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary",
+        "focus-visible:shadow-focus-ring focus-visible:outline-none",
         "data-disabled:cursor-not-allowed",
       )}
     >

--- a/src/components/Tabs/TabsTrigger.tsx
+++ b/src/components/Tabs/TabsTrigger.tsx
@@ -26,7 +26,7 @@ export const TabsTrigger = React.forwardRef<
       "data-disabled:pointer-events-none",
       "data-disabled:data-[state=active]:text-content-tertiary",
       "data-disabled:data-[state=inactive]:text-neutral-alphas-300",
-      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-interaction-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background-primary",
+      "focus-visible:shadow-focus-ring focus-visible:outline-none",
       className,
     )}
     {...props}

--- a/src/styles/buildStyles.js
+++ b/src/styles/buildStyles.js
@@ -217,7 +217,9 @@ const getEffectTokens = (effectTokens) => {
 
   // Focus ring colour is mode-aware via --fv-focus-ring-color (set in :root and .dark):
   // violet on light backgrounds, white on dark ones, so the ring stays visible either way.
-  output += `  --shadow-focus-ring: 0 0 0 2px var(--color-background-primary), 0 0 0 4px var(--fv-focus-ring-color);\n`;
+  // Inset (not outward) so the indicator paints inside the element's box and can never be
+  // clipped by an ancestor with overflow:hidden/auto (ENG-11352).
+  output += `  --shadow-focus-ring: inset 0 0 0 2px var(--fv-focus-ring-color);\n`;
 
   return output;
 };

--- a/src/styles/buildStyles.test.ts
+++ b/src/styles/buildStyles.test.ts
@@ -54,8 +54,7 @@ describe("getEffectTokens", () => {
   });
 
   it("drives the focus ring through the mode-aware colour var", () => {
-    expect(css).toContain("--shadow-focus-ring: 0 0 0 2px var(--color-background-primary)");
-    expect(css).toContain("var(--fv-focus-ring-color)");
+    expect(css).toContain("--shadow-focus-ring: inset 0 0 0 2px var(--fv-focus-ring-color)");
   });
 });
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -20,7 +20,7 @@
   --shadow-blur-menu: 0px 6px 12px 0px #0000001a;
   --shadow-blur-floating: 0px 12px 40px 2px #00000026;
   --shadow-ai-button-glow: -1px 1px 4px 0px #49f2643d, -4px 4px 12px 0px #49f26429, -8px 2px 24px 0px #49f2640a;
-  --shadow-focus-ring: 0 0 0 2px var(--color-background-primary), 0 0 0 4px var(--fv-focus-ring-color);
+  --shadow-focus-ring: inset 0 0 0 2px var(--fv-focus-ring-color);
   --radius-3xs: 2px;
   --radius-2xs: 4px;
   --radius-xs: 8px;


### PR DESCRIPTION
## Root cause

The keyboard focus indicator was drawn **outside** the element's box, so any ancestor with `overflow: hidden` / `overflow-y: auto` clipped it — producing visibly cropped focus rings across consuming apps (e.g. a text field flush inside a dialog, or a grouped card). This was never a `focus` vs `focus-visible` problem; components already use `focus-visible` correctly. Two outward patterns existed, both affected:

1. The `--shadow-focus-ring` token — an **outward** `box-shadow` (`0 0 0 2px bg, 0 0 0 4px ring`), consumed via `focus-visible:shadow-focus-ring` (~96 call sites).
2. A `focus-visible:ring-2 ring-offset-2 ring-offset-background-primary` pattern (Tailwind ring + ring-offset, also painted outside the box).

## The fix

Switch the focus indicator to an **inset** treatment so it sits just inside the element's edge and can never be clipped by an ancestor's overflow. One token change fixes all `shadow-focus-ring` call sites; no per-component overflow/padding workarounds.

- `--shadow-focus-ring` is now `inset 0 0 0 2px var(--fv-focus-ring-color)` (a solid 2px inset ring). The colour stays mode-aware via `--fv-focus-ring-color` (violet on light, white on dark), so it remains clearly visible and WCAG 2.4.7 compliant in both themes. The token is generated by `src/styles/buildStyles.js`; `theme.css` was regenerated.
- The 7 `ring-2 + ring-offset-2 + ring-offset-background-primary` usages (Accordion, BottomNavigation ×2, Checkbox, Radio, Slider thumb, Tabs) were standardised onto `focus-visible:shadow-focus-ring`, so the whole library now uses one consistent, non-clipping focus treatment.

## Visual trade-off (please review)

The indicator **no longer floats outside** the element — it loses the outer halo (the 2px background gap + outer coloured ring) and instead sits as a 2px ring **just inside** the element's edge. This is the intended cost of making it un-clippable. Worth a design eyeball on small round controls (Radio/Checkbox 16px, Slider thumb) and on bordered inputs before merge.

## Validation

- Type-check: pass
- Lint (biome): pass (0 errors; warnings unchanged from baseline)
- Tests (vitest): pass (3666/3666)
- Build (vite): pass

Marked as **draft** — design sign-off is required before merge.

Part of ENG-11352

Made with [Cursor](https://cursor.com)