### PR TITLE
feat(Breadcrumb): migrate to V2 with size prop and slash separator (ENG-10623)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4650,35 +4650,24 @@ function BreadcrumbDemo() {
             </BreadcrumbItem>
           </BreadcrumbList>
         </Breadcrumb>
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/section">Section</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Current Page</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/section">Section</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/section/subsection">Subsection</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbItem>
-              <BreadcrumbPage>Current Page</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+        {(["12px", "14px", "16px"] as const).map((size) => (
+          <Breadcrumb key={size}>
+            <BreadcrumbList size={size}>
+              <BreadcrumbItem>
+                <BreadcrumbLink href="/">Home</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbItem>
+                <BreadcrumbLink href="/section">Section</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbItem>
+                <BreadcrumbLink href="/section/subsection">Subsection</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbItem>
+                <BreadcrumbPage>Current Page</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        ))}
       </div>
     </div>
   );

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { ChevronRightIcon } from "../Icons/ChevronRightIcon";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -14,7 +15,7 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=14962-1155047",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17799-38008",
     },
   },
   tags: ["autodocs"],
@@ -80,15 +81,68 @@ export const FourItems: Story = {
   ),
 };
 
+export const Size12px: Story = {
+  name: "Size 12px",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList size="12px">
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/section">Section</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Current Page</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const Size14px: Story = {
+  name: "Size 14px",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList size="14px">
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/section">Section</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Current Page</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const Size16px: Story = {
+  name: "Size 16px",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList size="16px">
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/section">Section</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Current Page</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
 export const CustomSeparator: Story = {
   name: "Custom separator",
   render: () => (
     <Breadcrumb>
-      <BreadcrumbList
-        separator={
-          <span className="typography-description-12px-regular text-content-secondary">/</span>
-        }
-      >
+      <BreadcrumbList separator={<ChevronRightIcon className="size-4" />}>
         <BreadcrumbItem>
           <BreadcrumbLink href="/">Home</BreadcrumbLink>
         </BreadcrumbItem>

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -133,6 +133,49 @@ describe("Breadcrumb", () => {
       );
       expect(screen.getByTestId("custom-sep")).toBeInTheDocument();
     });
+
+    it("renders a slash glyph as the default separator", () => {
+      render(
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/">Home</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
+              <BreadcrumbPage>Page</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>,
+      );
+      const separator = document.querySelector('li[aria-hidden="true"]');
+      expect(separator).toHaveTextContent("/");
+    });
+
+    it("applies size typography to links and the current page", () => {
+      render(
+        <Breadcrumb>
+          <BreadcrumbList size="16px">
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/">Home</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
+              <BreadcrumbPage>Current Page</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>,
+      );
+      expect(screen.getByRole("link", { name: "Home" })).toHaveClass(
+        "typography-body-default-16px-regular",
+      );
+      expect(screen.getByText("Current Page")).toHaveClass("typography-body-default-16px-semibold");
+    });
+
+    it("defaults to the 12px size typography", () => {
+      render(<BasicBreadcrumb />);
+      expect(screen.getByRole("link", { name: "Home" })).toHaveClass(
+        "typography-description-12px-regular",
+      );
+    });
   });
 
   describe("accessibility", () => {

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,25 @@
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import { cn } from "../../utils/cn";
-import { ChevronRightIcon } from "../Icons/ChevronRightIcon";
+
+/** Text size preset controlling the typography of the whole breadcrumb trail. @default "12px" */
+export type BreadcrumbSize = "12px" | "14px" | "16px";
+
+const regularTypographyBySize: Record<BreadcrumbSize, string> = {
+  "12px": "typography-description-12px-regular",
+  "14px": "typography-body-small-14px-regular",
+  "16px": "typography-body-default-16px-regular",
+};
+
+const semiboldTypographyBySize: Record<BreadcrumbSize, string> = {
+  "12px": "typography-description-12px-semibold",
+  "14px": "typography-body-small-14px-semibold",
+  "16px": "typography-body-default-16px-semibold",
+};
+
+const BreadcrumbSizeContext = React.createContext<BreadcrumbSize>("12px");
+
+const useBreadcrumbSize = () => React.useContext(BreadcrumbSizeContext);
 
 export interface BreadcrumbProps extends React.ComponentPropsWithoutRef<"nav"> {
   /** Accessible label for the breadcrumb navigation landmark. @default "breadcrumb" */
@@ -14,7 +32,7 @@ export interface BreadcrumbProps extends React.ComponentPropsWithoutRef<"nav"> {
  * @example
  * ```tsx
  * <Breadcrumb>
- *   <BreadcrumbList>
+ *   <BreadcrumbList size="14px">
  *     <BreadcrumbItem><BreadcrumbLink href="/">Home</BreadcrumbLink></BreadcrumbItem>
  *     <BreadcrumbSeparator />
  *     <BreadcrumbItem><BreadcrumbPage>Current Page</BreadcrumbPage></BreadcrumbItem>
@@ -31,16 +49,19 @@ export const Breadcrumb = React.forwardRef<HTMLElement, BreadcrumbProps>(
 Breadcrumb.displayName = "Breadcrumb";
 
 export interface BreadcrumbListProps extends React.ComponentPropsWithoutRef<"ol"> {
-  /** Custom separator element rendered between items. @default ChevronRightIcon */
+  /** Custom separator element rendered between items. @default "/" */
   separator?: React.ReactNode;
+  /** Text size preset applied to every item in the trail. @default "12px" */
+  size?: BreadcrumbSize;
 }
 
 /**
  * Ordered list container for breadcrumb items. Automatically injects a
- * separator between each child item.
+ * separator between each child item and shares the trail {@link BreadcrumbSize}
+ * with its descendants.
  */
 export const BreadcrumbList = React.forwardRef<HTMLOListElement, BreadcrumbListProps>(
-  ({ className, children, separator, ...props }, ref) => {
+  ({ className, children, separator, size = "12px", ...props }, ref) => {
     const items = React.Children.toArray(children);
     const withSeparators = items.flatMap((child, index) => {
       const childKey = React.isValidElement(child) ? child.key : index;
@@ -53,9 +74,11 @@ export const BreadcrumbList = React.forwardRef<HTMLOListElement, BreadcrumbListP
     });
 
     return (
-      <ol ref={ref} className={cn("flex flex-wrap items-center gap-2", className)} {...props}>
-        {withSeparators}
-      </ol>
+      <BreadcrumbSizeContext.Provider value={size}>
+        <ol ref={ref} className={cn("flex flex-wrap items-center gap-2", className)} {...props}>
+          {withSeparators}
+        </ol>
+      </BreadcrumbSizeContext.Provider>
     );
   },
 );
@@ -87,11 +110,13 @@ export interface BreadcrumbLinkProps extends React.ComponentPropsWithoutRef<"a">
 export const BreadcrumbLink = React.forwardRef<HTMLAnchorElement, BreadcrumbLinkProps>(
   ({ asChild = false, className, ...props }, ref) => {
     const Comp = asChild ? Slot : "a";
+    const size = useBreadcrumbSize();
     return (
       <Comp
         ref={ref}
         className={cn(
-          "typography-description-12px-regular rounded-[2px] text-content-secondary underline-offset-2 transition-colors hover:text-content-primary hover:underline focus-visible:shadow-focus-ring focus-visible:outline-none",
+          regularTypographyBySize[size],
+          "rounded-[2px] text-content-secondary underline-offset-2 transition-colors hover:text-content-primary hover:underline focus-visible:shadow-focus-ring focus-visible:outline-none",
           className,
         )}
         {...props}
@@ -108,14 +133,17 @@ export interface BreadcrumbPageProps extends React.ComponentPropsWithoutRef<"spa
  * Non-interactive label representing the current page in the breadcrumb trail.
  */
 export const BreadcrumbPage = React.forwardRef<HTMLSpanElement, BreadcrumbPageProps>(
-  ({ className, ...props }, ref) => (
-    <span
-      ref={ref}
-      aria-current="page"
-      className={cn("typography-description-12px-semibold text-content-primary", className)}
-      {...props}
-    />
-  ),
+  ({ className, ...props }, ref) => {
+    const size = useBreadcrumbSize();
+    return (
+      <span
+        ref={ref}
+        aria-current="page"
+        className={cn(semiboldTypographyBySize[size], "text-content-primary", className)}
+        {...props}
+      />
+    );
+  },
 );
 
 BreadcrumbPage.displayName = "BreadcrumbPage";
@@ -124,19 +152,26 @@ export interface BreadcrumbSeparatorProps extends React.ComponentPropsWithoutRef
 
 /**
  * Visual separator rendered between breadcrumb items.
- * Renders a right-pointing chevron icon and is hidden from assistive technology.
+ * Renders a `/` glyph by default and is hidden from assistive technology.
  */
 export const BreadcrumbSeparator = React.forwardRef<HTMLLIElement, BreadcrumbSeparatorProps>(
-  ({ className, children, ...props }, ref) => (
-    <li
-      ref={ref}
-      aria-hidden="true"
-      className={cn("flex items-center text-content-secondary", className)}
-      {...props}
-    >
-      {children ?? <ChevronRightIcon className="size-4" />}
-    </li>
-  ),
+  ({ className, children, ...props }, ref) => {
+    const size = useBreadcrumbSize();
+    return (
+      <li
+        ref={ref}
+        aria-hidden="true"
+        className={cn(
+          "flex items-center text-content-secondary",
+          regularTypographyBySize[size],
+          className,
+        )}
+        {...props}
+      >
+        {children ?? "/"}
+      </li>
+    );
+  },
 );
 
 BreadcrumbSeparator.displayName = "BreadcrumbSeparator";

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type {
   BreadcrumbPageProps,
   BreadcrumbProps,
   BreadcrumbSeparatorProps,
+  BreadcrumbSize,
 } from "./components/Breadcrumb/Breadcrumb";
 export {
   Breadcrumb,


### PR DESCRIPTION
## Summary

Migrates `Breadcrumb` to the V2 Fanvue Library design ([ENG-10623](https://linear.app/fanvue/issue/ENG-10623/migrate-breadcrumb-to-v2)), additively and with no breaking public API changes.

- Default separator is now a `/` glyph (was a chevron icon), matching V2.
- New `size` prop on `BreadcrumbList` (`"12px" | "14px" | "16px"`, default `"12px"`) that drives the trail typography via a shared context, mapping to the `typography-description-12px-*`, `typography-body-small-14px-*`, and `typography-body-default-16px-*` tokens.
- `BreadcrumbSize` type exported from `src/index.ts`.
- The `separator` override and every existing subcomponent keep working; the previous chevron look is available by passing `separator={<ChevronRightIcon className="size-4" />}`.
- Refreshed stories, tests, and the `App.tsx` demo; updated the Figma `design` link to the V2 node.

## Acceptance criteria

- [x] 1:1 with the V2 Figma design ([V2 Breadcrumb](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17799-38008)) — `/` separator, `content/secondary` links, `content/primary` semibold current page, 12/14/16px sizes matching the depth/typography matrix
- [x] No breaking changes to public APIs (all changes additive)

## Quality gates

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (134 files, 3744 tests passing)
- [x] `pnpm build`

## Visual evidence

Captured via Playwright against local Storybook.

**Steps (default 12px, `/` separator)**

| 2 items | 3 items | 4 items |
| --- | --- | --- |
| ![2 items](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/two-items.png) | ![3 items](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/three-items.png) | ![4 items](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/four-items.png) |

**Sizes**

| 12px | 14px | 16px |
| --- | --- | --- |
| ![12px](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/size-12px.png) | ![14px](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/size-14px.png) | ![16px](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/size-16px.png) |

**Interactive & override**

| Hover (link) | Custom separator override |
| --- | --- |
| ![hover](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/hover-link.png) | ![custom separator](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-breadcrumb-v2/custom-separator.png) |

## Follow-up

- Remind the design team to link the component in Figma via the Storybook Connect plugin once Chromatic publishes this branch.

Made with [Cursor](https://cursor.com)