### PR TITLE
feat(Pagination): migrate page items to V2 Page Item styling (ENG-10646)

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=2440-20778",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16804-86903",
     },
   },
   tags: ["autodocs"],

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -91,7 +91,7 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
         className={cn(
           "inline-flex items-center pb-4",
           variant === "default" && "gap-3",
-          variant === "dots" && "gap-4",
+          variant === "dots" && "gap-3",
           className,
         )}
         {...props}
@@ -111,7 +111,7 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
               typeof page === "string" ? (
                 <span
                   key={page}
-                  className="flex size-4 items-center justify-center text-content-secondary text-xs"
+                  className="typography-description-12px-regular flex min-w-6 items-center justify-center p-1 text-content-primary"
                   aria-hidden="true"
                 >
                   &hellip;
@@ -124,10 +124,10 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
                   aria-current={page === currentPage ? "page" : undefined}
                   onClick={() => onPageChange?.(page)}
                   className={cn(
-                    "flex size-4 cursor-pointer items-center justify-center rounded-full text-xs focus-visible:shadow-focus-ring focus-visible:outline-none motion-safe:transition-colors motion-safe:duration-150",
+                    "typography-description-12px-regular flex min-w-6 cursor-pointer items-center justify-center rounded-2xs p-1 focus-visible:shadow-focus-ring focus-visible:outline-none motion-safe:transition-colors motion-safe:duration-150",
                     page === currentPage
-                      ? "bg-buttons-primary-default text-content-primary-inverted"
-                      : "bg-neutral-alphas-50 text-content-primary hover:bg-neutral-alphas-100 active:bg-neutral-alphas-100",
+                      ? "bg-surface-primary-inverted text-content-primary-inverted"
+                      : "text-content-primary hover:bg-buttons-secondary-default active:bg-buttons-secondary-hover",
                   )}
                 >
                   {page}
@@ -146,14 +146,14 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
                 aria-label={getPageLabel(page)}
                 aria-current={page === currentPage ? "page" : undefined}
                 onClick={() => onPageChange?.(page)}
-                className="flex size-6 cursor-pointer items-center justify-center rounded-full focus-visible:shadow-focus-ring focus-visible:outline-none"
+                className="group flex size-6 cursor-pointer items-center justify-center rounded-2xs focus-visible:shadow-focus-ring focus-visible:outline-none"
               >
                 <span
                   className={cn(
-                    "block rounded-full motion-safe:transition-all motion-safe:duration-150",
+                    "block size-2 rounded-2xs motion-safe:transition-colors motion-safe:duration-150",
                     page === currentPage
-                      ? "size-2 bg-neutral-alphas-400"
-                      : "size-1.5 bg-neutral-alphas-200 hover:bg-neutral-alphas-300 active:bg-neutral-alphas-300",
+                      ? "bg-surface-primary-inverted"
+                      : "bg-buttons-secondary-default group-hover:bg-buttons-secondary-hover group-active:bg-buttons-secondary-hover",
                   )}
                 />
               </button>


### PR DESCRIPTION
## Summary

Migrates the `Pagination` numbered and dot page items to match the **V2 Page Item** design ([Figma](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16804-86903)), closing the gap called out in ENG-10646 where page buttons were custom `size-4` circles rather than referencing V2 Page Item sizing/colour tokens.

- **Numbered items**: now 4px-radius rectangles (`rounded-2xs`, `min-w-6`, `p-1`) using `typography-description-12px-regular`. Active state uses `bg-surface-primary-inverted` + `text-content-primary-inverted`; inactive is transparent with a `buttons-secondary` hover/active fill.
- **Dot items**: equal-size 8px rounded squares (`size-2 rounded-2xs`). Active uses `bg-surface-primary-inverted`; inactive uses `bg-buttons-secondary-default` with a group hover.
- **Spacing**: arrow ↔ group gap aligned to the V2 root `sm` (12px) token for both variants.
- Story `design` param updated to the V2 Pagination node.

No breaking changes to the public API — purely visual/token alignment.

## Acceptance criteria

- [x] 1:1 with the V2 Figma design
- [x] No breaking changes to public APIs

## Quality gates

- [x] `pnpm lint` (no new warnings)
- [x] `pnpm typecheck`
- [x] `pnpm test` (3843 passed)
- [x] `pnpm build`

## Screenshots

Captured via Playwright against Storybook. Hosted on the `screenshots-pagination-v2` branch (not committed to this PR's diff).

### Numbered (default)

| Default (page 2/5) | First page | Last page |
| --- | --- | --- |
| ![default](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/default.png) | ![first-page](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/first-page.png) | ![last-page](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/last-page.png) |

| Many pages (ellipsis both sides) | Ellipsis at end | Ellipsis at start |
| --- | --- | --- |
| ![many-pages](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/many-pages.png) | ![many-pages-start](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/many-pages-start.png) | ![many-pages-end](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/many-pages-end.png) |

Single page:

![single-page](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/single-page.png)

### Dots

| Dots | Dots first page | Dots last page | Dots few pages |
| --- | --- | --- | --- |
| ![dots](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/dots.png) | ![dots-first-page](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/dots-first-page.png) | ![dots-last-page](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/dots-last-page.png) | ![dots-few-pages](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/dots-few-pages.png) |

### Interactive states

| Hover (numbered) | Focus-visible ring | Hover (dot) |
| --- | --- | --- |
| ![default-hover](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/default-hover.png) | ![default-focus](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/default-focus.png) | ![dots-hover](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-pagination-v2/dots-hover.png) |

Linear: [ENG-10646](https://linear.app/fanvue/issue/ENG-10646/migrate-pagination-to-v2)

Made with [Cursor](https://cursor.com)