### PR TITLE
[Tabs] Scope active-indicator z-index to a local stacking context

### DIFF
--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -53,6 +53,18 @@ describe("Tabs", () => {
       expect(screen.getByRole("tablist")).toHaveClass("custom-list");
     });
 
+    it("isolates the active-indicator z-index in a local stacking context", () => {
+      // `isolate` keeps the indicator's z-10 from escaping above page chrome.
+      render(
+        <Tabs defaultValue="t">
+          <TabsList>
+            <TabsTrigger value="t">T</TabsTrigger>
+          </TabsList>
+        </Tabs>,
+      );
+      expect(screen.getByRole("tablist")).toHaveClass("isolate");
+    });
+
     it("applies custom className to TabsTrigger", () => {
       render(
         <Tabs defaultValue="t">

--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -129,7 +129,10 @@ export const TabsList = React.forwardRef<
     <TabsPrimitive.List
       ref={innerRef}
       className={cn(
-        "relative",
+        // `isolate` scopes the active indicator's `z-10` to a local stacking
+        // context. Without it, `relative` alone creates no stacking context, so
+        // the indicator escapes and paints above page chrome (e.g. the header).
+        "relative isolate",
         getLayoutClass(variant, fullWidth, alignLeft),
         "data-[orientation=horizontal]:items-center data-[orientation=horizontal]:shadow-[inset_0_-1px_0_0_var(--color-border-primary)]",
         "data-[orientation=vertical]:flex-col data-[orientation=vertical]:shadow-[inset_-1px_0_0_0_var(--color-border-primary)]",


### PR DESCRIPTION
## Why

The V2 Tabs active-tab indicator carries `z-10` so it renders above the tab list's bottom border as it slides between tabs. However, `TabsList` was only `relative`, which **does not** establish a stacking context — so the absolutely-positioned indicator escaped its parent and participated in the root stacking context, painting **above unrelated page chrome** (e.g. the site header floating beneath the white underline gradient).

## Fix

Add `isolate` (`isolation: isolate`) to the `TabsList` container. This creates a local stacking context so the indicator's `z-10` stays scoped to the tabs. The indicator still sits above the list border (intent preserved), but can no longer cover the header or other page content.

Verified with an isolated stacking repro: at an overlap point, the indicator paints above a `z-index: 5` header **without** `isolate`, and the header correctly wins **with** `isolate`.

## Checks
- `biome check` ✅
- `tsc --noEmit` ✅
- Tabs unit + storybook tests (24) ✅