### PR TITLE
fix(ci): use RELEASE_PLEASE_PRIVATE_KEY token for release auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.FANVUE_ENGINEERING_GITHUB_APP_ID }}
-          private-key: ${{ secrets.FANVUE_ENGINEERING_GITHUB_APP_PRIVATE_KEY }}
-
       - name: Create Release PR or Publish
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
- Removes the broken "Generate GitHub App token" step from `release.yml`
- release-please now uses `secrets.RELEASE_PLEASE_PRIVATE_KEY` directly (matches `fanv-ui-internal`)

Release runs have failed since #521 (2026-06-17): the App secrets `FANVUE_ENGINEERING_GITHUB_APP_ID` / `FANVUE_ENGINEERING_GITHUB_APP_PRIVATE_KEY` were never added, so the App-token step errored with `Input required and not supplied: app-id`. The PAT secret was refreshed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)