### PR TITLE
feat(FanFollowerCount): add V2 fan & follower count component (ENG-11791)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,7 @@ import {
   EyeIcon,
   EyeSlashIcon,
   FacebookIcon,
+  FanFollowerCount,
   FlagIcon,
   FlameIcon,
   FolderIcon,
@@ -2714,6 +2715,24 @@ function CountDemo() {
   );
 }
 
+function FanFollowerCountDemo() {
+  return (
+    <div id="fan-follower-count" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Fan &amp; Follower Count</h2>
+      <div className="flex flex-wrap items-center gap-8">
+        <FanFollowerCount fans={1200} subs={3000} />
+        <FanFollowerCount fans={1250000} subs={48900} />
+        <FanFollowerCount fans={42} subs={7} />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-8">
+        <FanFollowerCount fans={1200} showSubs={false} />
+        <FanFollowerCount subs={3000} showFans={false} />
+      </div>
+    </div>
+  );
+}
+
 const CYCLING_TEXT_STAGES = [
   "Thinking",
   "Reading messages",
@@ -4977,6 +4996,7 @@ function App() {
     { id: "checkbox", label: "Checkbox" },
     { id: "chip", label: "Chip" },
     { id: "count", label: "Count" },
+    { id: "fan-follower-count", label: "Fan & Follower Count" },
     { id: "creator-card", label: "Creator Card" },
     { id: "creator-cover", label: "Creator Cover" },
     { id: "creator-tile", label: "Creator Tile" },
@@ -5187,6 +5207,9 @@ function App() {
 
             {/* Count */}
             <CountDemo />
+
+            {/* Fan & Follower Count */}
+            <FanFollowerCountDemo />
 
             {/* Cycling Text */}
             <CyclingTextDemo />

--- a/src/components/FanFollowerCount/FanFollowerCount.stories.tsx
+++ b/src/components/FanFollowerCount/FanFollowerCount.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FanFollowerCount } from "./FanFollowerCount";
+
+const meta = {
+  title: "Components/FanFollowerCount",
+  component: FanFollowerCount,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=19249-12840",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    fans: {
+      control: "text",
+    },
+    subs: {
+      control: "text",
+    },
+    showFans: {
+      control: "boolean",
+    },
+    showSubs: {
+      control: "boolean",
+    },
+  },
+} satisfies Meta<typeof FanFollowerCount>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    fans: 1200,
+    subs: 3000,
+  },
+};
+
+export const PreformattedStrings: Story = {
+  args: {
+    fans: "1.2k",
+    subs: "3k",
+  },
+};
+
+export const LargeCounts: Story = {
+  args: {
+    fans: 1250000,
+    subs: 48900,
+  },
+};
+
+export const SmallCounts: Story = {
+  args: {
+    fans: 42,
+    subs: 7,
+  },
+};
+
+export const FansOnly: Story = {
+  args: {
+    fans: 1200,
+    showSubs: false,
+  },
+};
+
+export const SubsOnly: Story = {
+  args: {
+    subs: 3000,
+    showFans: false,
+  },
+};

