### PR TITLE
fix(accordion): isolate content in a contained layer to fix mobile expand/collapse

### DIFF
--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -168,6 +168,28 @@ describe("Accordion", () => {
       expect(screen.getByRole("region")).toHaveClass("custom-content");
     });
 
+    it("renders the panel as a single overflow-clipped block (no display override)", async () => {
+      const user = userEvent.setup();
+      render(
+        <Accordion type="single" collapsible>
+          <AccordionItem value="item-1">
+            <AccordionTrigger>Trigger</AccordionTrigger>
+            <AccordionContent>Content</AccordionContent>
+          </AccordionItem>
+        </Accordion>,
+      );
+      await user.click(screen.getByRole("button"));
+      const region = screen.getByRole("region");
+      // The panel animates `height` and clips with `overflow-hidden`. It must NOT set a
+      // `display` (e.g. `grid`): that defeats Radix's `[hidden] { display: none }` closed
+      // state and leaves a residual padded strip + animation desync on mobile (ENG-7598).
+      expect(region).toHaveClass("overflow-hidden");
+      expect(region).not.toHaveClass("grid");
+      // Content is wrapped in an isolated `contain: layout paint` layer so the height
+      // animation re-clips a cached layer instead of reflowing the padded content.
+      expect(region.firstElementChild).toHaveClass("[contain:layout_paint]");
+    });
+
     it("forwards ref to AccordionItem", () => {
       const ref = React.createRef<HTMLDivElement>();
       render(

--- a/src/components/Accordion/AccordionContent.tsx
+++ b/src/components/Accordion/AccordionContent.tsx
@@ -18,6 +18,10 @@ export const AccordionContent = React.forwardRef<
   <AccordionPrimitive.Content
     ref={ref}
     className={cn(
+      // Overflow-clipped panel whose `height` is animated (see `accordion-expand`/
+      // `accordion-collapse` in base.css). No `display` override here: a closed item
+      // keeps Radix's `hidden` attribute, so `[hidden] { display: none }` removes its
+      // footprint entirely (a `display: grid` panel would defeat that and leave a strip).
       "overflow-hidden",
       "motion-safe:data-[state=closed]:animate-accordion-collapse",
       "motion-safe:data-[state=open]:animate-accordion-expand",
@@ -25,14 +29,23 @@ export const AccordionContent = React.forwardRef<
     )}
     {...props}
   >
-    <div
-      className={cn(
-        "overflow-wrap-anywhere min-w-0",
-        "typography-body-small-14px-regular text-content-secondary",
-        !noPadding && "px-3 pt-2 pb-3",
-      )}
-    >
-      {children}
+    {/*
+      Isolated layer between the height-animated panel and the content. `contain:
+      layout paint` makes this its own layout+paint boundary, so the parent's height
+      animation only re-clips this already-laid-out, already-painted layer instead of
+      re-flowing and re-painting the padded content on every frame. Without it, the
+      padding/content reflow per frame and visibly desync from the clip on mobile.
+    */}
+    <div className="[contain:layout_paint]">
+      <div
+        className={cn(
+          "overflow-wrap-anywhere min-w-0",
+          "typography-body-small-14px-regular text-content-secondary",
+          !noPadding && "px-3 pt-2 pb-3",
+        )}
+      >
+        {children}
+      </div>
     </div>
   </AccordionPrimitive.Content>
 ));

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -94,6 +94,22 @@
   }
 }
 
+/*
+ * Animate `height` between 0 and the panel's measured height
+ * (`--radix-accordion-content-height`, which Radix sets from a getBoundingClientRect
+ * in a useLayoutEffect). This is the canonical Radix/Collapsible pattern and keeps the
+ * closed state truly hidden: the paired `AccordionContent` adds no `display` override,
+ * so a closed panel keeps Radix's `hidden` attribute and `[hidden] { display: none }`
+ * removes its footprint entirely.
+ *
+ * Perf note (ENG-7598 — mobile jank): `height` is layout-animated and is NOT composited
+ * (only `transform`/`opacity` run off the main thread). To keep the animation smooth and
+ * stop the padded content reflowing/repainting every frame, `AccordionContent` wraps the
+ * content in an isolated `contain: layout paint` layer — the parent's height animation then
+ * only re-clips that cached layer. We deliberately do NOT animate `grid-template-rows`
+ * (also layout-bound, and `display: grid` defeats the `[hidden] { display: none }` closed
+ * state) and do NOT add `will-change` (a no-op hint for layout properties that wastes memory).
+ */
 @keyframes accordion-expand {
   from {
     height: 0;


### PR DESCRIPTION
## Why

The `Accordion` expand/collapse janks visibly on mobile (Bug Bounty — same component on **Refer & Earn** and **My AI Settings**); desktop is smooth.

**Root cause:** the open/close keyframes animate the CSS `height` property, which is **layout-bound** (not composited). With the padded content as a *direct child* of the animated panel, the browser reflows + repaints that content on **every frame**, so the padding visibly desyncs from the clip on lower-powered mobile hardware.

## What

Wrap the content in an **isolated `contain: layout paint` layer** between the height-animated panel and the padded content:

```
AccordionPrimitive.Content   ← overflow-hidden, animates `height` (no display override)
  └─ div [contain: layout paint]   ← isolated layout+paint layer
       └─ div (px-3 pt-2 pb-3)      ← padded content
```

The panel's height animation now only **re-clips an already-laid-out, already-painted layer** instead of reflowing/repainting the padded content each frame. Verified on the built showcase (mobile emulation): across the whole animation the content layer's top offset stays `0` and its height stays constant while only the panel's clip height animates — padding and content no longer drift apart.

### Notes / history

- Keeps the canonical `height` keyframes and **no `display` override**, so a closed item keeps Radix's `hidden` attribute → `[hidden] { display: none }` → zero footprint.
- An earlier revision animated `grid-template-rows` with `display: grid`; that defeated `[hidden]{display:none}` (residual padded strip + padding/content desync + multi-item timing bugs) and isn't cheaper (grid tracks are also layout-bound). Reverted.
- Honest scope: this isolates and caches the content's paint so clipping is cheap; `height` itself still isn't compositor-driven (only `transform`/`opacity` are). True 60fps composited reveal of undistorted, dynamic content would need a transform/clip redesign — out of scope. Approach chosen from a 5-way design spike.

## Verify

Storybook/showcase → Accordion, mobile viewport + CPU throttle, expand a long panel: padding stays glued to content, closed items have zero footprint, `prefers-reduced-motion` shows/hides instantly.

Part of ENG-7598