### PR TITLE
fix(Tabs): fill active indicator to full tab width

### DIFF
--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -79,14 +79,10 @@ export const TabsList = React.forwardRef<
     } else {
       indicator.style.background =
         "linear-gradient(90deg, var(--color-buttons-tertiary-default) 0%, var(--color-tab-active) 50%, var(--color-buttons-tertiary-default) 100%)";
-      const textSpan = activeTab.querySelector("span");
-      const textWidth = (textSpan ?? activeTab).getBoundingClientRect().width;
-      const tabCenter = activeTab.offsetLeft + activeTab.offsetWidth / 2;
-      const indicatorLeft = tabCenter - textWidth / 2;
       indicator.style.inset = "auto auto 0 0";
       indicator.style.height = "1px";
-      indicator.style.width = `${textWidth}px`;
-      indicator.style.transform = `translateX(${indicatorLeft}px)`;
+      indicator.style.width = `${activeTab.offsetWidth}px`;
+      indicator.style.transform = `translateX(${activeTab.offsetLeft}px)`;
     }
   }, []);
 


### PR DESCRIPTION
## Summary

The V2 Tabs active-state stroke didn't match the DS component: the horizontal active indicator was sized to the label's text width and centred, so the gradient stroke fell short of filling the tab. It now spans the full tab width (matching the vertical indicator, which already fills the full tab height).

## Changes

- Size the horizontal active indicator to `activeTab.offsetWidth` and position it at `activeTab.offsetLeft`, instead of measuring the label text span and centring.

## Checklist

- [x] Tests pass (`pnpm test`)
