### PR TITLE
feat(Link): add V2 Link component (ENG-11789)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,6 +136,7 @@ import {
   InfoCircleIcon,
   InfoIcon,
   InlineEdit,
+  Link,
   LinkIcon,
   Loader,
   LocationIcon,
@@ -2100,6 +2101,35 @@ function BadgeDemo() {
         <Badge variant="success" leftDot={false} rightIcon={<ArrowUpRightIcon />}>
           Right icon
         </Badge>
+      </div>
+    </div>
+  );
+}
+
+function LinkDemo() {
+  return (
+    <div id="link" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Link</h2>
+      <div className="flex flex-col gap-6">
+        {(["16", "14"] as const).map((size) => (
+          <div key={size} className="flex flex-wrap items-center gap-6">
+            <Link href="#" variant="primary" size={size}>
+              Primary {size}px
+            </Link>
+            <Link href="#" variant="brand" size={size}>
+              Brand {size}px
+            </Link>
+            <Link href="#" variant="primary" size={size} leftIcon={<WalletIcon />}>
+              Left icon
+            </Link>
+            <Link href="#" variant="brand" size={size} rightIcon={<ArrowUpRightIcon />}>
+              Right icon
+            </Link>
+            <Link href="#" variant="primary" size={size} disabled>
+              Disabled
+            </Link>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -4991,6 +5021,7 @@ function App() {
     { id: "icons", label: "Icons" },
     { id: "infobox", label: "InfoBox" },
     { id: "inlineedit", label: "Inline Edit" },
+    { id: "link", label: "Link" },
     { id: "loader", label: "Loader" },
     { id: "logo", label: "Logo" },
     { id: "stepper", label: "Stepper" },
@@ -5151,6 +5182,9 @@ function App() {
 
             {/* Badge */}
             <BadgeDemo />
+
+            {/* Link */}
+            <LinkDemo />
 
             {/* Icon Button */}
             <IconButtonDemo />

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ArrowUpRightIcon } from "../Icons/ArrowUpRightIcon";
+import { WalletIcon } from "../Icons/WalletIcon";
+import { Link } from "./Link";
+
+const meta = {
+  title: "Components/Link",
+  component: Link,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16800-10890",
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    href: "#",
+    children: "CTA",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "brand"],
+    },
+    size: {
+      control: "select",
+      options: ["16", "14"],
+    },
+    disabled: { control: "boolean" },
+  },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    variant: "primary",
+  },
+};
+
+export const Brand: Story = {
+  args: {
+    variant: "brand",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "14",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const LeftIcon: Story = {
+  args: {
+    leftIcon: <WalletIcon />,
+  },
+};
+
+export const RightIcon: Story = {
+  args: {
+    rightIcon: <ArrowUpRightIcon />,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {(["16", "14"] as const).map((size) => (
+        <div key={size} className="flex flex-col gap-3">
+          <span className="typography-description-12px-semibold text-content-tertiary">
+            {size}px
+          </span>
+          <div className="flex flex-wrap items-center gap-6">
+            <Link href="#" variant="primary" size={size}>
+              Primary
+            </Link>
+            <Link href="#" variant="brand" size={size}>
+              Brand
+            </Link>
+            <Link href="#" variant="primary" size={size} rightIcon={<ArrowUpRightIcon />}>
+              With icon
+            </Link>
+            <Link href="#" variant="primary" size={size} disabled>
+              Disabled
+            </Link>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -70,6 +70,24 @@ export const RightIcon: Story = {
   },
 };
 
+export const AsChildWithIcon: Story = {
+  name: "asChild (composed) with icon",
+  args: { children: undefined },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`asChild` composes onto a router link (or plain `<a>`) while still rendering `leftIcon` / `rightIcon` around the label.",
+      },
+    },
+  },
+  render: () => (
+    <Link asChild variant="brand" rightIcon={<ArrowUpRightIcon />}>
+      <a href="/plans">See our plans</a>
+    </Link>
+  ),
+};
+
 export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-col gap-6">

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -28,6 +28,29 @@ describe("Link", () => {
       expect(screen.getByRole("button", { name: /Action/i })).toBeInTheDocument();
     });
 
+    it("renders icons around the slotted child when asChild is true", () => {
+      render(
+        <Link asChild leftIcon={<svg data-testid="left" />} rightIcon={<svg data-testid="right" />}>
+          <a href="/pricing">Pricing</a>
+        </Link>,
+      );
+      const link = screen.getByRole("link", { name: /Pricing/i });
+      expect(link).toContainElement(screen.getByTestId("left"));
+      expect(link).toContainElement(screen.getByTestId("right"));
+    });
+
+    it("strips the child href for a disabled asChild link", () => {
+      render(
+        <Link asChild disabled>
+          <a href="/pricing">Pricing</a>
+        </Link>,
+      );
+      const link = screen.getByText("Pricing").closest("a");
+      expect(link).not.toHaveAttribute("href");
+      expect(link).toHaveAttribute("aria-disabled", "true");
+      expect(link).toHaveAttribute("tabindex", "-1");
+    });
+
     it("removes href and marks aria-disabled when disabled", () => {
       render(
         <Link href="/pricing" disabled>

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Link } from "./Link";
+
+describe("Link", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      render(
+        <Link href="#" className="custom">
+          Label
+        </Link>,
+      );
+      expect(screen.getByRole("link", { name: /Label/i })).toHaveClass("custom");
+    });
+
+    it("renders the provided href", () => {
+      render(<Link href="/pricing">Pricing</Link>);
+      expect(screen.getByRole("link", { name: /Pricing/i })).toHaveAttribute("href", "/pricing");
+    });
+
+    it("renders as the child element when asChild is true", () => {
+      render(
+        <Link asChild>
+          <button type="button">Action</button>
+        </Link>,
+      );
+      expect(screen.getByRole("button", { name: /Action/i })).toBeInTheDocument();
+    });
+
+    it("removes href and marks aria-disabled when disabled", () => {
+      render(
+        <Link href="/pricing" disabled>
+          Pricing
+        </Link>,
+      );
+      const link = screen.getByText("Pricing").closest("a");
+      expect(link).not.toHaveAttribute("href");
+      expect(link).toHaveAttribute("aria-disabled", "true");
+      expect(link).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("hides decorative icons from assistive tech", () => {
+      render(
+        <Link href="#" rightIcon={<svg data-testid="icon" />}>
+          Wallet
+        </Link>,
+      );
+      expect(screen.getByTestId("icon").parentElement).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(<Link href="/pricing">Pricing</Link>);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations when disabled", async () => {
+      const { container } = render(
+        <Link href="/pricing" disabled>
+          Pricing
+        </Link>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,4 @@
-import { Slot } from "@radix-ui/react-slot";
+import { Slot, Slottable } from "@radix-ui/react-slot";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 
@@ -61,6 +61,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       asChild = false,
       children,
       href,
+      onClick,
       ...props
     },
     ref,
@@ -74,10 +75,34 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
     const disabledProps = disabled ? { "aria-disabled": true, tabIndex: -1 } : {};
 
+    // Radix Slot lets the child's own props win when merging, so a disabled
+    // `asChild` link would keep the child's navigable href. Strip it from the
+    // child (anchors only) and block default navigation to honor `disabled`.
+    const slotChild =
+      disabled && React.isValidElement<{ href?: string }>(children) && children.type === "a"
+        ? React.cloneElement(children, { href: undefined })
+        : children;
+
+    const handleClick = disabled
+      ? (event: React.MouseEvent<HTMLAnchorElement>) => event.preventDefault()
+      : onClick;
+
+    const leftIconNode = leftIcon && (
+      <span className={ICON_WRAPPER} aria-hidden="true">
+        {leftIcon}
+      </span>
+    );
+    const rightIconNode = rightIcon && (
+      <span className={ICON_WRAPPER} aria-hidden="true">
+        {rightIcon}
+      </span>
+    );
+
     return (
       <Comp
         ref={ref}
         href={disabled ? undefined : href}
+        onClick={handleClick}
         className={cn(
           "inline-flex items-center gap-2 rounded-2xs transition-colors",
           "focus-visible:shadow-focus-ring focus-visible:outline-none",
@@ -91,23 +116,13 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         {...disabledProps}
         {...props}
       >
+        {leftIconNode}
         {asChild ? (
-          children
+          <Slottable>{slotChild}</Slottable>
         ) : (
-          <>
-            {leftIcon && (
-              <span className={ICON_WRAPPER} aria-hidden="true">
-                {leftIcon}
-              </span>
-            )}
-            <span className={textClasses}>{children}</span>
-            {rightIcon && (
-              <span className={ICON_WRAPPER} aria-hidden="true">
-                {rightIcon}
-              </span>
-            )}
-          </>
+          <span className={textClasses}>{children}</span>
         )}
+        {rightIconNode}
       </Comp>
     );
   },

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,0 +1,116 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Visual style variant of the link. */
+export type LinkVariant = "primary" | "brand";
+
+/** Text size of the link in pixels. */
+export type LinkSize = "16" | "14";
+
+export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Visual style variant of the link. @default "primary" */
+  variant?: LinkVariant;
+  /** Text size of the link in pixels. @default "16" */
+  size?: LinkSize;
+  /** When `true`, greys the link out and blocks interaction. @default false */
+  disabled?: boolean;
+  /** Icon element displayed before the label. */
+  leftIcon?: React.ReactNode;
+  /** Icon element displayed after the label. */
+  rightIcon?: React.ReactNode;
+  /** Merge props onto a child element instead of rendering an `<a>`. @default false */
+  asChild?: boolean;
+}
+
+const SIZE_CLASSES: Record<LinkSize, string> = {
+  "16": "typography-body-default-16px-semibold",
+  "14": "typography-body-small-14px-semibold",
+};
+
+const VARIANT_CLASSES: Record<LinkVariant, string> = {
+  primary: "text-buttons-link-primary-default hover:text-buttons-link-primary-hover",
+  brand: "text-buttons-link-brand-default hover:text-buttons-link-brand-hover",
+};
+
+const ICON_WRAPPER = "flex shrink-0 items-center justify-center [&>svg]:size-4";
+
+/**
+ * An inline text link for navigating to a related page or section without
+ * using a button. Use `primary` for standard navigation and `brand` for the
+ * Fanvue green accent on calls to action within content.
+ *
+ * Renders an underlined `<a>` by default. Pass `asChild` to compose with a
+ * router link (e.g. Next.js `Link`). When rendering without a visible label,
+ * provide an `aria-label`.
+ *
+ * @example
+ * ```tsx
+ * <Link href="/pricing" variant="brand">See our plans</Link>
+ * ```
+ */
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  (
+    {
+      className,
+      variant = "primary",
+      size = "16",
+      disabled = false,
+      leftIcon,
+      rightIcon,
+      asChild = false,
+      children,
+      href,
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : "a";
+
+    const textClasses = cn(
+      SIZE_CLASSES[size],
+      "underline decoration-from-font decoration-solid [text-underline-position:from-font]",
+    );
+
+    const disabledProps = disabled ? { "aria-disabled": true, tabIndex: -1 } : {};
+
+    return (
+      <Comp
+        ref={ref}
+        href={disabled ? undefined : href}
+        className={cn(
+          "inline-flex items-center gap-2 rounded-2xs transition-colors",
+          "focus-visible:shadow-focus-ring focus-visible:outline-none",
+          disabled
+            ? "pointer-events-none cursor-not-allowed text-content-disabled"
+            : VARIANT_CLASSES[variant],
+          asChild && textClasses,
+          className,
+        )}
+        {...(asChild ? {} : { "data-testid": "link" })}
+        {...disabledProps}
+        {...props}
+      >
+        {asChild ? (
+          children
+        ) : (
+          <>
+            {leftIcon && (
+              <span className={ICON_WRAPPER} aria-hidden="true">
+                {leftIcon}
+              </span>
+            )}
+            <span className={textClasses}>{children}</span>
+            {rightIcon && (
+              <span className={ICON_WRAPPER} aria-hidden="true">
+                {rightIcon}
+              </span>
+            )}
+          </>
+        )}
+      </Comp>
+    );
+  },
+);
+
+Link.displayName = "Link";

--- a/src/index.ts
+++ b/src/index.ts
@@ -546,6 +546,8 @@ export type {
   InlineEditSize,
 } from "./components/InlineEdit/InlineEdit";
 export { InlineEdit } from "./components/InlineEdit/InlineEdit";
+export type { LinkProps, LinkSize, LinkVariant } from "./components/Link/Link";
+export { Link } from "./components/Link/Link";
 export type { LoaderProps } from "./components/Loader/Loader";
 export { Loader } from "./components/Loader/Loader";
 export type {


### PR DESCRIPTION
## Summary

Adds the **V2 Link** component (`ENG-11789`) — a new inline text link with no prior code equivalent in `@fanvue/ui`.

- `variant`: `primary` (standard navigation) and `brand` (Fanvue green accent for CTAs in content)
- `size`: `16` (Body 1) and `14` (Body 2), semibold + underline per the V2 spec
- `disabled` state (greyed, `pointer-events-none`, `aria-disabled`, href dropped, non-focusable)
- Optional `leftIcon` / `rightIcon` slots (16px)
- Renders an underlined `<a>` by default; `asChild` composes with router links (Radix `Slot`)
- Uses V2 tokens: `buttons-link-primary/brand-default|hover`, `content-disabled`, `typography-body-*-semibold`
- Exports component + `LinkProps` / `LinkVariant` / `LinkSize` in `src/index.ts`, plus a demo in `App.tsx`

## Acceptance criteria

- [x] 1:1 with the V2 Figma design ([V2 Link](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16800-10890))
- [x] Ship with stories + tests per library conventions

## Quality gates

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 3867 passed (incl. Storybook browser tests)
- [x] `pnpm build` — success

## Visual evidence

Captured via Playwright against Storybook. Hosted on the `screenshots-link-v2` branch (kept out of this PR's diff, per convention).

**All variants (16px + 14px):**

![all variants](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/all-variants.png)

**Primary / Brand / Small (14px) / Disabled:**

![primary](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/primary.png)
![brand](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/brand.png)
![small](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/small.png)
![disabled](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/disabled.png)

**Icons (left / right):**

![left icon](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/left-icon.png)
![right icon](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/right-icon.png)

**Interactive states — hover / focus:**

![hover](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/hover.png)
![focus](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-link-v2/focus.png)
