### PR TITLE
fix(Tabs): re-measure active indicator after fonts load (ENG-11401)

### DIFF
--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -94,7 +94,15 @@ export const TabsList = React.forwardRef<
     const resizeObserver = new ResizeObserver(updateIndicator);
     resizeObserver.observe(list);
 
+    let cancelled = false;
+    if (document.fonts?.status !== "loaded") {
+      document.fonts?.ready.then(() => {
+        if (!cancelled) updateIndicator();
+      });
+    }
+
     return () => {
+      cancelled = true;
       mutationObserver.disconnect();
       resizeObserver.disconnect();
     };


### PR DESCRIPTION
## Summary

- Fixes a flaky/incorrect render of the `Tabs` active-tab indicator (the line under the active tab), where it appears shrunk and left-anchored (uncentered) under the tab.
- The indicator is sized from `activeTab.offsetWidth` in JS, with a `ResizeObserver` on the **list**. In full-width layouts the list is `flex w-full` (100% wide regardless of font), so the observer never fires when the web font (Inter) finishes loading and the tabs reflow wider — leaving a stale fallback-font width baked into the indicator.
- Re-measure on `document.fonts.ready` so the final width reflects the loaded font.

## Context

Surfaced as a flaky Chromatic diff on the 3.4.0 release PR (#511): the Tabs stories were re-snapshotted because of an unrelated focus-ring change, and that run lost the font-load race. This is a pre-existing latent bug, not introduced by the focus-ring change.

Linear: ENG-11401

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` (Tabs unit tests) pass
- [ ] Chromatic: Tabs full-width / align-left stories render the indicator at full active-tab width, centered under the tab

Made with [Cursor](https://cursor.com)