### PR TITLE
feat(ChatInput): add optional description to select options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -621,11 +621,13 @@ function ChatInputShowcase() {
             {
               value: "fanvue-ai",
               label: "Fanvue AI",
+              description: "Most capable for ambitious work",
               icon: <AIIcon className="size-4" />,
             },
             {
               value: "example",
               label: "Example",
+              description: "Fastest for quick answers",
               icon: <BulbIcon className="size-4" />,
             },
           ]}
@@ -640,11 +642,13 @@ function ChatInputShowcase() {
             {
               value: "fanvue-ai",
               label: "Fanvue AI",
+              description: "Most capable for ambitious work",
               icon: <AIIcon className="size-4" />,
             },
             {
               value: "example",
               label: "Example",
+              description: "Fastest for quick answers",
               icon: <BulbIcon className="size-4" />,
             },
           ]}

--- a/src/components/ChatInput/ChatInput.stories.tsx
+++ b/src/components/ChatInput/ChatInput.stories.tsx
@@ -8,9 +8,15 @@ const SELECT_OPTIONS = [
   {
     value: "fanvue-ai",
     label: "Fanvue AI",
+    description: "Most capable for ambitious work",
     icon: <AIIcon className="size-4" />,
   },
-  { value: "example", label: "Example", icon: <BulbIcon className="size-4" /> },
+  {
+    value: "example",
+    label: "Example",
+    description: "Fastest for quick answers",
+    icon: <BulbIcon className="size-4" />,
+  },
 ];
 
 const meta = {

--- a/src/components/ChatInput/ChatInput.stories.tsx
+++ b/src/components/ChatInput/ChatInput.stories.tsx
@@ -7,13 +7,16 @@ import { ChatInput } from "./ChatInput";
 const SELECT_OPTIONS = [
   {
     value: "fanvue-ai",
+    // Short label on the collapsed trigger; longer title inside the menu/sheet.
     label: "Fanvue AI",
+    menuLabel: "Fanvue AI",
     description: "Most capable for ambitious work",
     icon: <AIIcon className="size-4" />,
   },
   {
     value: "example",
     label: "Example",
+    menuLabel: "Example model",
     description: "Fastest for quick answers",
     icon: <BulbIcon className="size-4" />,
   },
@@ -93,6 +96,33 @@ export const WithModelSelector: Story = {
         selectOptions={SELECT_OPTIONS}
         selectValue={model}
         onSelectChange={setModel}
+        selectMenuTitle="Switch AI Model"
+      />
+    );
+  },
+};
+
+/**
+ * With `selectVariant="sheet"` the selector opens as a bottom sheet (Drawer
+ * `sheet` variant) titled by `selectMenuTitle`, instead of the dropdown. The
+ * consumer chooses the variant from its own breakpoint, e.g.
+ * `selectVariant={isDesktop ? "menu" : "sheet"}`.
+ */
+export const WithModelSelectorSheet: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+  },
+  render: () => {
+    const [model, setModel] = useState("fanvue-ai");
+
+    return (
+      <ChatInput
+        placeholder="Type a message..."
+        selectOptions={SELECT_OPTIONS}
+        selectValue={model}
+        onSelectChange={setModel}
+        selectVariant="sheet"
+        selectMenuTitle="Switch AI Model"
       />
     );
   },

--- a/src/components/ChatInput/ChatInput.test.tsx
+++ b/src/components/ChatInput/ChatInput.test.tsx
@@ -314,6 +314,31 @@ describe("ChatInput", () => {
       expect(screen.getByRole("option", { name: "Example" })).toBeInTheDocument();
     });
 
