### PR TITLE
feat(Radio): add trailing layout and avatar slot (ENG-10634)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2259,6 +2259,37 @@ function RadioDemo() {
         <Radio label="Option 2" value="y" />
         <Radio label="Option 3" value="z" />
       </RadioGroup>
+
+      <RadioGroup defaultValue="jane" aria-label="People" className="flex w-80 flex-col gap-2">
+        <Radio
+          layout="trailing"
+          label="Jane Doe"
+          helperText="@jane_doe"
+          value="jane"
+          avatar={
+            <Avatar
+              size={32}
+              src="https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?w=128&h=128&fit=crop"
+              alt="Jane Doe"
+              fallback="JD"
+              onlineIndicator
+            />
+          }
+        />
+        <Radio
+          layout="trailing"
+          label="Sam Rivers"
+          helperText="@sam_rivers"
+          value="sam"
+          avatar={<Avatar size={32} fallback="SR" />}
+        />
+        <Radio
+          label="Leading with avatar"
+          helperText="Radio placed before the avatar"
+          value="leading-avatar"
+          avatar={<Avatar size={32} fallback="LA" />}
+        />
+      </RadioGroup>
     </div>
   );
 }

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
+import { Avatar } from "../Avatar/Avatar";
 import { RadioGroup } from "../RadioGroup/RadioGroup";
 import { Radio } from "./Radio";
+
+const avatarSrc =
+  "https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?w=128&h=128&fit=crop";
 
 const meta = {
   title: "Components/Radio",
@@ -10,7 +14,7 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=9291-9370&m=dev",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17915-63462",
     },
   },
   tags: ["autodocs"],
@@ -18,6 +22,10 @@ const meta = {
     size: {
       control: "select",
       options: ["default", "small"],
+    },
+    layout: {
+      control: "radio",
+      options: ["leading", "trailing"],
     },
     disabled: {
       control: "boolean",
@@ -30,7 +38,7 @@ const meta = {
     },
   },
   render: (args) => (
-    <RadioGroup>
+    <RadioGroup className="w-64">
       <Radio {...args} />
     </RadioGroup>
   ),
@@ -111,4 +119,85 @@ export const WithHelperText: Story = {
     helperText: "This is helpful descriptive text",
     value: "helper",
   },
+};
+
+export const Trailing: Story = {
+  args: {
+    layout: "trailing",
+    label: "Radio Title",
+    helperText: "Helper",
+    value: "trailing",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`layout="trailing"` pushes the radio button to the far end of the row — ideal for list rows where the label is the primary element.',
+      },
+    },
+  },
+};
+
+export const WithAvatar: Story = {
+  args: {
+    label: "Jane Doe",
+    helperText: "@jane_doe",
+    value: "jane",
+    avatar: <Avatar size={32} src={avatarSrc} alt="Jane Doe" fallback="JD" onlineIndicator />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Enable an avatar for options that represent a person or account.",
+      },
+    },
+  },
+};
+
+export const TrailingWithAvatar: Story = {
+  args: {
+    layout: "trailing",
+    label: "Jane Doe",
+    helperText: "@jane_doe",
+    value: "jane",
+    avatar: <Avatar size={32} src={avatarSrc} alt="Jane Doe" fallback="JD" onlineIndicator />,
+  },
+};
+
+export const ListRows: Story = {
+  name: "List rows (trailing + avatar)",
+  args: { value: "unused" },
+  parameters: {
+    docs: {
+      description: {
+        story: "Trailing layout with avatars, as used for selectable list rows.",
+      },
+    },
+  },
+  render: () => (
+    <RadioGroup defaultValue="jane" aria-label="People" className="flex w-80 flex-col gap-2">
+      <Radio
+        layout="trailing"
+        label="Jane Doe"
+        helperText="@jane_doe"
+        value="jane"
+        avatar={<Avatar size={32} src={avatarSrc} alt="Jane Doe" fallback="JD" onlineIndicator />}
+      />
+      <Radio
+        layout="trailing"
+        label="Sam Rivers"
+        helperText="@sam_rivers"
+        value="sam"
+        avatar={<Avatar size={32} fallback="SR" />}
+      />
+      <Radio
+        layout="trailing"
+        label="Alex Kim"
+        helperText="@alex_kim"
+        value="alex"
+        disabled
+        avatar={<Avatar size={32} fallback="AK" />}
+      />
+    </RadioGroup>
+  ),
 };

--- a/src/components/Radio/Radio.test.tsx
+++ b/src/components/Radio/Radio.test.tsx
@@ -154,11 +154,49 @@ describe("Radio", () => {
     });
   });
 
