### PR TITLE
fix(ChartCard): prevent trendChip label truncation on mobile

### DIFF
--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -250,6 +250,22 @@ describe("Chart", () => {
     });
   });
 
+  describe("ChartCard", () => {
+    it("renders trendChip label in full without truncation", () => {
+      render(
+        <ChartCard
+          title="This month"
+          subtitle="$2,358.99"
+          trendChip={{ label: "$455.68 vs Mar", trend: "positive" }}
+          dateInfo="April 2026"
+        >
+          <div>chart</div>
+        </ChartCard>,
+      );
+      expect(screen.getByText("$455.68 vs Mar")).toBeInTheDocument();
+    });
+  });
+
   describe("accessibility", () => {
     it("ChartContainer has no accessibility violations", async () => {
       const { container } = render(

--- a/src/components/Chart/ChartCard.tsx
+++ b/src/components/Chart/ChartCard.tsx
@@ -102,14 +102,14 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                 )}
               </div>
               {subtitle && (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <span className="typography-header-heading-sm text-content-primary">
                     {subtitle}
                   </span>
                   {trendChip && (
                     <span
                       className={cn(
-                        "typography-description-12px-semibold rounded-full px-2 py-0.5",
+                        "typography-description-12px-semibold whitespace-nowrap rounded-full px-2 py-0.5",
                         TREND_CLASSES[trendChip.trend],
                       )}
                     >


### PR DESCRIPTION
## Summary

- Adds `flex-wrap` to the subtitle container div so the comparison badge wraps to the next line on narrow screens instead of being clipped
- Adds `whitespace-nowrap` to the trendChip span so badge text (e.g. `$455.68 vs Mar`) never breaks mid-word inside the pill

Fixes https://linear.app/fanvue/issue/ENG-10098

## Test plan

- [ ] Verify `$455.68 vs Mar` badge renders fully on narrow mobile viewports in the earnings ChartCard
- [ ] New unit test: `renders trendChip label in full without truncation` passes
- [ ] All existing Chart tests continue to pass