### PR TITLE
feat(ProfileStatus): add V2 active/inactive presence indicator (ENG-11790)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,7 @@ import {
   PlayIcon,
   PlusIcon,
   PrivacyIcon,
+  ProfileStatus,
   ProgressBar,
   Radio,
   RadioGroup,
@@ -3838,6 +3839,26 @@ function ReviewCardDemo() {
   );
 }
 
+function ProfileStatusDemo() {
+  return (
+    <div id="profile-status" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Profile Status</h2>
+      <div className="flex flex-wrap items-center gap-8">
+        <div className="flex items-center gap-3">
+          <ProfileStatus active size="sm" />
+          <ProfileStatus active size="md" />
+          <span className="typography-description-12px-regular">Active</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <ProfileStatus active={false} size="sm" />
+          <ProfileStatus active={false} size="md" />
+          <span className="typography-description-12px-regular">Inactive</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ProgressBarDemo() {
   return (
     <div id="progressbar" className="flex scroll-mt-20 flex-col gap-4">
@@ -4998,6 +5019,7 @@ function App() {
     { id: "pagination", label: "Pagination" },
     { id: "passwordfield", label: "Password Field" },
     { id: "pill", label: "Pill" },
+    { id: "profile-status", label: "Profile Status" },
     { id: "progressbar", label: "Progress Bar" },
     { id: "radio", label: "Radio" },
     { id: "searchfield", label: "Search Field" },
@@ -5229,6 +5251,9 @@ function App() {
 
             {/* Pagination */}
             <PaginationDemo />
+
+            {/* Profile Status */}
+            <ProfileStatusDemo />
 
             {/* ProgressBar */}
             <ProgressBarDemo />

--- a/src/components/ProfileStatus/ProfileStatus.stories.tsx
+++ b/src/components/ProfileStatus/ProfileStatus.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ProfileStatus } from "./ProfileStatus";
+
+const meta = {
+  title: "Components/ProfileStatus",
+  component: ProfileStatus,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17801-109201&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    active: { control: "boolean" },
+    size: { control: "select", options: ["sm", "md"] },
+  },
+} satisfies Meta<typeof ProfileStatus>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {
+  args: {
+    active: true,
+  },
+};
+
+export const Inactive: Story = {
+  args: {
+    active: false,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    active: true,
+    size: "sm",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    active: true,
+    size: "md",
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    active: true,
+    "aria-label": "Online",
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      <div className="flex items-center gap-3">
+        <ProfileStatus active size="sm" />
+        <ProfileStatus active size="md" />
+      </div>
+      <div className="flex items-center gap-3">
+        <ProfileStatus active={false} size="sm" />
+        <ProfileStatus active={false} size="md" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ProfileStatus/ProfileStatus.test.tsx
+++ b/src/components/ProfileStatus/ProfileStatus.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { ProfileStatus } from "./ProfileStatus";
+
+describe("ProfileStatus", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      render(<ProfileStatus data-testid="status" className="custom" />);
+      expect(screen.getByTestId("status")).toHaveClass("custom");
+    });
+
+    it("forwards ref correctly", () => {
+      const ref = React.createRef<HTMLSpanElement>();
+      render(<ProfileStatus ref={ref} data-testid="status" />);
+      expect(ref.current).toBe(screen.getByTestId("status"));
+    });
+
+    it("renders the active state with a pulsing overlay by default", () => {
+      const { container } = render(<ProfileStatus data-testid="status" />);
+      expect(screen.getByTestId("status")).toHaveClass("bg-messages-status-active");
+      expect(container.querySelector(".animate-ping")).toBeInTheDocument();
+    });
+
+    it("renders the inactive state without a pulsing overlay", () => {
+      const { container } = render(<ProfileStatus data-testid="status" active={false} />);
+      expect(screen.getByTestId("status")).toHaveClass("bg-messages-status-inactive");
+      expect(container.querySelector(".animate-ping")).not.toBeInTheDocument();
+    });
+
+    it("renders sm size by default", () => {
+      render(<ProfileStatus data-testid="status" />);
+      expect(screen.getByTestId("status")).toHaveClass("size-2");
+    });
+
+    it("renders md size", () => {
+      render(<ProfileStatus data-testid="status" size="md" />);
+      expect(screen.getByTestId("status")).toHaveClass("size-3");
+    });
+
+    it("is decorative (aria-hidden) when no accessible label is provided", () => {
+      render(<ProfileStatus data-testid="status" />);
+      const status = screen.getByTestId("status");
+      expect(status).toHaveAttribute("aria-hidden", "true");
+      expect(status).not.toHaveAttribute("role");
+    });
+
+    it("exposes an image role when an aria-label is provided", () => {
+      render(<ProfileStatus aria-label="Online" />);
+      const status = screen.getByRole("img", { name: "Online" });
+      expect(status).not.toHaveAttribute("aria-hidden");
+    });
+
+    it("spreads additional HTML attributes", () => {
+      render(<ProfileStatus data-testid="status" data-custom="value" />);
+      expect(screen.getByTestId("status")).toHaveAttribute("data-custom", "value");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations when decorative", async () => {
+      const { container } = render(<ProfileStatus />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations when labelled", async () => {
+      const { container } = render(<ProfileStatus aria-label="Online" />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/ProfileStatus/ProfileStatus.tsx
+++ b/src/components/ProfileStatus/ProfileStatus.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Size preset of the {@link ProfileStatus} indicator. */
+export type ProfileStatusSize = "sm" | "md";
+
+export interface ProfileStatusProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Whether the profile is currently active. Active renders a pulsing green dot; inactive renders a static grey dot. @default true */
+  active?: boolean;
+  /** Size preset of the indicator. @default "sm" */
+  size?: ProfileStatusSize;
+}
+
+const sizeClasses: Record<ProfileStatusSize, string> = {
+  sm: "size-2",
+  md: "size-3",
+};
+
+/**
+ * Presence indicator showing whether a creator or fan is currently active.
+ * The active state pulses to signal real-time presence; the inactive state is a
+ * static, muted dot for lists, tables, and content views where presence is less
+ * relevant.
+ *
+ * Decorative by default (`aria-hidden`) — pair it with a visible or visually
+ * hidden label at the usage site. Pass `aria-label` to expose it as a
+ * standalone image to assistive technology.
+ *
+ * Supersedes the V1 `OnlineBlinkingIcon`: `<ProfileStatus />` is a drop-in
+ * replacement for `<OnlineBlinkingIcon />`, adding the distinct inactive state.
+ *
+ * @example
+ * ```tsx
+ * <ProfileStatus active />
+ * <ProfileStatus active={false} size="md" />
+ * <ProfileStatus active aria-label="Online" />
+ * ```
+ */
+export const ProfileStatus = React.forwardRef<HTMLSpanElement, ProfileStatusProps>(
+  ({ className, active = true, size = "sm", ...props }, ref) => {
+    const hasAccessibleLabel = props["aria-label"] != null || props["aria-labelledby"] != null;
+
+    return (
+      <span
+        ref={ref}
+        role={hasAccessibleLabel ? "img" : undefined}
+        aria-hidden={hasAccessibleLabel ? undefined : true}
+        className={cn(
+          "relative inline-block rounded-full border border-border-background",
+          sizeClasses[size],
+          active ? "bg-messages-status-active" : "bg-messages-status-inactive",
+          className,
+        )}
+        {...props}
+      >
+        {active && (
+          <span className="absolute inset-0 animate-ping rounded-full bg-messages-status-active opacity-75" />
+        )}
+      </span>
+    );
+  },
+);
+
+ProfileStatus.displayName = "ProfileStatus";

--- a/src/index.ts
+++ b/src/index.ts
@@ -581,6 +581,11 @@ export { Pill } from "./components/Pill/Pill";
 export type { ProfileOnlineStatusProps } from "./components/ProfileOnlineStatus/ProfileOnlineStatus";
 export { ProfileOnlineStatus } from "./components/ProfileOnlineStatus/ProfileOnlineStatus";
 export type {
+  ProfileStatusProps,
+  ProfileStatusSize,
+} from "./components/ProfileStatus/ProfileStatus";
+export { ProfileStatus } from "./components/ProfileStatus/ProfileStatus";
+export type {
   ProgressBarProps,
   ProgressBarSize,
   ProgressBarVariant,


### PR DESCRIPTION
## Summary

Adds `ProfileStatus`, the V2 presence indicator that supersedes the V1 `OnlineBlinkingIcon`. It renders a pulsing green dot when **active** and a static grey dot when **inactive** — the distinct inactive state the old icon lacked. Built 1:1 with the V2 Figma "V2 Profile Status" node using the design tokens `messages-status-active`, `messages-status-inactive`, and the `border-background` ring.

- New component `ProfileStatus` (`forwardRef`, named export) with `active` (default `true`) and `size` (`sm` | `md`, default `sm`) props.
- Decorative by default (`aria-hidden`); exposes `role="img"` when an `aria-label`/`aria-labelledby` is provided.
- Drop-in migration path: `<ProfileStatus />` replaces `<OnlineBlinkingIcon />` (matching default green pulsing dot).
- Exported component + types in `src/index.ts`, added stories with the Figma `design` param, unit + a11y tests, and an `App.tsx` demo.

## Acceptance criteria

- [x] 1:1 with the V2 Figma design
- [x] Migration path from `OnlineBlinkingIcon`

## Quality gates

- [x] `pnpm lint` (biome clean on new files)
- [x] `pnpm typecheck`
- [x] `pnpm test` (145 files, 3870 tests passing)
- [x] `pnpm build`

## Screenshots

Active vs inactive (sm + md):

![all-states](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-profilestatus-v2/all-states.png)

Active (pulsing green):

![active](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-profilestatus-v2/active.png)

Inactive (static grey):

![inactive](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-profilestatus-v2/inactive.png)

Small:

![small](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-profilestatus-v2/small.png)

Medium:

![medium](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-profilestatus-v2/medium.png)

With accessible label:

![with-label](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-profilestatus-v2/with-label.png)