+  describe("layout and avatar", () => {
+    it("keeps the label associated with the radio in trailing layout", () => {
+      render(
+        <RadioGroup>
+          <Radio id="trailing-radio" layout="trailing" label="Trailing" value="test" />
+        </RadioGroup>,
+      );
+      const label = screen.getByText("Trailing");
+      expect(label).toHaveAttribute("for", "trailing-radio");
+      expect(screen.getByRole("radio")).toHaveAttribute("id", "trailing-radio");
+    });
+
+    it("renders the avatar slot content", () => {
+      render(
+        <RadioGroup>
+          <Radio label="Jane Doe" value="jane" avatar={<span data-testid="avatar-slot" />} />
+        </RadioGroup>,
+      );
+      expect(screen.getByTestId("avatar-slot")).toBeInTheDocument();
+    });
+  });
+
   describe("accessibility", () => {
     it("has no accessibility violations", async () => {
       const { container } = render(
         <RadioGroup>
           <Radio label="Accessible Radio" value="test" />
+        </RadioGroup>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations in trailing layout with an avatar", async () => {
+      const { container } = render(
+        <RadioGroup>
+          <Radio
+            layout="trailing"
+            label="Jane Doe"
+            helperText="@jane_doe"
+            value="jane"
+            avatar={<span aria-hidden="true" />}
+          />
         </RadioGroup>,
       );
       const results = await axe(container);

--- a/src/components/Radio/Radio.test.tsx
+++ b/src/components/Radio/Radio.test.tsx
@@ -174,6 +174,20 @@ describe("Radio", () => {
       );
       expect(screen.getByTestId("avatar-slot")).toBeInTheDocument();
     });
+
+    it("uses intrinsic width for leading and full width for trailing", () => {
+      const { container } = render(
+        <RadioGroup>
+          <Radio className="leading-row" label="Lead" value="lead" />
+          <Radio className="trailing-row" layout="trailing" label="Trail" value="trail" />
+        </RadioGroup>,
+      );
+      const leading = container.querySelector(".leading-row");
+      const trailing = container.querySelector(".trailing-row");
+      expect(leading).toHaveClass("inline-flex");
+      expect(leading).not.toHaveClass("w-full");
+      expect(trailing).toHaveClass("w-full");
+    });
   });
 
   describe("accessibility", () => {

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -58,7 +58,7 @@ export const Radio = React.forwardRef<
         aria-describedby={helperText ? helperTextId : undefined}
         className={cn(
           "relative h-4 w-4 shrink-0 cursor-pointer appearance-none rounded-full border border-content-primary bg-transparent transition-colors hover:bg-brand-primary-muted focus-visible:shadow-focus-ring focus-visible:outline-none not-disabled:active:bg-brand-primary-muted disabled:cursor-not-allowed disabled:border-neutral-alphas-600 disabled:bg-transparent data-[state=checked]:border-content-primary data-[state=checked]:bg-transparent",
-          hasContent && (avatar ? "mt-2" : "mt-1"),
+          hasContent && (avatar ? "mt-2" : size === "small" ? "mt-px" : "mt-1"),
         )}
         {...props}
       >

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -49,6 +49,8 @@ export const Radio = React.forwardRef<
     const inputId = id || generatedId;
     const helperTextId = `${inputId}-helper`;
     const hasContent = Boolean(label || helperText || avatar);
+    // Avatar + helper text reads better centered as a group; otherwise align to the first line.
+    const centerWithAvatar = Boolean(avatar && helperText);
 
     const button = (
       <RadioGroupPrimitive.Item
@@ -58,7 +60,9 @@ export const Radio = React.forwardRef<
         aria-describedby={helperText ? helperTextId : undefined}
         className={cn(
           "relative h-4 w-4 shrink-0 cursor-pointer appearance-none rounded-full border border-content-primary bg-transparent transition-colors hover:bg-brand-primary-muted focus-visible:shadow-focus-ring focus-visible:outline-none not-disabled:active:bg-brand-primary-muted disabled:cursor-not-allowed disabled:border-neutral-alphas-600 disabled:bg-transparent data-[state=checked]:border-content-primary data-[state=checked]:bg-transparent",
-          hasContent && (avatar ? "mt-2" : size === "small" ? "mt-px" : "mt-1"),
+          hasContent &&
+            !centerWithAvatar &&
+            (avatar ? "mt-2" : size === "small" ? "mt-px" : "mt-1"),
         )}
         {...props}
       >
@@ -69,14 +73,19 @@ export const Radio = React.forwardRef<
     );
 
     const content = hasContent && (
-      <div className="flex min-w-0 flex-1 items-start gap-3">
+      <div
+        className={cn(
+          "flex min-w-0 flex-1 gap-3",
+          centerWithAvatar ? "items-center" : "items-start",
+        )}
+      >
         {avatar && (
           <span className="shrink-0 group-has-disabled:opacity-60" aria-hidden="true">
             {avatar}
           </span>
         )}
         {(label || helperText) && (
-          <div className={cn("flex flex-col gap-0.5", avatar && "pt-1")}>
+          <div className={cn("flex flex-col gap-0.5", avatar && !centerWithAvatar && "pt-1")}>
             {label && (
               <label
                 htmlFor={inputId}
@@ -109,7 +118,15 @@ export const Radio = React.forwardRef<
     );
 
     return (
-      <div className={cn("group flex w-full items-start gap-3", className)}>
+      <div
+        className={cn(
+          "group gap-3",
+          // Full width only for trailing (button to far end); leading keeps intrinsic width for inline groups.
+          layout === "trailing" ? "flex w-full" : "inline-flex",
+          centerWithAvatar ? "items-center" : "items-start",
+          className,
+        )}
+      >
         {layout === "leading" && button}
         {content}
         {layout === "trailing" && button}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -2,6 +2,9 @@ import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 
+/** Placement of the radio button relative to its label. */
+export type RadioLayout = "leading" | "trailing";
+
 export interface RadioProps
   extends Omit<React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>, "asChild"> {
   /** Size variant controlling label and helper text typography. @default "default" */
@@ -10,30 +13,44 @@ export interface RadioProps
   label?: string;
   /** Descriptive text displayed below the label. */
   helperText?: string;
+  /**
+   * Placement of the radio button. `"leading"` renders it before the label;
+   * `"trailing"` pushes it to the far end of the row (for list rows). @default "leading"
+   */
+  layout?: RadioLayout;
+  /**
+   * Optional avatar shown alongside the label, for options that represent a
+   * person or account. Pass an {@link Avatar} sized to `32`.
+   */
+  avatar?: React.ReactNode;
 }
 
 /**
- * A single radio option within a {@link RadioGroup}. Includes an optional label
- * and helper text.
+ * A single radio option within a {@link RadioGroup}. Supports leading or
+ * trailing button placement, an optional avatar, a label, and helper text.
  *
  * @example
  * ```tsx
  * <RadioGroup value={value} onValueChange={setValue}>
  *   <Radio value="a" label="Option A" />
- *   <Radio value="b" label="Option B" />
+ *   <Radio value="b" label="Option B" layout="trailing" />
  * </RadioGroup>
  * ```
  */
 export const Radio = React.forwardRef<
   React.ComponentRef<typeof RadioGroupPrimitive.Item>,
   RadioProps
->(({ className, size = "default", label, helperText, id, ...props }, ref) => {
-  const generatedId = React.useId();
-  const inputId = id || generatedId;
-  const helperTextId = `${inputId}-helper`;
+>(
+  (
+    { className, size = "default", label, helperText, layout = "leading", avatar, id, ...props },
+    ref,
+  ) => {
+    const generatedId = React.useId();
+    const inputId = id || generatedId;
+    const helperTextId = `${inputId}-helper`;
+    const hasContent = Boolean(label || helperText || avatar);
 
-  return (
-    <div className={cn("group inline-flex items-center gap-2", className)}>
+    const button = (
       <RadioGroupPrimitive.Item
         ref={ref}
         id={inputId}
@@ -41,7 +58,7 @@ export const Radio = React.forwardRef<
         aria-describedby={helperText ? helperTextId : undefined}
         className={cn(
           "relative h-4 w-4 shrink-0 cursor-pointer appearance-none rounded-full border border-content-primary bg-transparent transition-colors hover:bg-brand-primary-muted focus-visible:shadow-focus-ring focus-visible:outline-none not-disabled:active:bg-brand-primary-muted disabled:cursor-not-allowed disabled:border-neutral-alphas-600 disabled:bg-transparent data-[state=checked]:border-content-primary data-[state=checked]:bg-transparent",
-          helperText && "mt-1 self-start",
+          hasContent && (avatar ? "mt-2" : "mt-1"),
         )}
         {...props}
       >
@@ -49,38 +66,56 @@ export const Radio = React.forwardRef<
           <span className="size-2 rounded-full bg-content-primary group-has-disabled:bg-neutral-alphas-600" />
         </RadioGroupPrimitive.Indicator>
       </RadioGroupPrimitive.Item>
-      {(label || helperText) && (
-        <div className="flex flex-col gap-0.5">
-          {label && (
-            <label
-              htmlFor={inputId}
-              className={cn(
-                "cursor-pointer select-none text-content-primary group-has-disabled:cursor-not-allowed group-has-disabled:text-content-tertiary",
-                size === "small"
-                  ? "typography-body-small-14px-semibold"
-                  : "typography-body-default-16px-semibold",
-              )}
-            >
-              {label}
-            </label>
-          )}
-          {helperText && (
-            <span
-              id={helperTextId}
-              className={cn(
-                "text-content-secondary group-has-disabled:cursor-not-allowed group-has-disabled:text-content-tertiary",
-                size === "small"
-                  ? "typography-body-small-14px-semibold"
-                  : "typography-description-12px-regular",
-              )}
-            >
-              {helperText}
-            </span>
-          )}
-        </div>
-      )}
-    </div>
-  );
-});
+    );
+
+    const content = hasContent && (
+      <div className="flex min-w-0 flex-1 items-start gap-3">
+        {avatar && (
+          <span className="shrink-0 group-has-disabled:opacity-60" aria-hidden="true">
+            {avatar}
+          </span>
+        )}
+        {(label || helperText) && (
+          <div className={cn("flex flex-col gap-0.5", avatar && "pt-1")}>
+            {label && (
+              <label
+                htmlFor={inputId}
+                className={cn(
+                  "cursor-pointer select-none text-content-primary group-has-disabled:cursor-not-allowed group-has-disabled:text-content-tertiary",
+                  size === "small"
+                    ? "typography-body-small-14px-semibold"
+                    : "typography-body-default-16px-semibold",
+                )}
+              >
+                {label}
+              </label>
+            )}
+            {helperText && (
+              <span
+                id={helperTextId}
+                className={cn(
+                  "text-content-secondary group-has-disabled:cursor-not-allowed group-has-disabled:text-content-tertiary",
+                  size === "small"
+                    ? "typography-body-small-14px-semibold"
+                    : "typography-description-12px-regular",
+                )}
+              >
+                {helperText}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    );
+
+    return (
+      <div className={cn("group flex w-full items-start gap-3", className)}>
+        {layout === "leading" && button}
+        {content}
+        {layout === "trailing" && button}
+      </div>
+    );
+  },
+);
 
 Radio.displayName = "Radio";

--- a/src/index.ts
+++ b/src/index.ts
@@ -588,7 +588,7 @@ export type {
   ProgressBarVariant,
 } from "./components/ProgressBar/ProgressBar";
 export { ProgressBar } from "./components/ProgressBar/ProgressBar";
-export type { RadioProps } from "./components/Radio/Radio";
+export type { RadioLayout, RadioProps } from "./components/Radio/Radio";
 export { Radio } from "./components/Radio/Radio";
 export type { RadioGroupProps } from "./components/RadioGroup/RadioGroup";
 export { RadioGroup } from "./components/RadioGroup/RadioGroup";


### PR DESCRIPTION
## Summary

Migrates **Radio** to the V2 Figma design (`node-id=17915-63462`), closing the two documented V1→V2 gaps **additively** (no breaking changes to the public API):

- **Trailing layout** — new `layout="leading" | "trailing"` prop (default `"leading"`). Trailing pushes the radio button to the far end of the row, for selectable list rows.
- **Show Avatar** — new `avatar` slot that renders an `<Avatar>` (or any node) alongside the label, for options that represent a person or account.

Existing props (`size`, `label`, `helperText`, all Radix `RadioGroup.Item` props) are unchanged. `RadioLayout` is exported from `src/index.ts`. Stories, tests, and an `App.tsx` demo were updated.

## Acceptance criteria

- [x] 1:1 with the V2 Figma design (Leading/Trailing + Avatar)
- [x] No breaking changes to public APIs

## Quality gates

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (3889 passed)
- [x] `pnpm build`

## Screenshots

Hosted on the `screenshots-radio-v2` branch (kept out of this PR's diff).

**Leading (default) — unchanged**

![leading default](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/01-leading-default.png)

**Leading with helper text**

![leading helper](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/02-leading-helper.png)

**Small**

![small](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/03-small.png)

**Disabled**

![disabled](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/04-disabled.png)

**Trailing (new)**

![trailing](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/05-trailing.png)

**Leading + avatar (new)**

![leading avatar](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/06-leading-avatar.png)

**Trailing + avatar (new)**

![trailing avatar](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/07-trailing-avatar.png)

**List rows (trailing + avatar, incl. selected & disabled)**

![list rows](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/08-list-rows.png)

**Focus ring (interactive)**

![focus ring](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/09-focus-ring.png)

**Hover on a selected row (interactive)**

![hover selected](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-radio-v2/10-hover-selected.png)

Linear: [ENG-10634](https://linear.app/fanvue/issue/ENG-10634/migrate-radio-to-v2)
