### PR TITLE
feat: migrate Badge & Pill to V2 semantic variants (ENG-10640)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2102,6 +2102,18 @@ function BadgeDemo() {
           Right icon
         </Badge>
       </div>
+      <div className="flex flex-wrap gap-4">
+        <Badge variant="successColour">Success</Badge>
+        <Badge variant="warningColour">Warning</Badge>
+        <Badge variant="errorColour">Error</Badge>
+        <Badge variant="infoColour">Info</Badge>
+        <Badge variant="aiGenerated" leftDot={false} leftIcon={<AIIcon className="size-3" />}>
+          AI Generated
+        </Badge>
+      </div>
+      <div className="flex flex-wrap gap-4 rounded-xs bg-surface-primary-inverted p-4">
+        <Badge variant="negative">Negative</Badge>
+      </div>
     </div>
   );
 }
@@ -2184,6 +2196,11 @@ function PillDemo() {
         <Pill variant="beta">Beta</Pill>
         <Pill variant="error">Error</Pill>
         <Pill variant="red">Red</Pill>
+      </div>
+
+      <div className="flex flex-wrap gap-4 rounded-xs bg-surface-primary-inverted p-4">
+        <Pill variant="contrast">Contrast</Pill>
+        <Pill variant="negative">Negative</Pill>
       </div>
 
       <div className="flex flex-wrap gap-4">

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { AIIcon } from "../Icons/AIIcon";
 import { ArrowUpRightIcon } from "../Icons/ArrowUpRightIcon";
 import { CheckCircleIcon } from "../Icons/CheckCircleIcon";
 import { Badge } from "./Badge";
@@ -25,6 +26,12 @@ const meta = {
         "error",
         "special",
         "info",
+        "successColour",
+        "warningColour",
+        "errorColour",
+        "infoColour",
+        "aiGenerated",
+        "negative",
         "online",
         "brand",
         "pink",
@@ -86,6 +93,57 @@ export const Info: Story = {
     variant: "info",
     children: "Info",
   },
+};
+
+export const SuccessColour: Story = {
+  args: {
+    variant: "successColour",
+    children: "Success",
+  },
+};
+
+export const WarningColour: Story = {
+  args: {
+    variant: "warningColour",
+    children: "Warning",
+  },
+};
+
+export const ErrorColour: Story = {
+  args: {
+    variant: "errorColour",
+    children: "Error",
+  },
+};
+
+export const InfoColour: Story = {
+  args: {
+    variant: "infoColour",
+    children: "Info",
+  },
+};
+
+export const AIGenerated: Story = {
+  args: {
+    variant: "aiGenerated",
+    leftDot: false,
+    leftIcon: <AIIcon className="size-3" />,
+    children: "AI Generated",
+  },
+};
+
+export const Negative: Story = {
+  args: {
+    variant: "negative",
+    children: "Negative",
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-xs bg-surface-primary-inverted p-4">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export const Online: Story = {

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -59,6 +59,23 @@ describe("Badge", () => {
     });
   });
 
+  describe("V2 variants", () => {
+    it("applies a filled surface for colour-emphasis variants", () => {
+      render(<Badge variant="successColour">Active</Badge>);
+      expect(screen.getByTestId("badge")).toHaveClass("bg-success-surface");
+    });
+
+    it("inverts the text colour for the negative variant", () => {
+      render(<Badge variant="negative">On dark</Badge>);
+      expect(screen.getByTestId("badge")).toHaveClass("text-content-primary-inverted");
+    });
+
+    it("uses the always-white surface for the aiGenerated variant", () => {
+      render(<Badge variant="aiGenerated">AI Generated</Badge>);
+      expect(screen.getByTestId("badge")).toHaveClass("bg-buttons-always-white-default");
+    });
+  });
+
   describe("accessibility", () => {
     it("has no accessibility violations", async () => {
       const { container } = render(<Badge>Accessible Badge</Badge>);

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -11,6 +11,12 @@ const badgeVariants = {
     error: "bg-neutral-alphas-50 text-content-primary",
     special: "bg-neutral-alphas-50 text-content-primary",
     info: "bg-neutral-alphas-50 text-content-primary",
+    successColour: "bg-success-surface text-content-primary",
+    warningColour: "bg-warning-surface text-content-primary",
+    errorColour: "bg-error-surface text-content-primary",
+    infoColour: "bg-info-surface text-content-primary",
+    aiGenerated: "bg-buttons-always-white-default text-content-always-black",
+    negative: "bg-buttons-secondary-negative-default text-content-primary-inverted",
     online: "bg-background-primary text-brand-primary-default",
     brand: "bg-brand-primary-default text-content-always-black",
     pink: "bg-brand-secondary-default text-content-always-black",
@@ -25,6 +31,12 @@ const badgeVariants = {
     error: "bg-error-content",
     special: "bg-special-default",
     info: "bg-info-content",
+    successColour: "bg-success-content",
+    warningColour: "bg-warning-content",
+    errorColour: "bg-error-content",
+    infoColour: "bg-info-content",
+    aiGenerated: "bg-content-always-black",
+    negative: "bg-icons-primary-inverted",
     online: "bg-brand-primary-default",
     brand: "bg-content-always-black",
     pink: "bg-content-always-black",
@@ -42,6 +54,12 @@ export type BadgeVariant =
   | "error"
   | "special"
   | "info"
+  | "successColour"
+  | "warningColour"
+  | "errorColour"
+  | "infoColour"
+  | "aiGenerated"
+  | "negative"
   | "online"
   | "brand"
   | "pink"

--- a/src/components/Pill/Pill.stories.tsx
+++ b/src/components/Pill/Pill.stories.tsx
@@ -24,6 +24,8 @@ const meta = {
         "gold",
         "pinkLight",
         "base",
+        "contrast",
+        "negative",
         "brand",
         "brandLight",
         "beta",
@@ -77,6 +79,34 @@ export const Base: Story = {
     variant: "base",
     children: "Example",
   },
+};
+
+export const Contrast: Story = {
+  args: {
+    variant: "contrast",
+    children: "Contrast",
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-xs bg-surface-primary-inverted p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Negative: Story = {
+  args: {
+    variant: "negative",
+    children: "Negative",
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-xs bg-surface-primary-inverted p-4">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export const Brand: Story = {

--- a/src/components/Pill/Pill.test.tsx
+++ b/src/components/Pill/Pill.test.tsx
@@ -23,6 +23,20 @@ describe("Pill", () => {
     });
   });
 
+  describe("V2 variants", () => {
+    it("applies the dark-surface treatment for the contrast variant", () => {
+      render(<Pill variant="contrast">Contrast</Pill>);
+      expect(screen.getByTestId("pill")).toHaveClass("bg-buttons-primary-default");
+    });
+
+    it("applies the inverted treatment for the negative variant", () => {
+      render(<Pill variant="negative">Negative</Pill>);
+      const pill = screen.getByTestId("pill");
+      expect(pill).toHaveClass("bg-buttons-secondary-negative-default");
+      expect(pill).toHaveClass("text-content-primary-inverted");
+    });
+  });
+
   describe("accessibility", () => {
     it("has no accessibility violations", async () => {
       const { container } = render(<Pill>Accessible Pill</Pill>);

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -10,6 +10,8 @@ const pillVariants = {
     gold: "bg-warning-surface text-warning-content",
     pinkLight: "bg-brand-secondary-muted text-content-primary",
     base: "bg-surface-primary-inverted text-content-primary-inverted",
+    contrast: "bg-buttons-primary-default text-content-primary-inverted",
+    negative: "bg-buttons-secondary-negative-default text-content-primary-inverted",
     brand: "bg-brand-primary-default text-content-always-black",
     brandLight: "bg-brand-primary-muted text-content-primary",
     beta: "bg-brand-secondary-default text-content-always-black",
@@ -26,6 +28,8 @@ export type PillVariant =
   | "gold"
   | "pinkLight"
   | "base"
+  | "contrast"
+  | "negative"
   | "brand"
   | "brandLight"
   | "beta"


### PR DESCRIPTION
## Summary

Migrates **Badge** and **Pill** to their V2 Figma designs, additively. All existing public variants are preserved (no breaking changes to the exported API) — this run only fills the documented V1→V2 gaps.

- **Badge**: the semantic states previously all rendered the same neutral chrome (only the dot colour differed). Added the distinct filled colour-emphasis treatments plus the two missing V2 types:
  - `successColour`, `warningColour`, `errorColour`, `infoColour` — tinted status surfaces with a matching pip
  - `aiGenerated` — always-white surface for AI-generated content (pair with `AIIcon`)
  - `negative` — inverted treatment for dark / brand surfaces
- **Pill**: added the explicit dark-surface variants that were missing (`base` was the closest approximation):
  - `contrast` — solid dark surface
  - `negative` — translucent inverted surface for dark backgrounds

Stories, `App.tsx` demos, and targeted unit tests were updated for the new variants; the `BadgeVariant` / `PillVariant` unions are already re-exported from `src/index.ts`.

Linear: [ENG-10640](https://linear.app/fanvue/issue/ENG-10640/migrate-badge-and-pill-to-v2)
Figma: [V2 Badges](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18028-289) · [V2 Pills](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17944-3562)

## Acceptance criteria

- [x] 1:1 with the V2 Figma design (all variants/states) — documented gap variants added for Badge & Pill
- [x] No breaking changes to public APIs — additive variant unions only

## Quality gates

- [x] `pnpm lint` (scoped biome check on changed files clean)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 3881 passed
- [x] `pnpm build`

## Screenshots

Hosted on the `screenshots-badge-pill-v2` branch (not committed to this PR diff).

### Badge — colour-emphasis variants

| Success (Colour) | Warning (Colour) | Error (Colour) | Info (Colour) |
| --- | --- | --- | --- |
| ![Badge success colour](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/badge-success-colour.png) | ![Badge warning colour](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/badge-warning-colour.png) | ![Badge error colour](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/badge-error-colour.png) | ![Badge info colour](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/badge-info-colour.png) |

### Badge — AI Generated & Negative

![Badge AI Generated](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/badge-ai-generated.png)

![Badge Negative](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/badge-negative.png)

### Pill — Contrast & Negative

![Pill Contrast](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/pill-contrast.png)

![Pill Negative](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-badge-pill-v2/pill-negative.png)

Made with [Cursor](https://cursor.com)