### PR TITLE
chore: add dev:watch script for local live-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ pnpm storybook
 | ------------------------ | ------------------------------------ |
 | **Development**          |                                      |
 | `pnpm dev`               | Start Vite dev server                |
+| `pnpm dev:watch`         | Rebuild `dist/` on change (live-reload into apps) |
 | `pnpm build`             | Build the library for production     |
 | `pnpm preview`           | Preview production build             |
 | **Testing**              |                                      |
@@ -136,6 +137,15 @@ pnpm storybook
 | `pnpm size-limit` | Check bundle size |
 | **Publishing** | |
 | `pnpm publish:dry-run` | Build and dry-run npm publish |
+
+### Live-reloading into pandora/eden
+
+To iterate on a component and see it live in eden (`local.fanvue.com`) without publishing:
+
+- **Easiest:** from the pandora repo root, run `pnpm dev:local-ui`. It runs this library's watch build automatically and points eden at this checkout's `dist/`. See pandora's README ("Live-reloading `@fanvue/ui`") — the pandora wiring ships in a companion PR.
+- **Manual:** run `pnpm dev:watch` here, and start eden with `USE_LOCAL_FANVUE_UI=1` (or `pnpm --filter @pandora/eden start:local-ui`).
+
+Requires this repo checked out beside `pandora` (or `FANVUE_UI_PATH` set in pandora). Component markup and Tailwind classes hot-reload; design **tokens** in `theme.css` are loaded by eden from the installed package, so local `theme.css` edits aren't reflected — test those via a published (pre)release.
 
 ## Figma + Storybook Integration
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   ],
   "scripts": {
     "dev": "vite --host",
+    "dev:watch": "vite build --watch",
     "build": "vite build && mkdir -p dist/styles && cp src/styles/theme.css src/styles/base.css dist/styles/",
     "build:showcase": "vite build --config vite.showcase.config.ts",
     "preview": "vite preview",


### PR DESCRIPTION
## Why

Adds a `dev:watch` script so this library can be hot-reloaded into a consuming app (notably pandora/eden) without publishing to npm — removing the edit → publish → bump → test loop.

## What

```jsonc
"dev:watch": "vite build --watch"
```

`vite build --watch` rebuilds `dist/` incrementally on every save, reusing the existing `vite.config.ts` (lib mode, ESM/CJS, dts). README gains a short "Live-reloading into pandora/eden" note.

This is the watcher invoked by pandora's `pnpm dev:local-ui`: https://github.com/fanvue/pandora/pull/27853

No behavioural change to the published package; nothing runs unless `dev:watch` is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)