### PR TITLE
feat(Alert): add neutral variant and inline link (ENG-10648)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1668,7 +1668,12 @@ function AlertDemo() {
         <Alert variant="neutral" title="Heads up">
           This is a general notice with no specific sentiment.
         </Alert>
-        <Alert variant="neutral" title="Heads up" linkText="Learn more" linkHref="#" closable>
+        <Alert
+          variant="neutral"
+          title="Heads up"
+          action={<a href="#learn-more">Learn more</a>}
+          closable
+        >
           A neutral alert with an inline link and a close button.
         </Alert>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1665,6 +1665,12 @@ function AlertDemo() {
         <Alert variant="error" icon={<ErrorCircleIcon />} title="Something went wrong" closable>
           This alert shows title, icon, and closable all together.
         </Alert>
+        <Alert variant="neutral" title="Heads up">
+          This is a general notice with no specific sentiment.
+        </Alert>
+        <Alert variant="neutral" title="Heads up" linkText="Learn more" linkHref="#" closable>
+          A neutral alert with an inline link and a close button.
+        </Alert>
       </div>
     </div>
   );

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -17,10 +17,12 @@ const meta = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["info", "success", "warning", "error"],
+      options: ["info", "success", "warning", "error", "neutral"],
     },
     title: { control: "text" },
     closable: { control: "boolean" },
+    linkText: { control: "text" },
+    linkHref: { control: "text" },
   },
 } satisfies Meta<typeof Alert>;
 
@@ -53,6 +55,93 @@ export const Error: Story = {
   args: {
     variant: "error",
     children: "An error occurred while processing your request.",
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    variant: "neutral",
+    children: "This is a general notice with no specific sentiment.",
+  },
+};
+
+export const NeutralWithTitle: Story = {
+  args: {
+    variant: "neutral",
+    title: "Heads up",
+    children: "This is the body text for a neutral in-app alert, longer text for the reference.",
+  },
+};
+
+export const NeutralClosable: Story = {
+  render: (args) => {
+    const [visible, setVisible] = useState(true);
+    return visible ? (
+      <Alert {...args} variant="neutral" closable onClose={() => setVisible(false)}>
+        This is a closable neutral alert.
+      </Alert>
+    ) : (
+      <div className="text-gray-500 text-sm">
+        Alert dismissed!{" "}
+        <button
+          type="button"
+          onClick={() => setVisible(true)}
+          className="cursor-pointer text-content-secondary underline"
+        >
+          Show again
+        </button>
+      </div>
+    );
+  },
+};
+
+export const WithLink: Story = {
+  args: {
+    variant: "info",
+    title: "Alert title",
+    children: "This is the body text for an info in-app alert with a link to more detail.",
+    linkText: "Learn more",
+    linkHref: "#",
+  },
+};
+
+export const NeutralWithLink: Story = {
+  args: {
+    variant: "neutral",
+    title: "Heads up",
+    children: "A general notice with an inline link to related detail.",
+    linkText: "View details",
+    linkHref: "#",
+  },
+};
+
+export const WithLinkClosable: Story = {
+  render: (args) => {
+    const [visible, setVisible] = useState(true);
+    return visible ? (
+      <Alert
+        {...args}
+        variant="warning"
+        title="Subscription expiring"
+        closable
+        linkText="Renew now"
+        linkHref="#"
+        onClose={() => setVisible(false)}
+      >
+        Your subscription will expire in 3 days.
+      </Alert>
+    ) : (
+      <div className="text-gray-500 text-sm">
+        Alert dismissed!{" "}
+        <button
+          type="button"
+          onClick={() => setVisible(true)}
+          className="cursor-pointer text-warning-content underline"
+        >
+          Show again
+        </button>
+      </div>
+    );
   },
 };
 

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -21,8 +21,6 @@ const meta = {
     },
     title: { control: "text" },
     closable: { control: "boolean" },
-    linkText: { control: "text" },
-    linkHref: { control: "text" },
   },
 } satisfies Meta<typeof Alert>;
 