+    it("renders option descriptions in the dropdown", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChatInput
+          placeholder="Test"
+          selectOptions={[
+            {
+              value: "opus",
+              label: "Opus 4.8",
+              description: "Most capable for ambitious work",
+            },
+            {
+              value: "sonnet",
+              label: "Sonnet 4.6",
+              description: "Most efficient for everyday tasks",
+            },
+          ]}
+          selectValue="opus"
+        />,
+      );
+      await user.click(screen.getByRole("combobox", { name: "Select model" }));
+      expect(screen.getByText("Most capable for ambitious work")).toBeInTheDocument();
+      expect(screen.getByText("Most efficient for everyday tasks")).toBeInTheDocument();
+    });
+
     it("applies the hover background to the select trigger while open", async () => {
       const user = userEvent.setup();
       render(

--- a/src/components/ChatInput/ChatInput.test.tsx
+++ b/src/components/ChatInput/ChatInput.test.tsx
@@ -293,28 +293,28 @@ describe("ChatInput", () => {
       expect(screen.getByTestId("fanvue-ai-icon")).toBeInTheDocument();
     });
 
-    it("renders per-option icons in the dropdown", async () => {
+    it("renders per-option icons in the menu", async () => {
       const user = userEvent.setup();
       render(
         <ChatInput placeholder="Test" selectOptions={MODEL_OPTIONS} selectValue="fanvue-ai" />,
       );
-      await user.click(screen.getByRole("combobox", { name: "Select model" }));
-      const listbox = screen.getByRole("listbox");
-      expect(within(listbox).getByTestId("fanvue-ai-icon")).toBeInTheDocument();
-      expect(within(listbox).getByTestId("example-icon")).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Select model" }));
+      const menu = screen.getByRole("menu");
+      expect(within(menu).getByTestId("fanvue-ai-icon")).toBeInTheDocument();
+      expect(within(menu).getByTestId("example-icon")).toBeInTheDocument();
     });
 
-    it("opens dropdown on click and shows all options", async () => {
+    it("opens the menu on click and shows all options", async () => {
       const user = userEvent.setup();
       render(
         <ChatInput placeholder="Test" selectOptions={MODEL_OPTIONS} selectValue="fanvue-ai" />,
       );
-      await user.click(screen.getByRole("combobox", { name: "Select model" }));
-      expect(screen.getByRole("option", { name: "Fanvue AI" })).toBeInTheDocument();
-      expect(screen.getByRole("option", { name: "Example" })).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Select model" }));
+      expect(screen.getByRole("menuitem", { name: "Fanvue AI" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Example" })).toBeInTheDocument();
     });
 
-    it("renders option descriptions in the dropdown", async () => {
+    it("renders option descriptions in the menu", async () => {
       const user = userEvent.setup();
       render(
         <ChatInput
@@ -334,22 +334,46 @@ describe("ChatInput", () => {
           selectValue="opus"
         />,
       );
-      await user.click(screen.getByRole("combobox", { name: "Select model" }));
+      await user.click(screen.getByRole("button", { name: "Select model" }));
       expect(screen.getByText("Most capable for ambitious work")).toBeInTheDocument();
       expect(screen.getByText("Most efficient for everyday tasks")).toBeInTheDocument();
     });
 
-    it("applies the hover background to the select trigger while open", async () => {
+    it("shows the short label on the trigger but the menu label on the option", async () => {
+      const user = userEvent.setup();
+      render(
+        <ChatInput
+          placeholder="Test"
+          selectOptions={[
+            {
+              value: "sonnet",
+              label: "Sonnet 4.6",
+              menuLabel: "Claude Sonnet 4.6",
+              description: "Fast and versatile",
+            },
+            { value: "opus", label: "Opus 4.8", menuLabel: "Claude Opus 4.8" },
+          ]}
+          selectValue="sonnet"
+        />,
+      );
+      const trigger = screen.getByRole("button", { name: "Select model" });
+      expect(trigger).toHaveTextContent("Sonnet 4.6");
+      await user.click(trigger);
+      expect(screen.getByRole("menuitem", { name: /Claude Sonnet 4\.6/ })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /Claude Opus 4\.8/ })).toBeInTheDocument();
+    });
+
+    it("applies the active background to the trigger while open", async () => {
       const user = userEvent.setup();
       render(
         <ChatInput placeholder="Test" selectOptions={MODEL_OPTIONS} selectValue="fanvue-ai" />,
       );
-      const trigger = screen.getByRole("combobox", { name: "Select model" });
+      const trigger = screen.getByRole("button", { name: "Select model" });
       await user.click(trigger);
       expect(trigger).toHaveClass("bg-neutral-alphas-50");
     });
 
-    it("shows a check icon only on the selected option", async () => {
+    it("shows a tick icon only on the selected option", async () => {
       const user = userEvent.setup();
       render(
         <ChatInput
@@ -361,9 +385,9 @@ describe("ChatInput", () => {
           selectValue="opus"
         />,
       );
-      await user.click(screen.getByRole("combobox", { name: "Select model" }));
-      expect(screen.getByRole("option", { name: "Opus 4.8" }).querySelector("svg")).toBeTruthy();
-      expect(screen.getByRole("option", { name: "Sonnet 4.6" }).querySelector("svg")).toBeNull();
+      await user.click(screen.getByRole("button", { name: "Select model" }));
+      expect(screen.getByRole("menuitem", { name: "Opus 4.8" }).querySelector("svg")).toBeTruthy();
+      expect(screen.getByRole("menuitem", { name: "Sonnet 4.6" }).querySelector("svg")).toBeNull();
     });
 
     it("calls onSelectChange when an option is clicked", async () => {
@@ -377,8 +401,8 @@ describe("ChatInput", () => {
           onSelectChange={handleChange}
         />,
       );
-      await user.click(screen.getByRole("combobox", { name: "Select model" }));
-      await user.click(screen.getByRole("option", { name: "Example" }));
+      await user.click(screen.getByRole("button", { name: "Select model" }));
+      await user.click(screen.getByRole("menuitem", { name: "Example" }));
       expect(handleChange).toHaveBeenCalledWith("example");
     });
 
@@ -393,36 +417,36 @@ describe("ChatInput", () => {
         />,
       );
       const textarea = screen.getByRole("textbox");
-      const select = screen.getByRole("combobox", { name: "Select model" });
+      const select = screen.getByRole("button", { name: "Select model" });
 
       expect(screen.getByText("Fanvue AI")).toBeInTheDocument();
       expect(textarea).not.toBeDisabled();
       expect(select).toBeDisabled();
 
       await user.click(select);
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
 
-    it("closes dropdown after selecting an option", async () => {
+    it("closes the menu after selecting an option", async () => {
       const user = userEvent.setup();
       render(
         <ChatInput placeholder="Test" selectOptions={MODEL_OPTIONS} selectValue="fanvue-ai" />,
       );
-      await user.click(screen.getByRole("combobox", { name: "Select model" }));
-      expect(screen.getByRole("listbox")).toBeInTheDocument();
-      await user.click(screen.getByRole("option", { name: "Example" }));
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Select model" }));
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+      await user.click(screen.getByRole("menuitem", { name: "Example" }));
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
 
-    it("closes dropdown on Escape key", async () => {
+    it("closes the menu on Escape key", async () => {
       const user = userEvent.setup();
       render(
         <ChatInput placeholder="Test" selectOptions={MODEL_OPTIONS} selectValue="fanvue-ai" />,
       );
-      await user.click(screen.getByRole("combobox", { name: "Select model" }));
-      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Select model" }));
+      expect(screen.getByRole("menu")).toBeInTheDocument();
       await user.keyboard("{Escape}");
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     });
 
     it("is not rendered when toolbarRight is provided", () => {
@@ -435,7 +459,58 @@ describe("ChatInput", () => {
         />,
       );
       expect(screen.getByTestId("custom-toolbar")).toBeInTheDocument();
-      expect(screen.queryByRole("combobox", { name: "Select model" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Select model" })).not.toBeInTheDocument();
+    });
+
+    describe("bottom sheet variant", () => {
+      it("opens a titled bottom sheet when selectVariant is 'sheet'", async () => {
+        const user = userEvent.setup();
+        render(
+          <ChatInput
+            placeholder="Test"
+            selectOptions={MODEL_OPTIONS}
+            selectValue="fanvue-ai"
+            selectVariant="sheet"
+            selectMenuTitle="Switch AI Model"
+          />,
+        );
+        await user.click(screen.getByRole("button", { name: "Select model" }));
+        const dialog = screen.getByRole("dialog");
+        expect(within(dialog).getByText("Switch AI Model")).toBeInTheDocument();
+        expect(within(dialog).getByRole("option", { name: "Fanvue AI" })).toBeInTheDocument();
+      });
+
+      it("does not render a menu in the sheet variant", async () => {
+        const user = userEvent.setup();
+        render(
+          <ChatInput
+            placeholder="Test"
+            selectOptions={MODEL_OPTIONS}
+            selectValue="fanvue-ai"
+            selectVariant="sheet"
+          />,
+        );
+        await user.click(screen.getByRole("button", { name: "Select model" }));
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      it("calls onSelectChange from the bottom sheet", async () => {
+        const user = userEvent.setup();
+        const handleChange = vi.fn();
+        render(
+          <ChatInput
+            placeholder="Test"
+            selectOptions={MODEL_OPTIONS}
+            selectValue="fanvue-ai"
+            selectVariant="sheet"
+            onSelectChange={handleChange}
+          />,
+        );
+        await user.click(screen.getByRole("button", { name: "Select model" }));
+        await user.click(screen.getByRole("option", { name: "Example" }));
+        expect(handleChange).toHaveBeenCalledWith("example");
+      });
     });
   });
 

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -23,6 +23,8 @@ export interface ChatInputSelectOption {
   value: string;
   /** Display label. */
   label: string;
+  /** Optional secondary text shown below the label in the dropdown menu. */
+  description?: string;
   /** Optional icon rendered to the left of the label. */
   icon?: React.ReactNode;
 }
@@ -249,7 +251,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
 
     React.useEffect(() => {
       adjustHeight();
-    }, [resolvedValue, adjustHeight]);
+    }, [adjustHeight]);
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       if (!isControlled) {
@@ -360,7 +362,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
                 aria-label={fileButtonAriaLabel}
                 onClick={onFileClick}
                 disabled={disabled}
-                className="sm:border sm:border-border-primary max-sm:-ml-2"
+                className="max-sm:-ml-2 sm:border sm:border-border-primary"
               />
             )}
           </div>
@@ -374,7 +376,7 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
               aria-label={submitAriaLabel}
               onClick={handleSubmit}
               disabled={!canSubmit}
-              className="disabled:bg-surface-secondary disabled:opacity-100 disabled:text-icons-primary"
+              className="disabled:bg-surface-secondary disabled:text-icons-primary disabled:opacity-100"
             />
           </div>
         </div>
@@ -479,7 +481,14 @@ function InlineSelect({ options, value, onChange, disabled, selectedOption }: In
               {option.icon && (
                 <span className="flex shrink-0 items-center [&>svg]:size-4">{option.icon}</span>
               )}
-              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate">{option.label}</span>
+                {option.description && (
+                  <span className="typography-description-12px-regular block truncate text-content-secondary">
+                    {option.description}
+                  </span>
+                )}
+              </span>
               {option.value === value && (
                 <span className="ml-auto flex size-4 shrink-0 items-center justify-center">
                   <CheckIcon className="size-4 text-content-primary" aria-hidden="true" />

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -1,11 +1,18 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from "../Drawer/Drawer";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../DropdownMenu/DropdownMenu";
 import { IconButton } from "../IconButton/IconButton";
 import { AddIcon } from "../Icons/AddIcon";
 import { ArrowUpIcon } from "../Icons/ArrowUpIcon";
-import { CheckIcon } from "../Icons/CheckIcon";
 import { ChevronDownIcon } from "../Icons/ChevronDownIcon";
 import { CloseIcon } from "../Icons/CloseIcon";
+import { TickIcon } from "../Icons/TickIcon";
 
 /** A single image thumbnail in the built-in attachment strip. */
 export interface ChatInputAttachmentItem {
@@ -21,8 +28,13 @@ export interface ChatInputAttachmentItem {
 export interface ChatInputSelectOption {
   /** Unique value for this option. */
   value: string;
-  /** Display label. */
+  /** Short label shown on the collapsed trigger button (e.g. "Sonnet 4.6"). */
   label: string;
+  /**
+   * Optional longer title shown on the option's row inside the open menu/sheet
+   * (e.g. "Claude Sonnet 4.6"). Falls back to {@link label} when omitted.
+   */
+  menuLabel?: string;
   /** Optional secondary text shown below the label in the dropdown menu. */
   description?: string;
   /** Optional icon rendered to the left of the label. */
@@ -73,6 +85,21 @@ export interface ChatInputProps
    * Ignored when `toolbarRight` is provided.
    */
   selectOptions?: ChatInputSelectOption[];
+  /**
+   * How the built-in selector presents its options:
+   * - `"menu"` (default) — a dropdown anchored to the trigger, for pointer/desktop.
+   * - `"sheet"` — a bottom sheet, for mobile/touch viewports.
+   *
+   * The viewport decision belongs to the consumer (it owns the breakpoint
+   * source of truth), so pass e.g. `selectVariant={isDesktop ? "menu" : "sheet"}`.
+   * @default "menu"
+   */
+  selectVariant?: "menu" | "sheet";
+  /**
+   * Title shown at the top of the `"sheet"` variant of the built-in selector
+   * (e.g. "Switch AI Model"). @default "Select an option"
+   */
+  selectMenuTitle?: string;
   /** Currently selected value for the built-in dropdown. Should match one of `selectOptions[].value`. */
   selectValue?: string;
   /** When `true`, disables only the built-in dropdown selector. @default false */
@@ -209,6 +236,8 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       submitIcon,
       toolbarRight,
       selectOptions,
+      selectVariant = "menu",
+      selectMenuTitle,
       selectValue,
       selectDisabled = false,
       onSelectChange,
@@ -306,6 +335,8 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
           onChange={onSelectChange}
           disabled={disabled || selectDisabled}
           selectedOption={selectedOption}
+          variant={selectVariant}
+          menuTitle={selectMenuTitle}
         />
       ) : null);
 
@@ -393,111 +424,181 @@ interface InlineSelectProps {
   onChange?: (value: string) => void;
   disabled?: boolean;
   selectedOption?: ChatInputSelectOption;
+  /** Presentation: anchored dropdown (`"menu"`) or bottom sheet (`"sheet"`). */
+  variant: "menu" | "sheet";
+  /** Title for the bottom-sheet header. */
+  menuTitle?: string;
 }
 
-function InlineSelect({ options, value, onChange, disabled, selectedOption }: InlineSelectProps) {
+interface SelectTriggerButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Whether the menu/sheet is open (drives chevron rotation + active background). */
+  open: boolean;
+  selectedOption?: ChatInputSelectOption;
+  /** Label shown when no option is selected. */
+  fallbackLabel?: string;
+}
+
+/**
+ * The collapsed pill trigger (icon + short label + chevron). Shared by the
+ * desktop menu and mobile sheet; spreads Radix-injected trigger props via
+ * `asChild`.
+ */
+const SelectTriggerButton = React.forwardRef<HTMLButtonElement, SelectTriggerButtonProps>(
+  ({ open, selectedOption, fallbackLabel, className, ...props }, ref) => (
+    <button
+      ref={ref}
+      type="button"
+      aria-label="Select model"
+      className={cn(
+        "typography-description-12px-semibold text-content-primary",
+        "flex items-center gap-1 rounded-md px-2 py-2",
+        "hover:bg-neutral-alphas-50 focus-visible:shadow-focus-ring focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "motion-safe:transition-colors",
+        open && "bg-neutral-alphas-50",
+        className,
+      )}
+      {...props}
+    >
+      {selectedOption?.icon && (
+        <span className="flex shrink-0 items-center [&>svg]:size-4">{selectedOption.icon}</span>
+      )}
+      {selectedOption?.label ?? fallbackLabel ?? "Select"}
+      <ChevronDownIcon
+        className={cn("size-4 motion-safe:transition-transform", open && "rotate-180")}
+      />
+    </button>
+  ),
+);
+SelectTriggerButton.displayName = "SelectTriggerButton";
+
+/** The green tick shown on the selected option (matches DropDown V2). */
+function SelectedTick() {
+  return <TickIcon size={16} className="text-success-negative-content" aria-hidden="true" />;
+}
+
+/**
+ * Inline model/option selector for the ChatInput toolbar. Renders the
+ * design-system dropdown (DropDown V2) on desktop and a bottom sheet on mobile.
+ */
+function InlineSelect({
+  options,
+  value,
+  onChange,
+  disabled,
+  selectedOption,
+  variant,
+  menuTitle,
+}: InlineSelectProps) {
   const [open, setOpen] = React.useState(false);
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const fallbackLabel = options[0]?.label;
 
-  React.useEffect(() => {
-    if (!open) return;
-    const handleClick = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
+  // Never allow the menu/sheet to open while disabled, regardless of how the
+  // open request originates (click, keyboard, programmatic).
+  const handleOpenChange = (next: boolean) => {
+    if (disabled && next) return;
+    setOpen(next);
+  };
 
-  React.useEffect(() => {
-    if (!open) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [open]);
+  const trigger = (
+    <SelectTriggerButton
+      open={open}
+      selectedOption={selectedOption}
+      fallbackLabel={fallbackLabel}
+      disabled={disabled}
+    />
+  );
+
+  if (variant === "sheet") {
+    return (
+      <Drawer open={open} onOpenChange={handleOpenChange}>
+        <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+        <DrawerContent position="bottom" variant="sheet">
+          <DrawerHeader>
+            <DrawerTitle className="typography-header-heading-xs">
+              {menuTitle ?? "Select an option"}
+            </DrawerTitle>
+          </DrawerHeader>
+          {/* Mirrors DropdownMenuItem's two-line layout, which can't be reused
+              here because it requires a DropdownMenu (Radix Menu) context. */}
+          <div className="flex flex-col gap-1 overflow-y-auto px-4 pb-4" role="listbox">
+            {options.map((option) => {
+              const isSelected = option.value === value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => {
+                    onChange?.(option.value);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "flex w-full items-start gap-2 rounded-sm px-3 py-2 text-left outline-none",
+                    "focus-visible:shadow-focus-ring",
+                    isSelected
+                      ? "typography-body-default-16px-semibold bg-buttons-primary-default text-content-primary-inverted"
+                      : "typography-body-default-16px-regular text-content-primary hover:bg-neutral-alphas-50",
+                  )}
+                >
+                  {option.icon && (
+                    <span className="flex shrink-0 items-center pt-1 [&>svg]:size-4">
+                      {option.icon}
+                    </span>
+                  )}
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="truncate">{option.menuLabel ?? option.label}</span>
+                    {option.description && (
+                      <span
+                        className={cn(
+                          "typography-body-small-14px-regular truncate",
+                          isSelected ? "text-content-primary-inverted" : "text-content-secondary",
+                        )}
+                      >
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
+                  {isSelected && (
+                    <span className="flex shrink-0 items-center pt-1">
+                      <SelectedTick />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
 
   return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        role="combobox"
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        aria-label="Select model"
-        disabled={disabled}
-        onClick={() => setOpen((prev) => !prev)}
-        className={cn(
-          "typography-description-12px-semibold text-content-primary",
-          "flex items-center gap-1 rounded-md px-2 py-2",
-          "hover:bg-neutral-alphas-50 focus-visible:shadow-focus-ring focus-visible:outline-none",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          "motion-safe:transition-colors",
-          open && "bg-neutral-alphas-50",
-        )}
-      >
-        {selectedOption?.icon && (
-          <span className="flex shrink-0 items-center [&>svg]:size-4">{selectedOption.icon}</span>
-        )}
-        {selectedOption?.label ?? options[0]?.label ?? "Select"}
-        <ChevronDownIcon
-          className={cn("size-4 motion-safe:transition-transform", open && "rotate-180")}
-        />
-      </button>
-
-      {open && (
-        <div
-          role="listbox"
-          className={cn(
-            "absolute right-0 bottom-full z-10 mb-1 min-w-[180px]",
-            "overflow-hidden rounded-xs border border-border-primary bg-surface-primary p-1.5 shadow-lg",
-          )}
-        >
-          {options.map((option) => (
-            <div
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="end" className="min-w-[244px]">
+        {options.map((option) => {
+          const isSelected = option.value === value;
+          return (
+            <DropdownMenuItem
               key={option.value}
-              role="option"
-              tabIndex={0}
-              aria-selected={option.value === value}
-              className={cn(
-                "typography-body-small-14px-regular flex cursor-pointer items-center gap-2 rounded-xs py-2.5 pr-2 pl-3",
-                "text-content-primary hover:bg-neutral-alphas-50",
-                "focus-visible:shadow-focus-ring focus-visible:outline-none",
-              )}
-              onClick={() => {
-                onChange?.(option.value);
-                setOpen(false);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  onChange?.(option.value);
-                  setOpen(false);
-                }
-              }}
+              size="40"
+              selected={isSelected}
+              description={option.description}
+              leadingIcon={
+                option.icon ? (
+                  <span className="flex size-4 items-center [&>svg]:size-4">{option.icon}</span>
+                ) : undefined
+              }
+              trailingIcon={isSelected ? <SelectedTick /> : undefined}
+              onSelect={() => onChange?.(option.value)}
             >
-              {option.icon && (
-                <span className="flex shrink-0 items-center [&>svg]:size-4">{option.icon}</span>
-              )}
-              <span className="min-w-0 flex-1">
-                <span className="block truncate">{option.label}</span>
-                {option.description && (
-                  <span className="typography-description-12px-regular block truncate text-content-secondary">
-                    {option.description}
-                  </span>
-                )}
-              </span>
-              {option.value === value && (
-                <span className="ml-auto flex size-4 shrink-0 items-center justify-center">
-                  <CheckIcon className="size-4 text-content-primary" aria-hidden="true" />
-                </span>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+              {option.menuLabel ?? option.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -155,6 +155,26 @@ export const Bottom: Story = {
   ),
 };
 
+export const BottomSheet: Story = {
+  args: { position: "bottom", variant: "sheet" },
+  play: openDrawer,
+  render: (args) => (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button>Open Bottom Sheet</Button>
+      </DrawerTrigger>
+      <DrawerContent {...args}>
+        <DrawerHeader>
+          <DrawerTitle className="typography-header-heading-xs">Switch AI Model</DrawerTitle>
+        </DrawerHeader>
+        <div className="p-4 pt-0">
+          <p>The sheet variant uses the modal surface and a large top radius.</p>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ),
+};
+
 export const WithoutOverlay: Story = {
   args: { overlay: false },
   play: openDrawer,

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -105,6 +105,14 @@ describe("Drawer", () => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
     });
+
+    it("renders the header close button as a large secondary icon button", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+      await user.click(screen.getByRole("button", { name: "Open drawer" }));
+      const closeButton = screen.getByRole("button", { name: "Close drawer" });
+      expect(closeButton).toHaveClass("size-8", "bg-neutral-alphas-50");
+    });
   });
 
   describe("controlled mode", () => {

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -12,6 +12,23 @@ export type DrawerPosition = "left" | "right" | "top" | "bottom";
 export type DrawerSize = "sm" | "md" | "lg" | "full";
 
 /**
+ * Visual treatment of the drawer panel.
+ *
+ * - `"panel"` (default) — the standard edge-anchored surface.
+ * - `"sheet"` — a bottom-sheet treatment matching the modal surface: large
+ *   top-only radius (32px), modal background/stroke, and menu blur+shadow.
+ *   Intended for `position="bottom"`.
+ */
+export type DrawerVariant = "panel" | "sheet";
+
+/**
+ * Shared surface classes for the `"sheet"` variant. Mirrors the mobile sheet
+ * treatment used by {@link Dialog} so bottom sheets are visually consistent.
+ */
+const SHEET_CLASSES =
+  "rounded-t-xl border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[4px]";
+
+/**
  * Props for the {@link Drawer} root component.
  *
  * Inherits `open`, `onOpenChange`, and `defaultOpen` from Radix Dialog.Root.
@@ -156,6 +173,11 @@ export interface DrawerContentProps
    */
   size?: DrawerSize;
   /**
+   * Visual treatment of the panel. Use `"sheet"` (with `position="bottom"`) for
+   * a bottom sheet with the modal surface treatment. @default "panel"
+   */
+  variant?: DrawerVariant;
+  /**
    * Whether to render the default {@link DrawerOverlay} behind the content.
    * Set to `false` to provide your own overlay or omit it entirely.
    *
@@ -184,6 +206,7 @@ export const DrawerContent = React.forwardRef<
       className,
       position = "right",
       size = "sm",
+      variant = "panel",
       overlay: overlayProp,
       overlayProps,
       style,
@@ -229,6 +252,7 @@ export const DrawerContent = React.forwardRef<
             "data-[state=open]:duration-200 data-[state=open]:ease-out",
             SLIDE_CLASSES[position],
             sizeClass,
+            variant === "sheet" && SHEET_CLASSES,
             className,
           )}
           {...props}
@@ -255,15 +279,15 @@ export interface DrawerHeaderProps extends React.HTMLAttributes<HTMLDivElement> 
  */
 export const DrawerHeader = React.forwardRef<HTMLDivElement, DrawerHeaderProps>(
   ({ className, showClose = true, closeLabel = "Close drawer", children, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-start gap-2 p-4", className)} {...props}>
+    <div ref={ref} className={cn("flex items-center gap-2 p-4", className)} {...props}>
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">{children}</div>
       {showClose && (
         <DialogPrimitive.Close asChild>
           <IconButton
             icon={<CloseIcon />}
             aria-label={closeLabel}
-            variant="tertiary"
-            size="24"
+            variant="secondary"
+            size="32"
             className="shrink-0"
           />
         </DialogPrimitive.Close>

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -520,6 +520,24 @@ describe("DropdownMenuItem", () => {
       expect(screen.getByTestId("trail")).toBeInTheDocument();
     });
 
+    it("renders a two-line layout with top-aligned icons when description is set", () => {
+      renderMenu(
+        <DropdownMenuItem description="Fast and versatile" data-testid="item">
+          Claude Sonnet 4.6
+        </DropdownMenuItem>,
+      );
+      const item = screen.getByTestId("item");
+      expect(item).toHaveClass("items-start");
+      expect(item).not.toHaveClass("items-center");
+      expect(screen.getByText("Claude Sonnet 4.6")).toBeInTheDocument();
+      expect(screen.getByText("Fast and versatile")).toBeInTheDocument();
+    });
+
+    it("keeps the single-line layout when no description is set", () => {
+      renderMenu(<DropdownMenuItem data-testid="item">Claude Sonnet 4.6</DropdownMenuItem>);
+      expect(screen.getByTestId("item")).toHaveClass("items-center");
+    });
+
     it("fires onSelect on click", async () => {
       const user = userEvent.setup();
       const onSelect = vi.fn();

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -285,6 +285,12 @@ export interface DropdownMenuItemProps
   leadingIcon?: React.ReactNode;
   /** Icon (or other node) rendered after the label. */
   trailingIcon?: React.ReactNode;
+  /**
+   * Optional secondary text rendered on a second line below the label. When
+   * provided, the row switches to a two-line layout and the leading/trailing
+   * icons align to the title line (top) rather than the row's vertical centre.
+   */
+  description?: React.ReactNode;
   /** Marks the item as the current selection in a single-select menu. @default false */
   selected?: boolean;
 }
@@ -314,6 +320,7 @@ export const DropdownMenuItem = React.forwardRef<
       destructive,
       leadingIcon,
       trailingIcon,
+      description,
       selected,
       className,
       children,
@@ -323,8 +330,10 @@ export const DropdownMenuItem = React.forwardRef<
     ref,
   ) => {
     const normalizedSize = SIZE_NORMALIZED[size];
+    const hasDescription = description != null;
     const itemClassName = cn(
-      "flex w-full cursor-pointer items-center gap-2 rounded-xs px-3 outline-none",
+      "flex w-full cursor-pointer gap-2 rounded-xs px-3 outline-none",
+      hasDescription ? "items-start" : "items-center",
       ITEM_SIZE_CLASSES[normalizedSize],
       "data-[highlighted]:bg-neutral-alphas-50",
       "data-[disabled]:cursor-not-allowed data-[disabled]:text-content-disabled",
@@ -345,11 +354,39 @@ export const DropdownMenuItem = React.forwardRef<
       );
     }
 
+    // In the two-line (description) layout, icons sit on the title's line.
+    // 24px title line-height vs 16px icon → 4px (pt-1) centres the icon on it.
+    const iconAlignClassName = hasDescription ? "flex shrink-0 items-center pt-1" : null;
+
     return (
       <DropdownMenuPrimitive.Item ref={ref} className={itemClassName} {...props}>
-        {leadingIcon}
-        <span className="min-w-0 flex-1 truncate">{children}</span>
-        {trailingIcon}
+        {leadingIcon != null &&
+          (hasDescription ? (
+            <span className={iconAlignClassName!}>{leadingIcon}</span>
+          ) : (
+            leadingIcon
+          ))}
+        {hasDescription ? (
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="truncate">{children}</span>
+            <span
+              className={cn(
+                "typography-body-small-14px-regular truncate",
+                selected ? "text-content-primary-inverted" : "text-content-secondary",
+              )}
+            >
+              {description}
+            </span>
+          </span>
+        ) : (
+          <span className="min-w-0 flex-1 truncate">{children}</span>
+        )}
+        {trailingIcon != null &&
+          (hasDescription ? (
+            <span className={iconAlignClassName!}>{trailingIcon}</span>
+          ) : (
+            trailingIcon
+          ))}
       </DropdownMenuPrimitive.Item>
     );
   },

--- a/src/components/Icons/TickIcon.tsx
+++ b/src/components/Icons/TickIcon.tsx
@@ -4,7 +4,9 @@ import type { BaseIconProps, IconVariants } from "./types";
 
 const VARIANTS: IconVariants = {
   16: {
-    outlined: [{ d: "m3.333 8 3.334 3.333L13 5" }],
+    // `sw` must be set so BaseIcon strokes the checkmark; without it the path
+    // is filled into a solid wedge instead of a tick.
+    outlined: [{ d: "m3.333 8 3.334 3.333L13 5", sw: 1.333 }],
   },
   24: {
     outlined: [{ d: "m5 12 5 5 9.5-9.5", sw: 1.5 }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ export type {
   DrawerSize,
   DrawerTitleProps,
   DrawerTriggerProps,
+  DrawerVariant,
 } from "./components/Drawer/Drawer";
 export {
   Drawer,


### PR DESCRIPTION
## Summary

Allows an optional description line to be added below each Option in the ChatInput DropDown.

Also includes a `sheet` variant on the Drawer component to be used for dropdowns in mobile screen sizes

Figma:
https://www.figma.com/design/59ZXgZ6KIDx23YV0MB2Bvf/Content-Agent?node-id=3018-24094&t=KRDQt6m0gyECilu5-11

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<img width="429" height="466" alt="image" src="https://github.com/user-attachments/assets/6ff14505-f674-4a4c-a119-ba54bf976933" />

<img width="391" height="675" alt="image" src="https://github.com/user-attachments/assets/45a3fa26-555f-4d98-a20c-affb41d982c1" />

<img width="407" height="270" alt="image" src="https://github.com/user-attachments/assets/9ae88929-fa06-4ad1-96ec-de2d93f4daae" />

