### PR TITLE
fix(ci): mint release-please token from GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.FANVUE_ENGINEERING_GITHUB_APP_ID }}
+          private-key: ${{ secrets.FANVUE_ENGINEERING_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Create Release PR or Publish
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
- Release workflow failed with `Bad credentials` — the `RELEASE_PLEASE_PRIVATE_KEY` PAT expired 90 days after creation
- Mint a short-lived token from the FANVUE_ENGINEERING GitHub App per run, so the credential never expires
- Second recurrence of this PAT-expiry failure (see #149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)