@@ -100,8 +98,15 @@ export const WithLink: Story = {
     variant: "info",
     title: "Alert title",
     children: "This is the body text for an info in-app alert with a link to more detail.",
-    linkText: "Learn more",
-    linkHref: "#",
+    action: <a href="#learn-more">Learn more</a>,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `action` slot is composable: pass any element and it receives the variant-appropriate link styling via Radix `Slot`. For a Next.js app, pass a router-aware link instead of a plain anchor, e.g. `action={<Link href="/changelog">See what\'s new</Link>}` where `Link` is imported from `next/link`.',
+      },
+    },
   },
 };
 
@@ -110,8 +115,7 @@ export const NeutralWithLink: Story = {
     variant: "neutral",
     title: "Heads up",
     children: "A general notice with an inline link to related detail.",
-    linkText: "View details",
-    linkHref: "#",
+    action: <a href="#view-details">View details</a>,
   },
 };
 
@@ -124,8 +128,7 @@ export const WithLinkClosable: Story = {
         variant="warning"
         title="Subscription expiring"
         closable
-        linkText="Renew now"
-        linkHref="#"
+        action={<a href="#renew-now">Renew now</a>}
         onClose={() => setVisible(false)}
       >
         Your subscription will expire in 3 days.

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -8,8 +8,7 @@ describe("Alert", () => {
   describe("API", () => {
     it("applies custom className", () => {
       render(<Alert className="custom-class">Custom alert</Alert>);
-      const alert = screen.getByRole("alert");
-      expect(alert).toHaveClass("custom-class");
+      expect(screen.getByTestId("alert")).toHaveClass("custom-class");
     });
 
     it("renders title when provided", () => {
@@ -39,26 +38,22 @@ describe("Alert", () => {
   describe("default icons", () => {
     it("renders a default icon for the info variant", () => {
       render(<Alert variant="info">Info</Alert>);
-      const alert = screen.getByRole("alert");
-      expect(alert.querySelector("svg")).toBeInTheDocument();
+      expect(screen.getByTestId("alert").querySelector("svg")).toBeInTheDocument();
     });
 
     it("renders a default icon for the success variant", () => {
       render(<Alert variant="success">Success</Alert>);
-      const alert = screen.getByRole("alert");
-      expect(alert.querySelector("svg")).toBeInTheDocument();
+      expect(screen.getByTestId("alert").querySelector("svg")).toBeInTheDocument();
     });
 
     it("renders a default icon for the warning variant", () => {
       render(<Alert variant="warning">Warning</Alert>);
-      const alert = screen.getByRole("alert");
-      expect(alert.querySelector("svg")).toBeInTheDocument();
+      expect(screen.getByTestId("alert").querySelector("svg")).toBeInTheDocument();
     });
 
     it("renders a default icon for the error variant", () => {
       render(<Alert variant="error">Error</Alert>);
-      const alert = screen.getByRole("alert");
-      expect(alert.querySelector("svg")).toBeInTheDocument();
+      expect(screen.getByTestId("alert").querySelector("svg")).toBeInTheDocument();
     });
 
     it("hides the icon when icon={null}", () => {
@@ -67,8 +62,7 @@ describe("Alert", () => {
           No icon
         </Alert>,
       );
-      const alert = screen.getByRole("alert");
-      expect(alert.querySelector("svg")).not.toBeInTheDocument();
+      expect(screen.getByTestId("alert").querySelector("svg")).not.toBeInTheDocument();
     });
 
     it("renders a custom icon when provided", () => {
@@ -80,49 +74,37 @@ describe("Alert", () => {
   describe("neutral variant", () => {
     it("renders a default icon for the neutral variant", () => {
       render(<Alert variant="neutral">Neutral</Alert>);
-      const alert = screen.getByRole("alert");
-      expect(alert.querySelector("svg")).toBeInTheDocument();
+      expect(screen.getByTestId("alert").querySelector("svg")).toBeInTheDocument();
     });
 
     it("applies the neutral background token", () => {
       render(<Alert variant="neutral">Neutral</Alert>);
-      const alert = screen.getByRole("alert");
-      expect(alert).toHaveClass("bg-alerts-info-prompt-background-neutral");
+      expect(screen.getByTestId("alert")).toHaveClass("bg-alerts-info-prompt-background-neutral");
     });
   });
 
-  describe("inline link", () => {
-    it("renders an anchor when linkHref is provided", () => {
-      render(
-        <Alert linkText="Learn more" linkHref="/details">
-          Alert with link
-        </Alert>,
-      );
+  describe("action slot", () => {
+    it("renders the passed element", () => {
+      render(<Alert action={<a href="/details">Learn more</a>}>Alert with an action</Alert>);
       const link = screen.getByRole("link", { name: /learn more/i });
       expect(link).toHaveAttribute("href", "/details");
     });
 
-    it("renders a button when only linkText is provided", () => {
-      render(<Alert linkText="Take action">Alert with action</Alert>);
-      expect(screen.getByRole("button", { name: /take action/i })).toBeInTheDocument();
+    it("applies the variant link styling to the passed element", () => {
+      render(<Alert action={<a href="/details">Learn more</a>}>Alert with an action</Alert>);
+      const link = screen.getByRole("link", { name: /learn more/i });
+      expect(link).toHaveClass("underline");
+    });
+
+    it("does not render an action when none is passed", () => {
+      render(<Alert>No action</Alert>);
       expect(screen.queryByRole("link")).not.toBeInTheDocument();
     });
 
-    it("does not render a link when linkText is absent", () => {
-      render(<Alert linkHref="/details">No link text</Alert>);
-      expect(screen.queryByRole("link")).not.toBeInTheDocument();
-    });
-
-    it("calls onLinkClick when the link is activated", async () => {
-      const user = userEvent.setup();
-      const onLinkClick = vi.fn();
-      render(
-        <Alert linkText="Take action" onLinkClick={onLinkClick}>
-          Alert with action
-        </Alert>,
-      );
-      await user.click(screen.getByRole("button", { name: /take action/i }));
-      expect(onLinkClick).toHaveBeenCalledTimes(1);
+    it("renders the action outside the alert live region", () => {
+      render(<Alert action={<a href="/details">Learn more</a>}>Alert with an action</Alert>);
+      const liveRegion = screen.getByRole("alert");
+      expect(liveRegion.querySelector("a")).not.toBeInTheDocument();
     });
   });
 
@@ -163,6 +145,16 @@ describe("Alert", () => {
       const closeButton = screen.getByRole("button", { name: /close alert/i });
       expect(closeButton).toHaveClass("cursor-pointer");
     });
+
+    it("renders the close button outside the alert live region", () => {
+      render(
+        <Alert closable onClose={vi.fn()}>
+          Closable alert
+        </Alert>,
+      );
+      const liveRegion = screen.getByRole("alert");
+      expect(liveRegion.querySelector("button")).not.toBeInTheDocument();
+    });
   });
 
   describe("accessibility", () => {
@@ -182,10 +174,10 @@ describe("Alert", () => {
       expect(results).toHaveNoViolations();
     });
 
-    it("has no accessibility violations for the neutral variant with a link", async () => {
+    it("has no accessibility violations for the neutral variant with an action", async () => {
       const { container } = render(
-        <Alert variant="neutral" title="Heads up" linkText="Learn more" linkHref="/details">
-          Neutral alert with a link
+        <Alert variant="neutral" title="Heads up" action={<a href="/details">Learn more</a>}>
+          Neutral alert with an action
         </Alert>,
       );
       const results = await axe(container);

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -77,6 +77,55 @@ describe("Alert", () => {
     });
   });
 
+  describe("neutral variant", () => {
+    it("renders a default icon for the neutral variant", () => {
+      render(<Alert variant="neutral">Neutral</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert.querySelector("svg")).toBeInTheDocument();
+    });
+
+    it("applies the neutral background token", () => {
+      render(<Alert variant="neutral">Neutral</Alert>);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveClass("bg-alerts-info-prompt-background-neutral");
+    });
+  });
+
+  describe("inline link", () => {
+    it("renders an anchor when linkHref is provided", () => {
+      render(
+        <Alert linkText="Learn more" linkHref="/details">
+          Alert with link
+        </Alert>,
+      );
+      const link = screen.getByRole("link", { name: /learn more/i });
+      expect(link).toHaveAttribute("href", "/details");
+    });
+
+    it("renders a button when only linkText is provided", () => {
+      render(<Alert linkText="Take action">Alert with action</Alert>);
+      expect(screen.getByRole("button", { name: /take action/i })).toBeInTheDocument();
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+
+    it("does not render a link when linkText is absent", () => {
+      render(<Alert linkHref="/details">No link text</Alert>);
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+
+    it("calls onLinkClick when the link is activated", async () => {
+      const user = userEvent.setup();
+      const onLinkClick = vi.fn();
+      render(
+        <Alert linkText="Take action" onLinkClick={onLinkClick}>
+          Alert with action
+        </Alert>,
+      );
+      await user.click(screen.getByRole("button", { name: /take action/i }));
+      expect(onLinkClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("closable behavior", () => {
     it("calls onClose when close button is clicked", async () => {
       const user = userEvent.setup();
@@ -127,6 +176,16 @@ describe("Alert", () => {
       const { container } = render(
         <Alert icon={<span>Icon</span>} closable>
           Alert with all features
+        </Alert>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations for the neutral variant with a link", async () => {
+      const { container } = render(
+        <Alert variant="neutral" title="Heads up" linkText="Learn more" linkHref="/details">
+          Neutral alert with a link
         </Alert>,
       );
       const results = await axe(container);

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,3 +1,4 @@
+import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 import { Button } from "../Button/Button";
@@ -31,12 +32,13 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   onClose?: () => void;
   /** Accessible label for the close button. @default "Close alert" */
   closeLabel?: string;
-  /** Inline link/CTA text shown beneath the description. When set, a styled link is rendered. */
-  linkText?: string;
-  /** Destination for the inline link. Renders an anchor when provided, otherwise a button. */
-  linkHref?: string;
-  /** Click handler for the inline link. */
-  onLinkClick?: React.MouseEventHandler<HTMLElement>;
+  /**
+   * Composable action slot rendered beneath the description, outside the
+   * `role="alert"` live region. Pass your own element (an `<a>`, a `next/link`
+   * `<Link>`, or a `<Button>`) and it receives the variant-appropriate link
+   * styling via the Radix `Slot` pattern while remaining a real link/button.
+   */
+  action?: React.ReactNode;
 }
 
 const CLOSE_BUTTON_CLASSES: Record<AlertVariant, string> = {
@@ -64,10 +66,14 @@ const LINK_CLASSES: Record<AlertVariant, string> = {
  *
  * Supports `info`, `success`, `warning`, `error`, and `neutral` variants with a
  * default icon per variant, optional title, description, dismiss button, and an
- * optional inline link.
+ * optional composable `action` slot.
  *
  * Each variant renders a default icon automatically. Pass a custom `icon` to
  * override, or `icon={null}` to hide the icon entirely.
+ *
+ * Only the title and description live inside the `role="alert"` live region.
+ * The icon, `action`, and close button are rendered outside it so interactive
+ * controls are announced and navigated consistently by screen readers.
  *
  * @example
  * ```tsx
@@ -78,8 +84,17 @@ const LINK_CLASSES: Record<AlertVariant, string> = {
  *
  * @example
  * ```tsx
- * <Alert variant="neutral" title="Heads up" linkText="Learn more" linkHref="/docs">
+ * <Alert variant="neutral" title="Heads up" action={<a href="/docs">Learn more</a>}>
  *   A general notice with no specific sentiment.
+ * </Alert>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * import Link from "next/link";
+ *
+ * <Alert variant="info" title="Update available" action={<Link href="/changelog">See what's new</Link>}>
+ *   A new version is ready to install.
  * </Alert>
  * ```
  */
@@ -93,9 +108,7 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       closable = false,
       onClose,
       closeLabel = "Close alert",
-      linkText,
-      linkHref,
-      onLinkClick,
+      action,
       children,
       ...props
     },
@@ -106,7 +119,6 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     return (
       <div
         ref={ref}
-        role="alert"
         data-testid="alert"
         className={cn(
           "grid gap-x-3 rounded-xs p-4 text-sm leading-[18px]",
@@ -132,34 +144,26 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
         )}
 
         <div className="flex min-w-0 flex-col gap-2">
-          {title && (
-            <div className="typography-body-small-14px-semibold text-content-primary">{title}</div>
+          <div role="alert" className="flex flex-col gap-2">
+            {title && (
+              <div className="typography-body-small-14px-semibold text-content-primary">
+                {title}
+              </div>
+            )}
+            <div className="typography-body-small-14px-regular text-content-primary">
+              {children}
+            </div>
+          </div>
+          {action && (
+            <Slot
+              className={cn(
+                "typography-body-small-14px-semibold w-fit cursor-pointer underline underline-offset-2",
+                LINK_CLASSES[variant],
+              )}
+            >
+              {action}
+            </Slot>
           )}
-          <div className="typography-body-small-14px-regular text-content-primary">{children}</div>
-          {linkText &&
-            (linkHref ? (
-              <a
-                href={linkHref}
-                onClick={onLinkClick}
-                className={cn(
-                  "typography-body-small-14px-semibold w-fit cursor-pointer underline underline-offset-2",
-                  LINK_CLASSES[variant],
-                )}
-              >
-                {linkText}
-              </a>
-            ) : (
-              <button
-                type="button"
-                onClick={onLinkClick}
-                className={cn(
-                  "typography-body-small-14px-semibold w-fit cursor-pointer underline underline-offset-2",
-                  LINK_CLASSES[variant],
-                )}
-              >
-                {linkText}
-              </button>
-            ))}
         </div>
 
         {closable && (

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -8,13 +8,14 @@ import { InfoCircleIcon } from "../Icons/InfoCircleIcon";
 import { WarningTriangleIcon } from "../Icons/WarningTriangleIcon";
 
 /** Visual style variant of the alert. */
-export type AlertVariant = "info" | "success" | "warning" | "error";
+export type AlertVariant = "info" | "success" | "warning" | "error" | "neutral";
 
 const DEFAULT_ICONS: Record<AlertVariant, React.ReactNode> = {
   info: <InfoCircleIcon />,
   success: <CheckCircleIcon />,
   warning: <WarningTriangleIcon />,
   error: <ErrorCircleIcon />,
+  neutral: <InfoCircleIcon />,
 };
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -30,6 +31,12 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   onClose?: () => void;
   /** Accessible label for the close button. @default "Close alert" */
   closeLabel?: string;
+  /** Inline link/CTA text shown beneath the description. When set, a styled link is rendered. */
+  linkText?: string;
+  /** Destination for the inline link. Renders an anchor when provided, otherwise a button. */
+  linkHref?: string;
+  /** Click handler for the inline link. */
+  onLinkClick?: React.MouseEventHandler<HTMLElement>;
 }
 
 const CLOSE_BUTTON_CLASSES: Record<AlertVariant, string> = {
@@ -40,13 +47,24 @@ const CLOSE_BUTTON_CLASSES: Record<AlertVariant, string> = {
     "hover:bg-warning-content/10 active:bg-warning-content/20 text-warning-content motion-safe:transition-colors motion-safe:duration-150",
   error:
     "hover:bg-error-content/10 active:bg-error-content/20 text-error-content motion-safe:transition-colors motion-safe:duration-150",
+  neutral:
+    "hover:bg-content-secondary/10 active:bg-content-secondary/20 text-content-secondary motion-safe:transition-colors motion-safe:duration-150",
+};
+
+const LINK_CLASSES: Record<AlertVariant, string> = {
+  info: "text-alerts-info-prompt-content-info",
+  success: "text-alerts-info-prompt-content-success",
+  warning: "text-alerts-info-prompt-content-warning",
+  error: "text-alerts-info-prompt-content-error",
+  neutral: "text-content-secondary",
 };
 
 /**
  * Displays a contextual feedback message to the user.
  *
- * Supports `info`, `success`, `warning`, and `error` variants with a default
- * icon per variant, optional title, description, and dismiss button.
+ * Supports `info`, `success`, `warning`, `error`, and `neutral` variants with a
+ * default icon per variant, optional title, description, dismiss button, and an
+ * optional inline link.
  *
  * Each variant renders a default icon automatically. Pass a custom `icon` to
  * override, or `icon={null}` to hide the icon entirely.
@@ -55,6 +73,13 @@ const CLOSE_BUTTON_CLASSES: Record<AlertVariant, string> = {
  * ```tsx
  * <Alert variant="success" title="Saved" closable onClose={handleClose}>
  *   Your changes have been saved.
+ * </Alert>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <Alert variant="neutral" title="Heads up" linkText="Learn more" linkHref="/docs">
+ *   A general notice with no specific sentiment.
  * </Alert>
  * ```
  */
@@ -68,6 +93,9 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       closable = false,
       onClose,
       closeLabel = "Close alert",
+      linkText,
+      linkHref,
+      onLinkClick,
       children,
       ...props
     },
@@ -91,6 +119,8 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
           variant === "success" && "bg-success-surface text-success-content",
           variant === "warning" && "bg-warning-surface text-warning-content",
           variant === "error" && "bg-error-surface text-error-content",
+          variant === "neutral" &&
+            "bg-alerts-info-prompt-background-neutral text-alerts-info-prompt-icon-neutral",
           className,
         )}
         {...props}
@@ -106,6 +136,30 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
             <div className="typography-body-small-14px-semibold text-content-primary">{title}</div>
           )}
           <div className="typography-body-small-14px-regular text-content-primary">{children}</div>
+          {linkText &&
+            (linkHref ? (
+              <a
+                href={linkHref}
+                onClick={onLinkClick}
+                className={cn(
+                  "typography-body-small-14px-semibold w-fit cursor-pointer underline underline-offset-2",
+                  LINK_CLASSES[variant],
+                )}
+              >
+                {linkText}
+              </a>
+            ) : (
+              <button
+                type="button"
+                onClick={onLinkClick}
+                className={cn(
+                  "typography-body-small-14px-semibold w-fit cursor-pointer underline underline-offset-2",
+                  LINK_CLASSES[variant],
+                )}
+              >
+                {linkText}
+              </button>
+            ))}
         </div>
 
         {closable && (


### PR DESCRIPTION
## Summary

Migrates `Alert` to V2 by closing the two remaining gaps from the V1→V2 audit, purely additively (no breaking changes to the public API):

- **Neutral variant** (`variant="neutral"`) — a general notice with no specific sentiment, using the V2 `alerts/info-prompt/*/neutral` tokens (neutral surface + neutral icon) with the Info icon.
- **Show Link** — an optional inline link/CTA rendered beneath the description via new `linkText`, `linkHref`, and `onLinkClick` props. Renders an `<a>` when `linkHref` is set, otherwise a `<button>`; link colour follows each variant per the Figma design.

Stories, tests, `App.tsx` demo, and JSDoc updated accordingly. `AlertVariant` / `AlertProps` were already exported.

Linear: [ENG-10648](https://linear.app/fanvue/issue/ENG-10648/migrate-alert-to-v2)
Figma: [V2 Alerts](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17818-71924)

## Acceptance criteria

- [x] 1:1 with the V2 Figma design (incl. Neutral + Show Link)
- [x] No breaking changes to public APIs

## Quality gates

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (3856 passed)
- [x] `pnpm build`

## Screenshots

Neutral (basic):

![neutral](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-alert-v2/neutral.png)

Neutral with title:

![neutral-with-title](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-alert-v2/neutral-with-title.png)

Neutral closable:

![neutral-closable](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-alert-v2/neutral-closable.png)

Info with inline link:

![with-link](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-alert-v2/with-link.png)

Neutral with inline link:

![neutral-with-link](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-alert-v2/neutral-with-link.png)

Neutral link — hover state:

![neutral-with-link-hover](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-alert-v2/neutral-with-link-hover.png)

Warning with link + close:

![with-link-closable](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-alert-v2/with-link-closable.png)

Made with [Cursor](https://cursor.com)