### PR TITLE
feat: add RatingSummary and ReviewCard review components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,10 +171,12 @@ import {
   ProgressBar,
   Radio,
   RadioGroup,
+  RatingSummary,
   RepeatIcon,
   Reply2Icon,
   ReplyIcon,
   ReverseIcon,
+  ReviewCard,
   SearchField,
   SearchIcon,
   Select,
@@ -3784,6 +3786,58 @@ function PaginationDemo() {
   );
 }
 
+function RatingSummaryDemo() {
+  return (
+    <div id="ratingsummary" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Rating Summary</h2>
+      <div className="flex max-w-md flex-col gap-8">
+        <RatingSummary
+          distribution={[
+            { rating: 5, count: 300 },
+            { rating: 4, count: 20 },
+            { rating: 3, count: 20 },
+            { rating: 2, count: 10 },
+            { rating: 1, count: 0 },
+          ]}
+        />
+        <RatingSummary
+          averageRating={4.3}
+          distribution={[
+            { rating: 5, count: 18420 },
+            { rating: 4, count: 7310 },
+            { rating: 3, count: 1290 },
+            { rating: 2, count: 540 },
+            { rating: 1, count: 880 },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ReviewCardDemo() {
+  const body =
+    "Easily plan and organize your content with this app. Streamline your scheduling and management tasks to focus on what you do best — creating.";
+  return (
+    <div id="reviewcard" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Review Card</h2>
+      <div className="flex max-w-md flex-col gap-6">
+        <ReviewCard rating={5} author="@jane_doe" title="A great app to start!">
+          {body}
+        </ReviewCard>
+        <Divider />
+        <ReviewCard rating={4} author="@sam_smith" title="Really useful">
+          {body}
+        </ReviewCard>
+        <Divider />
+        <ReviewCard rating={3} author="@alex_p" title="Does the job">
+          {body}
+        </ReviewCard>
+      </div>
+    </div>
+  );
+}
+
 function ProgressBarDemo() {
   return (
     <div id="progressbar" className="flex scroll-mt-20 flex-col gap-4">
@@ -5189,6 +5243,12 @@ function App() {
 
             {/* ProgressBar */}
             <ProgressBarDemo />
+
+            {/* Rating Summary */}
+            <RatingSummaryDemo />
+
+            {/* Review Card */}
+            <ReviewCardDemo />
 
             {/* Stepper */}
             <StepperDemo />

--- a/src/components/RatingSummary/RatingSummary.stories.tsx
+++ b/src/components/RatingSummary/RatingSummary.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { RatingSummary } from "./RatingSummary";
+
+const meta = {
+  title: "Components/RatingSummary",
+  component: RatingSummary,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs"],
+  argTypes: {
+    maxRating: { control: { type: "number", min: 1 } },
+    averageRating: { control: { type: "number", min: 0, step: 0.1 } },
+  },
+} satisfies Meta<typeof RatingSummary>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    distribution: [
+      { rating: 5, count: 300 },
+      { rating: 4, count: 20 },
+      { rating: 3, count: 20 },
+      { rating: 2, count: 10 },
+      { rating: 1, count: 0 },
+    ],
+  },
+};
+
+export const Mixed: Story = {
+  args: {
+    distribution: [
+      { rating: 5, count: 64 },
+      { rating: 4, count: 81 },
+      { rating: 3, count: 40 },
+      { rating: 2, count: 18 },
+      { rating: 1, count: 12 },
+    ],
+  },
+};
+
+export const CustomAverage: Story = {
+  args: {
+    averageRating: 4.3,
+    distribution: [
+      { rating: 5, count: 300 },
+      { rating: 4, count: 20 },
+      { rating: 3, count: 20 },
+      { rating: 2, count: 10 },
+      { rating: 1, count: 0 },
+    ],
+  },
+};
+
+export const LargeVolume: Story = {
+  args: {
+    distribution: [
+      { rating: 5, count: 18420 },
+      { rating: 4, count: 7310 },
+      { rating: 3, count: 1290 },
+      { rating: 2, count: 540 },
+      { rating: 1, count: 880 },
+    ],
+  },
+};
+
+export const SingleReview: Story = {
+  args: {
+    distribution: [
+      { rating: 5, count: 1 },
+      { rating: 4, count: 0 },
+      { rating: 3, count: 0 },
+      { rating: 2, count: 0 },
+      { rating: 1, count: 0 },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    distribution: [
+      { rating: 5, count: 0 },
+      { rating: 4, count: 0 },
+      { rating: 3, count: 0 },
+      { rating: 2, count: 0 },
+      { rating: 1, count: 0 },
+    ],
+  },
+};

--- a/src/components/RatingSummary/RatingSummary.test.tsx
+++ b/src/components/RatingSummary/RatingSummary.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { RatingSummary } from "./RatingSummary";
+
+const SAMPLE: { rating: number; count: number }[] = [
+  { rating: 5, count: 300 },
+  { rating: 4, count: 20 },
+  { rating: 3, count: 20 },
+  { rating: 2, count: 10 },
+  { rating: 1, count: 0 },
+];
+
+describe("RatingSummary", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      const { container } = render(
+        <RatingSummary distribution={SAMPLE} className="custom-class" />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("forwards arbitrary props to the root element", () => {
+      const { container } = render(<RatingSummary distribution={SAMPLE} data-foo="bar" />);
+      expect(container.firstChild).toHaveAttribute("data-foo", "bar");
+    });
+  });
+
+  describe("aggregation", () => {
+    it("derives the count-weighted average and total from the distribution", () => {
+      render(<RatingSummary distribution={SAMPLE} />);
+      expect(
+        screen.getByRole("img", { name: "Average rating 4.7 out of 5, 350 reviews" }),
+      ).toBeInTheDocument();
+    });
+
+    it("prefers an explicit averageRating over the derived value", () => {
+      render(<RatingSummary distribution={SAMPLE} averageRating={4.3} />);
+      expect(
+        screen.getByRole("img", { name: "Average rating 4.3 out of 5, 350 reviews" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders a row for every rating down to 1, including ratings with no reviews", () => {
+      render(<RatingSummary distribution={SAMPLE} />);
+      expect(screen.getByRole("img", { name: "5 stars, 300 reviews" })).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "1 star, 0 reviews" })).toBeInTheDocument();
+    });
+
+    it("renders maxRating rows plus the header", () => {
+      render(<RatingSummary distribution={SAMPLE} maxRating={3} />);
+      expect(screen.getAllByRole("img")).toHaveLength(4);
+      expect(screen.queryByRole("img", { name: /^5 stars/ })).not.toBeInTheDocument();
+    });
+
+    it("excludes out-of-range ratings from the derived total and average", () => {
+      render(<RatingSummary distribution={SAMPLE} maxRating={3} />);
+      expect(
+        screen.getByRole("img", { name: "Average rating 2.7 out of 3, 30 reviews" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("histogram bars", () => {
+    it("scales bar widths relative to the most-reviewed rating", () => {
+      const { container } = render(
+        <RatingSummary
+          distribution={[
+            { rating: 5, count: 200 },
+            { rating: 4, count: 100 },
+            { rating: 3, count: 0 },
+            { rating: 2, count: 0 },
+            { rating: 1, count: 0 },
+          ]}
+        />,
+      );
+      const widths = Array.from(
+        container.querySelectorAll<HTMLElement>("[style*='width']"),
+        (fill) => fill.style.width,
+      );
+      expect(widths).toEqual(["100%", "50%", "0%", "0%", "0%"]);
+    });
+
+    it("fills the track for the busiest rating even when it is not the top rating", () => {
+      const { container } = render(
+        <RatingSummary
+          distribution={[
+            { rating: 5, count: 50 },
+            { rating: 4, count: 100 },
+            { rating: 3, count: 20 },
+            { rating: 2, count: 0 },
+            { rating: 1, count: 0 },
+          ]}
+        />,
+      );
+      const widths = Array.from(
+        container.querySelectorAll<HTMLElement>("[style*='width']"),
+        (fill) => fill.style.width,
+      );
+      expect(widths).toEqual(["50%", "100%", "20%", "0%", "0%"]);
+    });
+
+    it("renders zero-width bars when there are no reviews", () => {
+      const { container } = render(
+        <RatingSummary
+          distribution={[
+            { rating: 5, count: 0 },
+            { rating: 4, count: 0 },
+            { rating: 3, count: 0 },
+            { rating: 2, count: 0 },
+            { rating: 1, count: 0 },
+          ]}
+        />,
+      );
+      const fills = container.querySelectorAll<HTMLElement>("[style*='width']");
+      expect(fills).toHaveLength(5);
+      for (const fill of fills) {
+        expect(fill.style.width).toBe("0%");
+      }
+    });
+  });
+
+  describe("count formatting", () => {
+    it("pluralises the default review label for a single review", () => {
+      render(<RatingSummary distribution={[{ rating: 5, count: 1 }]} />);
+      expect(
+        screen.getByRole("img", { name: "Average rating 5.0 out of 5, 1 review" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "5 stars, 1 review" })).toBeInTheDocument();
+    });
+
+    it("uses a custom formatCount for both header and row labels", () => {
+      render(
+        <RatingSummary
+          distribution={[{ rating: 5, count: 12 }]}
+          formatCount={(count) => `${count} ratings`}
+        />,
+      );
+      expect(
+        screen.getByRole("img", { name: "Average rating 5.0 out of 5, 12 ratings" }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "5 stars, 12 ratings" })).toBeInTheDocument();
+    });
+  });
+
+  describe("accessible label overrides", () => {
+    it("uses formatAverageLabel for the header label", () => {
+      render(
+        <RatingSummary
+          distribution={SAMPLE}
+          formatAverageLabel={(average, max, total) => `${average}/${max} from ${total}`}
+        />,
+      );
+      expect(screen.getByRole("img", { name: "4.7/5 from 350" })).toBeInTheDocument();
+    });
+
+    it("uses formatRatingLabel for each row label", () => {
+      render(
+        <RatingSummary
+          distribution={SAMPLE}
+          formatRatingLabel={(rating, count) => `rating ${rating}: ${count}`}
+        />,
+      );
+      expect(screen.getByRole("img", { name: "rating 5: 300" })).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "rating 1: 0" })).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(<RatingSummary distribution={SAMPLE} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations when empty", async () => {
+      const { container } = render(<RatingSummary distribution={[]} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/RatingSummary/RatingSummary.tsx
+++ b/src/components/RatingSummary/RatingSummary.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+import { StarIcon } from "../Icons/StarIcon";
+
+/** A single rating value paired with the number of reviews that gave it. */
+export interface RatingCount {
+  /** The rating value this entry represents (e.g. `5`). */
+  rating: number;
+  /** Number of reviews that gave this rating. */
+  count: number;
+}
+
+export interface RatingSummaryProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+  /**
+   * Per-rating review counts. Order is not significant — rows always render from
+   * `maxRating` down to `1`, and any rating without an entry renders as zero.
+   * Entries are expected to use whole-number ratings within `1`–`maxRating`;
+   * any outside that range are ignored, including in the derived total and average.
+   */
+  distribution: RatingCount[];
+  /**
+   * Average rating shown in the header. Defaults to the count-weighted mean of
+   * `distribution`; provide it to display a server-computed average instead.
+   */
+  averageRating?: number;
+  /** Highest possible rating. Sets how many histogram rows render. @default 5 */
+  maxRating?: number;
+  /**
+   * Formats a review count into its label, without surrounding parentheses.
+   * Used for the visible text and as the count portion of the default
+   * accessible labels.
+   * @default ``(count) => `${count.toLocaleString()} review(s)` ``
+   */
+  formatCount?: (count: number) => string;
+  /**
+   * Builds the accessible label for the header. Override to localise the
+   * screen-reader text. `average` is the already-formatted average string.
+   * @default ``(average, max, total) => `Average rating ${average} out of ${max}, ${formatCount(total)}` ``
+   */
+  formatAverageLabel?: (average: string, maxRating: number, total: number) => string;
+  /**
+   * Builds the accessible label for each histogram row. Override to localise the
+   * screen-reader text.
+   * @default ``(rating, count) => `${rating} star(s), ${formatCount(count)}` ``
+   */
+  formatRatingLabel?: (rating: number, count: number) => string;
+}
+
+function defaultFormatCount(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? "review" : "reviews"}`;
+}
+
+function getWeightedAverage(distribution: RatingCount[]): number {
+  let total = 0;
+  let weighted = 0;
+  for (const { rating, count } of distribution) {
+    total += count;
+    weighted += rating * count;
+  }
+  return total === 0 ? 0 : weighted / total;
+}
+
+/**
+ * An aggregated rating overview: a headline average with the total review count,
+ * followed by a per-rating histogram. Bar lengths are scaled relative to the
+ * most-reviewed rating, so the busiest rating always fills the track.
+ *
+ * The brand star is decorative; the header and each histogram row expose
+ * `role="img"` with an accessible label (override via `formatAverageLabel` /
+ * `formatRatingLabel`) so the single-star-plus-number reads clearly.
+ *
+ * @example
+ * ```tsx
+ * <RatingSummary
+ *   distribution={[
+ *     { rating: 5, count: 300 },
+ *     { rating: 4, count: 20 },
+ *     { rating: 3, count: 20 },
+ *     { rating: 2, count: 10 },
+ *     { rating: 1, count: 0 },
+ *   ]}
+ * />
+ * ```
+ */
+export const RatingSummary = React.forwardRef<HTMLDivElement, RatingSummaryProps>(
+  (
+    {
+      distribution,
+      averageRating,
+      maxRating = 5,
+      formatCount = defaultFormatCount,
+      formatAverageLabel,
+      formatRatingLabel,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const countByRating = new Map<number, number>();
+    for (const { rating, count } of distribution) {
+      countByRating.set(rating, (countByRating.get(rating) ?? 0) + count);
+    }
+
+    const rows = Array.from({ length: maxRating }, (_, index) => {
+      const rating = maxRating - index;
+      return { rating, count: countByRating.get(rating) ?? 0 };
+    });
+
+    const totalCount = rows.reduce((sum, row) => sum + row.count, 0);
+    const maxCount = rows.reduce((max, row) => Math.max(max, row.count), 0);
+    const average = averageRating ?? getWeightedAverage(rows);
+    const averageLabel = average.toFixed(1);
+
+    const headerLabel = formatAverageLabel
+      ? formatAverageLabel(averageLabel, maxRating, totalCount)
+      : `Average rating ${averageLabel} out of ${maxRating}, ${formatCount(totalCount)}`;
+
+    return (
+      <div ref={ref} className={cn("flex flex-col gap-4", className)} {...props}>
+        <div className="flex items-center gap-1" role="img" aria-label={headerLabel}>
+          <StarIcon size={24} filled className="shrink-0 text-brand-primary-default" />
+          <span className="flex items-center gap-1.5">
+            <span className="typography-body-small-14px-semibold text-content-primary">
+              {averageLabel}
+            </span>
+            <span className="typography-body-small-14px-regular text-content-tertiary">
+              ({formatCount(totalCount)})
+            </span>
+          </span>
+        </div>
+
+        <ul className="m-0 flex list-none flex-col gap-4 p-0" aria-label="Rating breakdown">
+          {rows.map(({ rating, count }) => (
+            <li key={rating}>
+              <div
+                className="flex items-center gap-4"
+                role="img"
+                aria-label={
+                  formatRatingLabel
+                    ? formatRatingLabel(rating, count)
+                    : `${rating} ${rating === 1 ? "star" : "stars"}, ${formatCount(count)}`
+                }
+              >
+                <div className="relative h-4 flex-1 overflow-hidden rounded-full bg-neutral-alphas-50">
+                  <div
+                    className="absolute inset-y-0 left-0 rounded-full bg-brand-primary-default transition-[width] duration-300 ease-in-out"
+                    style={{ width: maxCount === 0 ? "0%" : `${(count / maxCount) * 100}%` }}
+                  />
+                </div>
+                <span className="flex shrink-0 items-center gap-1.5">
+                  <span className="typography-body-small-14px-semibold text-content-primary">
+                    {rating}
+                  </span>
+                  <span className="typography-body-small-14px-regular text-content-tertiary">
+                    ({formatCount(count)})
+                  </span>
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  },
+);
+
+RatingSummary.displayName = "RatingSummary";

--- a/src/components/ReviewCard/ReviewCard.stories.tsx
+++ b/src/components/ReviewCard/ReviewCard.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Divider } from "../Divider/Divider";
+import { ReviewCard } from "./ReviewCard";
+
+const SAMPLE_BODY =
+  "Easily plan and organize your content with this app. Streamline your scheduling and management tasks to focus on what you do best — creating.";
+
+const meta = {
+  title: "Components/ReviewCard",
+  component: ReviewCard,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs"],
+  argTypes: {
+    rating: { control: { type: "number", min: 0 } },
+    maxRating: { control: { type: "number", min: 1 } },
+  },
+} satisfies Meta<typeof ReviewCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    rating: 4,
+    author: "@jane_doe",
+    title: "A great app to start!",
+    children: SAMPLE_BODY,
+  },
+};
+
+export const WithoutAuthor: Story = {
+  args: {
+    rating: 5,
+    title: "Exactly what I needed",
+    children: SAMPLE_BODY,
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    rating: 3,
+    author: "@user_123",
+    title: "Good, but room to grow.",
+  },
+};
+
+export const LowRating: Story = {
+  args: {
+    rating: 1,
+    author: "@user_456",
+    title: "Not for me",
+    children:
+      "The idea is solid but it kept crashing on launch. Hoping a future update sorts out the stability issues.",
+  },
+};
+
+export const List: Story = {
+  args: { rating: 5 },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <ReviewCard rating={5} author="@jane_doe" title="A great app to start!">
+        {SAMPLE_BODY}
+      </ReviewCard>
+      <Divider />
+      <ReviewCard rating={4} author="@sam_smith" title="Really useful">
+        {SAMPLE_BODY}
+      </ReviewCard>
+      <Divider />
+      <ReviewCard rating={3} author="@alex_p" title="Does the job">
+        {SAMPLE_BODY}
+      </ReviewCard>
+    </div>
+  ),
+};

--- a/src/components/ReviewCard/ReviewCard.test.tsx
+++ b/src/components/ReviewCard/ReviewCard.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { ReviewCard } from "./ReviewCard";
+
+describe("ReviewCard", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      const { container } = render(
+        <ReviewCard rating={4} className="custom-class">
+          Body
+        </ReviewCard>,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("forwards arbitrary props to the root element", () => {
+      const { container } = render(
+        <ReviewCard rating={4} data-foo="bar">
+          Body
+        </ReviewCard>,
+      );
+      expect(container.firstChild).toHaveAttribute("data-foo", "bar");
+    });
+  });
+
+  describe("content", () => {
+    it("renders the title and body", () => {
+      render(
+        <ReviewCard rating={4} title="A great app to start!">
+          Easily plan and organize your content.
+        </ReviewCard>,
+      );
+      expect(screen.getByText("A great app to start!")).toBeInTheDocument();
+      expect(screen.getByText("Easily plan and organize your content.")).toBeInTheDocument();
+    });
+
+    it("renders the author byline when provided", () => {
+      render(
+        <ReviewCard rating={4} author="@jane_doe">
+          Body
+        </ReviewCard>,
+      );
+      expect(screen.getByText(/by\s*@jane_doe/)).toBeInTheDocument();
+    });
+
+    it("omits the byline when no author is provided", () => {
+      render(<ReviewCard rating={4}>Body</ReviewCard>);
+      expect(screen.queryByText(/by/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("rating", () => {
+    it("exposes an accessible label for the rating", () => {
+      render(<ReviewCard rating={4}>Body</ReviewCard>);
+      expect(screen.getByRole("img", { name: "Rated 4 out of 5" })).toBeInTheDocument();
+    });
+
+    it("reflects a custom maxRating in the accessible label", () => {
+      render(
+        <ReviewCard rating={7} maxRating={10}>
+          Body
+        </ReviewCard>,
+      );
+      expect(screen.getByRole("img", { name: "Rated 7 out of 10" })).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(
+        <ReviewCard rating={4} author="@jane_doe" title="A great app to start!">
+          Easily plan and organize your content.
+        </ReviewCard>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+import { StarIcon } from "../Icons/StarIcon";
+
+export interface ReviewCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+  /** Star rating the reviewer gave, shown beside the star icon. */
+  rating: number;
+  /** Highest possible rating, used only in the accessible label (e.g. "4 out of 5"). @default 5 */
+  maxRating?: number;
+  /** Reviewer name or handle, rendered after "by". Omitted when not provided. */
+  author?: React.ReactNode;
+  /** Short headline for the review. */
+  title?: React.ReactNode;
+  /** Review body text. */
+  children?: React.ReactNode;
+}
+
+/**
+ * A single written review: a star rating with an optional author byline, a
+ * title, and the review body. Stack several with a {@link Divider} between them
+ * to build a review list.
+ *
+ * @example
+ * ```tsx
+ * <ReviewCard rating={4} author="@jane_doe" title="A great app to start!">
+ *   Easily plan and organize your content. Streamline your scheduling so you can
+ *   focus on what you do best.
+ * </ReviewCard>
+ * ```
+ */
+export const ReviewCard = React.forwardRef<HTMLDivElement, ReviewCardProps>(
+  ({ rating, maxRating = 5, author, title, children, className, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cn("flex flex-col gap-2", className)} {...props}>
+        <div className="flex items-center gap-1">
+          <StarIcon size={24} filled className="shrink-0 text-brand-primary-default" />
+          <span
+            className="typography-body-small-14px-semibold text-content-primary"
+            role="img"
+            aria-label={`Rated ${rating} out of ${maxRating}`}
+          >
+            {rating}
+          </span>
+          {author != null && (
+            <span className="typography-body-small-14px-regular text-content-tertiary">
+              by {author}
+            </span>
+          )}
+        </div>
+        {title != null && (
+          <p className="typography-body-default-16px-semibold text-content-primary">{title}</p>
+        )}
+        {children != null && (
+          <p className="typography-body-small-14px-regular text-content-secondary">{children}</p>
+        )}
+      </div>
+    );
+  },
+);
+
+ReviewCard.displayName = "ReviewCard";

--- a/src/index.ts
+++ b/src/index.ts
@@ -583,6 +583,10 @@ export type { RadioProps } from "./components/Radio/Radio";
 export { Radio } from "./components/Radio/Radio";
 export type { RadioGroupProps } from "./components/RadioGroup/RadioGroup";
 export { RadioGroup } from "./components/RadioGroup/RadioGroup";
+export type { RatingCount, RatingSummaryProps } from "./components/RatingSummary/RatingSummary";
+export { RatingSummary } from "./components/RatingSummary/RatingSummary";
+export type { ReviewCardProps } from "./components/ReviewCard/ReviewCard";
+export { ReviewCard } from "./components/ReviewCard/ReviewCard";
 export type {
   SearchFieldProps,
   SearchFieldSize,


### PR DESCRIPTION
## Summary

Adds two new generic, public-library components for displaying reviews:

- **`RatingSummary`** - an aggregated rating overview: a headline average + total review count, followed by a per-rating histogram. Bars are normalised so the most-reviewed rating fills the track (the standard app-store style). Average and total are derived from the distribution by default; `averageRating` can be passed to show a server-computed value.
- **`ReviewCard`** - a single written review: a star rating with optional `by {author}` byline, a title, and the body. Stack several with `<Divider/>` to build a review list.

Both are intentionally generic (no app-store-specific wording or coupling), so they live in the public `@fanvue/ui` library rather than `fanv-ui-internal`. Naming follows the existing `*Card` / summary conventions.

### Why these names
The designs show a single brand-green star + a number (not a 5-star row), so the components are named for what they represent rather than the artwork: `RatingSummary` (aggregate + breakdown) and `ReviewCard` (one review). A small `RatingCount` type (`{ rating, count }`) is exported for the distribution.

## API

```tsx
<RatingSummary
  distribution={[
    { rating: 5, count: 300 },
    { rating: 4, count: 20 },
    { rating: 3, count: 20 },
    { rating: 2, count: 10 },
    { rating: 1, count: 0 },
  ]}
/>

<ReviewCard rating={4} author="@jane_doe" title="A great app to start!">
  Easily plan and organize your content…
</ReviewCard>
```

- `RatingSummary`: `distribution`, `averageRating?`, `maxRating?` (default 5), `formatCount?` (default pluralised `"N reviews"`, also drives accessible labels).
- `ReviewCard`: `rating`, `author?`, `title?`, `children` (body), `maxRating?` (default 5, for the accessible label).

## Accessibility
- The brand star is decorative (`aria-hidden`); the summary header, each histogram row, and the review rating expose `role="img"` + an `aria-label` (e.g. *"Average rating 4.7 out of 5, 350 reviews"*, *"5 stars, 300 reviews"*, *"Rated 4 out of 5"*) so the otherwise-ambiguous single star/number reads clearly.
- axe has no violations (covered in unit tests, including the empty state).

## Tests & stories
- Unit tests cover the real logic (weighted average, total, bar normalisation, pluralisation, custom `formatCount`, zero/empty/single-review edges, byline presence/absence) + axe; story smoke tests cover every variant.
- Story/demo data is public-safe (fictional handles, generic copy) - no real users, internal URLs, or unreleased feature names.

## Checks
- `pnpm typecheck` ✅ · `pnpm lint` (biome) ✅ · unit tests ✅ (full suite **2996 passing**, 24 new across the two components incl. axe)
- Ran a 6-lens adversarial code review (correctness, a11y, API design, conventions, responsive/theming, tests + data-safety) with per-finding verification; applied the confirmed fixes (typography token names, list semantics for the histogram, `shrink-0` on the star, overridable a11y labels, extra test coverage).
- Added demos to `src/App.tsx` and exports to `src/index.ts`; component + all public types exported per the open-source export rules.

## Storybook screenshots

### RatingSummary

| Default | Mixed | Large volume (locale-formatted counts) |
| --- | --- | --- |
| ![RatingSummary default](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-rating-summary-review-card/rating-summary-default.png) | ![RatingSummary mixed](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-rating-summary-review-card/rating-summary-mixed.png) | ![RatingSummary large volume](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-rating-summary-review-card/rating-summary-large-volume.png) |

### ReviewCard

| Default | Low rating |
| --- | --- |
| ![ReviewCard default](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-rating-summary-review-card/review-card-default.png) | ![ReviewCard low rating](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-rating-summary-review-card/review-card-low-rating.png) |

A list composed with `<Divider/>` between cards (the Figma "text reviews" layout):

![ReviewCard list](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-rating-summary-review-card/review-card-list.png)

<sub>Screenshots captured from this branch's Storybook. They live on the throwaway `screenshots-rating-summary-review-card` branch (not for merge) so `main` stays free of binary assets - delete it after review.</sub>

> Note: I intentionally left the Figma `design` parameter off the stories - the source design lives in an internal Figma file, and AGENTS.md's open-source data-safety rules say not to embed private Figma URLs in the public Storybook. Happy to link it via the Storybook Connect plugin once Chromatic publishes.