--- a/src/components/FanFollowerCount/FanFollowerCount.test.tsx
+++ b/src/components/FanFollowerCount/FanFollowerCount.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { FanFollowerCount } from "./FanFollowerCount";
+
+describe("FanFollowerCount", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      const { container } = render(<FanFollowerCount fans={10} className="custom-class" />);
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("forwards ref correctly", () => {
+      const ref = { current: null };
+      render(<FanFollowerCount fans={10} ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+  });
+
+  describe("value display", () => {
+    it("compacts numeric counts", () => {
+      render(<FanFollowerCount fans={1200} subs={3000} />);
+      expect(screen.getByText("1.2k")).toBeInTheDocument();
+      expect(screen.getByText("3k")).toBeInTheDocument();
+    });
+
+    it("renders string counts verbatim", () => {
+      render(<FanFollowerCount fans="1.2m" subs="42" />);
+      expect(screen.getByText("1.2m")).toBeInTheDocument();
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+
+    it("renders the default labels", () => {
+      render(<FanFollowerCount fans={1} subs={1} />);
+      expect(screen.getByText("Fans")).toBeInTheDocument();
+      expect(screen.getByText("Subs")).toBeInTheDocument();
+    });
+
+    it("supports custom labels", () => {
+      render(<FanFollowerCount fans={1} subs={1} fansLabel="Followers" subsLabel="Members" />);
+      expect(screen.getByText("Followers")).toBeInTheDocument();
+      expect(screen.getByText("Members")).toBeInTheDocument();
+    });
+  });
+
+  describe("visibility", () => {
+    it("hides the fans group when showFans is false", () => {
+      render(<FanFollowerCount fans={10} subs={20} showFans={false} />);
+      expect(screen.queryByText("Fans")).not.toBeInTheDocument();
+      expect(screen.getByText("Subs")).toBeInTheDocument();
+    });
+
+    it("hides the subs group when showSubs is false", () => {
+      render(<FanFollowerCount fans={10} subs={20} showSubs={false} />);
+      expect(screen.getByText("Fans")).toBeInTheDocument();
+      expect(screen.queryByText("Subs")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(<FanFollowerCount fans={1200} subs={3000} />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/FanFollowerCount/FanFollowerCount.tsx
+++ b/src/components/FanFollowerCount/FanFollowerCount.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { DiamondIcon } from "../Icons/DiamondIcon";
+import { HeartIcon } from "../Icons/HeartIcon";
+
+const compactFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function formatCount(value: number | string): string {
+  return typeof value === "number" ? compactFormatter.format(value).toLowerCase() : value;
+}
+
+export interface FanFollowerCountProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Fan count. Numbers are compacted (e.g. `1200` → `"1.2k"`); strings render verbatim. @default 0 */
+  fans?: number | string;
+  /** Subscriber count. Numbers are compacted (e.g. `3000` → `"3k"`); strings render verbatim. @default 0 */
+  subs?: number | string;
+  /** Show the fan count group. @default true */
+  showFans?: boolean;
+  /** Show the subscriber count group. @default true */
+  showSubs?: boolean;
+  /** Label rendered after the fan count. @default "Fans" */
+  fansLabel?: string;
+  /** Label rendered after the subscriber count. @default "Subs" */
+  subsLabel?: string;
+}
+
+/**
+ * Displays a creator's formatted fan and subscriber counts, each paired with an
+ * icon. Numeric values are compacted (`1200` → `"1.2k"`); pass a pre-formatted
+ * string to bypass formatting. Either group can be hidden independently.
+ *
+ * @example
+ * ```tsx
+ * <FanFollowerCount fans={1200} subs={3000} />
+ * ```
+ */
+export const FanFollowerCount = React.forwardRef<HTMLDivElement, FanFollowerCountProps>(
+  (
+    {
+      className,
+      fans = 0,
+      subs = 0,
+      showFans = true,
+      showSubs = true,
+      fansLabel = "Fans",
+      subsLabel = "Subs",
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div ref={ref} className={cn("inline-flex items-center gap-3", className)} {...props}>
+        {showFans && (
+          <span className="inline-flex items-center gap-2">
+            <HeartIcon size={16} className="text-icons-tertiary" />
+            <span className="typography-body-small-14px-semibold inline-flex items-center gap-1 text-content-primary">
+              <span>{formatCount(fans)}</span>
+              <span>{fansLabel}</span>
+            </span>
+          </span>
+        )}
+        {showSubs && (
+          <span className="inline-flex items-center gap-2">
+            <DiamondIcon size={16} className="text-icons-tertiary" />
+            <span className="typography-body-small-14px-semibold inline-flex items-center gap-1 text-content-primary">
+              <span>{formatCount(subs)}</span>
+              <span>{subsLabel}</span>
+            </span>
+          </span>
+        )}
+      </div>
+    );
+  },
+);
+
+FanFollowerCount.displayName = "FanFollowerCount";

--- a/src/components/FanFollowerCount/FanFollowerCount.tsx
+++ b/src/components/FanFollowerCount/FanFollowerCount.tsx
@@ -55,7 +55,7 @@ export const FanFollowerCount = React.forwardRef<HTMLDivElement, FanFollowerCoun
       <div ref={ref} className={cn("inline-flex items-center gap-3", className)} {...props}>
         {showFans && (
           <span className="inline-flex items-center gap-2">
-            <HeartIcon size={16} className="text-icons-tertiary" />
+            <HeartIcon size={16} filled className="text-icons-tertiary" />
             <span className="typography-body-small-14px-semibold inline-flex items-center gap-1 text-content-primary">
               <span>{formatCount(fans)}</span>
               <span>{fansLabel}</span>
@@ -64,7 +64,7 @@ export const FanFollowerCount = React.forwardRef<HTMLDivElement, FanFollowerCoun
         )}
         {showSubs && (
           <span className="inline-flex items-center gap-2">
-            <DiamondIcon size={16} className="text-icons-tertiary" />
+            <DiamondIcon size={16} filled className="text-icons-tertiary" />
             <span className="typography-body-small-14px-semibold inline-flex items-center gap-1 text-content-primary">
               <span>{formatCount(subs)}</span>
               <span>{subsLabel}</span>

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,6 +221,8 @@ export type {
   EmptyStateVariant,
 } from "./components/EmptyState/EmptyState";
 export { EmptyState } from "./components/EmptyState/EmptyState";
+export type { FanFollowerCountProps } from "./components/FanFollowerCount/FanFollowerCount";
+export { FanFollowerCount } from "./components/FanFollowerCount/FanFollowerCount";
 export type {
   IconButtonProps,
   IconButtonSize,


### PR DESCRIPTION
## Summary

Adds the new **V2 Fan & Follower Count** component (`FanFollowerCount`) to `@fanvue/ui`, built 1:1 from the [V2 Figma design](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=19249-12840). It renders a creator's formatted fan and subscriber counts, each paired with an icon (heart for fans, diamond for subs).

Resolves [ENG-11791](https://linear.app/fanvue/issue/ENG-11791/build-v2-fan-and-follower-count). This component is a dependency for the upcoming V2 Profile Card (ENG-11783).

### What changed

- New `FanFollowerCount` component using `forwardRef` + `displayName`, `cn()`, `typography-body-small-14px-semibold`, and the `content-primary` / `icons-tertiary` tokens.
- Reuses the existing `HeartIcon` and `DiamondIcon` primitives (size 16).
- Numeric counts are compacted (`1200` → `1.2k`, `3000` → `3k`); a pre-formatted string can be passed to bypass formatting. `showFans` / `showSubs` toggle each group; `fansLabel` / `subsLabel` allow label overrides.
- Stories + unit/accessibility tests, exported component + `FanFollowerCountProps` in `src/index.ts`, and a demo added to `App.tsx`.

## Acceptance criteria

- [x] 1:1 with the V2 Figma design
- [x] Ships with stories + tests per library conventions

## Quality gates

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (3868 passed, incl. 9 new)
- [x] `pnpm build`

## Screenshots

Hosted on the `screenshots-fan-follower-count-v2` branch (not committed to this PR's diff).

**Default** (`fans={1200}` `subs={3000}`)

![default](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-fan-follower-count-v2/default.png)

**Pre-formatted strings** (`fans="1.2k"` `subs="3k"`)

![preformatted-strings](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-fan-follower-count-v2/preformatted-strings.png)

**Large counts** (`fans={1250000}` `subs={48900}`)

![large-counts](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-fan-follower-count-v2/large-counts.png)

**Small counts** (`fans={42}` `subs={7}`)

![small-counts](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-fan-follower-count-v2/small-counts.png)

**Fans only** (`showSubs={false}`)

![fans-only](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-fan-follower-count-v2/fans-only.png)

**Subs only** (`showFans={false}`)

![subs-only](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-fan-follower-count-v2/subs-only.png)
