### PR TITLE
fix(components): align V2 inputs, badges, dialogs with CRM reskin Figma spec

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -6,11 +6,11 @@ const badgeVariants = {
   variant: {
     default: "bg-neutral-alphas-50 text-content-primary",
     dark: "bg-neutral-alphas-600 text-content-always-white",
-    success: "bg-neutral-alphas-50 text-content-primary",
-    warning: "bg-neutral-alphas-50 text-content-primary",
-    error: "bg-neutral-alphas-50 text-content-primary",
+    success: "bg-success-surface text-success-content",
+    warning: "bg-warning-surface text-warning-content",
+    error: "bg-error-surface text-error-content",
     special: "bg-neutral-alphas-50 text-content-primary",
-    info: "bg-neutral-alphas-50 text-content-primary",
+    info: "bg-info-surface text-info-content",
     successColour: "bg-success-surface text-content-primary",
     warningColour: "bg-warning-surface text-content-primary",
     errorColour: "bg-error-surface text-content-primary",
@@ -110,7 +110,7 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
         data-testid="badge"
         className={cn(
           // Base styles
-          "typography-description-12px-semibold inline-flex h-5 min-w-0 items-center gap-2 rounded-full px-2",
+          "typography-description-12px-semibold inline-flex h-6 min-w-0 items-center gap-2 rounded-full px-2",
           // Variant styles
           badgeVariants.variant[variant],
           // Interactive

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -115,7 +115,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           onCheckedChange={handleCheckedChange}
           className={cn(
             // Base styles
-            "flex items-center justify-center rounded border-2",
+            "flex items-center justify-center rounded border",
             BOX_SIZE_CLASS[boxSize],
             "transition-[border-color,background-color,color,box-shadow] duration-150",
             // Default state

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -151,7 +151,7 @@ describe("Dialog", () => {
       renderDialog();
       const dialog = screen.getByRole("dialog");
       expect(dialog).toHaveClass("rounded-t-xl");
-      expect(dialog).toHaveClass("sm:rounded-xl");
+      expect(dialog).toHaveClass("sm:rounded-lg");
       expect(dialog).toHaveClass("inset-x-0");
       expect(dialog).toHaveClass("w-full");
       expect(dialog).toHaveClass("border-modal-stroke");
@@ -167,6 +167,17 @@ describe("Dialog", () => {
 
     it("hides the mobile sheet handle when showMobileHandle is false", () => {
       renderDialog({ showMobileHandle: false });
+      expect(document.querySelector(".bg-icons-tertiary")).not.toBeInTheDocument();
+    });
+
+    it("renders as a floating card on mobile when mobilePresentation is card", () => {
+      renderDialog({ mobilePresentation: "card" });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveClass("inset-x-4");
+      expect(dialog).toHaveClass("rounded-xl");
+      expect(dialog).toHaveClass("p-6");
+      expect(dialog).not.toHaveClass("bottom-0");
+      expect(dialog).not.toHaveClass("rounded-t-xl");
       expect(document.querySelector(".bg-icons-tertiary")).not.toBeInTheDocument();
     });
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -83,8 +83,17 @@ export interface DialogContentProps
    * @default true
    */
   portal?: boolean;
-  /** Show the v2 mobile sheet pull handle. @default true */
+  /** Show the v2 mobile sheet pull handle. Only rendered when `mobilePresentation` is `"sheet"`. @default true */
   showMobileHandle?: boolean;
+  /**
+   * How the dialog presents below the `sm` breakpoint.
+   * - `"sheet"` — bottom sheet pinned to the viewport bottom edge (default)
+   * - `"card"` — centered floating card per the v2-modal confirmation spec:
+   *   16px side margins, 24px padding, 32px radius on all corners, no pull handle
+   *
+   * @default "sheet"
+   */
+  mobilePresentation?: "sheet" | "card";
 }
 
 const SIZE_CLASSES: Record<NonNullable<DialogContentProps["size"]>, string> = {
@@ -100,8 +109,9 @@ const SIZE_CLASSES: Record<NonNullable<DialogContentProps["size"]>, string> = {
  * `fixed` positioning still applies; ancestors with `transform` or `overflow` may affect layout.
  *
  * On mobile viewports (<640px), the dialog slides up from the bottom as a sheet
- * with top-only border radius. On larger viewports it renders centered with
- * full border radius.
+ * with top-only border radius by default; pass `mobilePresentation="card"` to
+ * render a centered floating card instead (used for small confirmation dialogs).
+ * On larger viewports it renders centered with full border radius.
  *
  * @example
  * ```tsx
@@ -136,6 +146,7 @@ export const DialogContent = React.forwardRef<
       overlay = true,
       portal = true,
       showMobileHandle = true,
+      mobilePresentation = "sheet",
       style,
       onOpenAutoFocus,
       ...props
@@ -158,21 +169,31 @@ export const DialogContent = React.forwardRef<
           }}
           className={cn(
             "fixed flex flex-col overflow-hidden border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[4px] focus:outline-none",
-            "inset-x-0 bottom-0 max-h-[85vh] w-full rounded-t-xl p-4 pt-3",
             "data-[state=open]:fade-in-0 data-[state=open]:animate-in",
             "data-[state=closed]:fade-out-0 data-[state=closed]:animate-out",
-            "data-[state=open]:slide-in-from-bottom-full",
-            "data-[state=closed]:slide-out-to-bottom-full",
-            "sm:inset-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:w-full sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl sm:p-6",
-            "sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:zoom-in-95",
-            "sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=closed]:zoom-out-95",
+            mobilePresentation === "card"
+              ? // Floating confirmation card (v2-modal): 16px side margins, vertically centered, 32px radius
+                cn(
+                  "inset-x-4 top-1/2 max-h-[85vh] -translate-y-1/2 rounded-xl p-6",
+                  "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+                  "sm:inset-x-auto",
+                )
+              : // Bottom sheet pinned to the viewport bottom edge
+                cn(
+                  "inset-x-0 bottom-0 max-h-[85vh] w-full rounded-t-xl p-4 pt-3",
+                  "data-[state=open]:slide-in-from-bottom-full",
+                  "data-[state=closed]:slide-out-to-bottom-full",
+                  "sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:zoom-in-95",
+                  "sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=closed]:zoom-out-95",
+                ),
+            "sm:inset-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:w-full sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:p-6",
             "duration-200",
             SIZE_CLASSES[size],
             className,
           )}
           {...props}
         >
-          {showMobileHandle && (
+          {showMobileHandle && mobilePresentation === "sheet" && (
             <div
               aria-hidden="true"
               className="mb-3 h-1 w-8 shrink-0 self-center rounded-full bg-icons-tertiary sm:hidden"
@@ -310,7 +331,7 @@ export interface DialogBodyProps extends React.HTMLAttributes<HTMLDivElement> {}
  */
 export const DialogBody = React.forwardRef<HTMLDivElement, DialogBodyProps>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex-1 overflow-y-auto py-4 sm:py-6", className)} {...props} />
+    <div ref={ref} className={cn("flex-1 overflow-y-auto py-4", className)} {...props} />
   ),
 );
 DialogBody.displayName = "DialogBody";

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -26,7 +26,7 @@ const iconButtonVariants = {
 
 const iconSizeVariants = {
   24: "[&>svg]:size-4",
-  32: "[&>svg]:size-5",
+  32: "[&>svg]:size-4",
   40: "[&>svg]:size-6",
   52: "[&>svg]:size-7",
   72: "[&>svg]:size-8",

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -77,7 +77,7 @@ export const Pill = React.forwardRef<HTMLSpanElement, PillProps>(
         data-testid="pill"
         className={cn(
           // Base styles
-          "inline-flex min-w-0 items-center justify-center gap-2 rounded-full px-3 py-1",
+          "inline-flex min-w-0 items-center justify-center gap-2 rounded-full px-2 py-1",
           // Typography
           "typography-description-12px-semibold",
           // Variant styles

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -125,7 +125,7 @@ export const Select = React.forwardRef<
           {label && (
             <label
               htmlFor={triggerId}
-              className="typography-description-12px-semibold px-1 pt-1 pb-2 text-content-primary"
+              className="typography-description-12px-semibold pb-2 text-content-primary"
             >
               {label}
             </label>
@@ -140,12 +140,12 @@ export const Select = React.forwardRef<
               aria-describedby={bottomText ? helperTextId : undefined}
               aria-invalid={error || undefined}
               className={cn(
-                "flex w-full cursor-pointer items-center justify-between rounded-sm border bg-neutral-alphas-50 outline-none motion-safe:transition-colors focus-visible:shadow-focus-ring",
+                "flex w-full cursor-pointer items-center justify-between rounded-sm border bg-inputs-inputs-primary outline-none motion-safe:transition-colors focus-visible:shadow-focus-ring",
                 TRIGGER_HEIGHT[size],
                 TRIGGER_PADDING_X[size],
                 TRIGGER_GAP[size],
                 TRIGGER_TYPOGRAPHY[size],
-                error ? "border-error-content" : "border-transparent",
+                error ? "border-error-content" : "border-border-primary",
                 !disabled &&
                   !error &&
                   "hover:border-neutral-alphas-400 data-[state=open]:border-neutral-alphas-400",
@@ -161,7 +161,7 @@ export const Select = React.forwardRef<
                     {leftIcon}
                   </span>
                 )}
-                <span className="min-w-0 flex-1 truncate text-left text-content-primary [&>[data-placeholder]]:text-content-secondary [&>[data-placeholder]]:opacity-40">
+                <span className="min-w-0 flex-1 truncate text-left text-content-primary [&>[data-placeholder]]:text-content-tertiary">
                   <SelectPrimitive.Value placeholder={placeholder} />
                 </span>
               </div>

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -238,15 +238,15 @@ describe("TextField", () => {
       const inputContainer = container.querySelector('[class*="border"]');
       expect(inputContainer).toBeInTheDocument();
       expect(inputContainer).toHaveClass("border");
-      expect(inputContainer).toHaveClass("border-transparent");
+      expect(inputContainer).toHaveClass("border-border-primary");
     });
 
-    it("renders border-error-content instead of border-transparent when error", () => {
+    it("renders border-error-content instead of border-border-primary when error", () => {
       const { container } = render(<TextField aria-label="Test" error />);
       const inputContainer = container.querySelector('[class*="border-error-content"]');
       expect(inputContainer).toBeInTheDocument();
       expect(inputContainer).toHaveClass("border");
-      expect(inputContainer).not.toHaveClass("border-transparent");
+      expect(inputContainer).not.toHaveClass("border-border-primary");
     });
 
     it("renders focus ring class on input container", () => {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -59,8 +59,8 @@ const ICON_INSET: Record<TextFieldSize, string> = {
 
 function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative overflow-hidden rounded-sm border bg-neutral-alphas-50 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
-    error ? "border-error-content" : "border-transparent",
+    "relative overflow-hidden rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    error ? "border-error-content" : "border-border-primary",
     !disabled && !error && "hover:border-neutral-alphas-400",
     CONTAINER_HEIGHT[size],
     disabled && "opacity-50",
@@ -69,7 +69,7 @@ function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: b
 
 function getInputClassName(size: TextFieldSize, hasLeftIcon: boolean, hasRightIcon: boolean) {
   return cn(
-    "h-full w-full rounded-sm bg-transparent text-content-primary no-underline placeholder:text-content-secondary focus:outline-none disabled:cursor-not-allowed",
+    "h-full w-full rounded-sm bg-transparent text-content-primary no-underline placeholder:text-content-tertiary focus:outline-none disabled:cursor-not-allowed",
     INPUT_SIZE_CLASSES[size],
     hasLeftIcon ? INPUT_PL[size].withIcon : INPUT_PL[size].default,
     hasRightIcon ? INPUT_PR[size].withIcon : INPUT_PR[size].default,
@@ -159,7 +159,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         {label && (
           <label
             htmlFor={inputId}
-            className="typography-description-12px-semibold px-1 pt-1 pb-2 text-content-primary"
+            className="typography-description-12px-semibold pb-2 text-content-primary"
           >
             {label}
           </label>


### PR DESCRIPTION
Implements the @fanvue/ui-level fixes from the CRM reskin Figma parity audit (95-finding audit of the Creator Management/Teams handover designs vs pandora PRs #28079/#28139).

## Changes

- **TextField / Select** — resting chrome now matches V2 Input Fields: solid `inputs-primary` surface + 1px `border-primary` border (was 10% white-alpha fill with transparent border); placeholders use `content-tertiary` (Select also drops its 40% opacity); labels sit flush above the field (removed 4px inset)
- **Badge** — `success`/`warning`/`error`/`info` variants now render their semantic surface+content token pairs per V2 Pills (previously identical neutral pills, colour only via `leftDot`); height 20px → 24px
- **Pill** — horizontal padding 12px → 8px per V2 Pills
- **Checkbox** — 1px outline per V2 Checkbox Item (was 2px)
- **IconButton** — size-32 renders a 16px icon (was forced 20px, overriding the icon's own size prop)
- **Dialog** — desktop radius 32px → 24px and uniform 16px title/body/footer rhythm per v2-modal; new opt-in `mobilePresentation="card"` renders small confirmations as a centered floating card on mobile (16px margins, 24px padding, 32px radius, no pull handle) instead of a bottom sheet — default sheet behaviour unchanged

## Review notes

- Badge height and Checkbox border are library-wide default changes (Chromatic will flag them beyond CRM surfaces) — intentional, they are the V2 spec values.
- Figma is internally inconsistent on modal radius (24px desktop v2-modal vs 32px mobile card, and `--color-modal-radius` in the theme is still 32px) — implemented as designed per-frame, flagging for a design tie-break.

Audit findings covered: 1, 4, 5, 6, 8, 9, 15, 16, 23, 24, 29, 40, 41, 50, 64, 74, 81, 87, 88.
Full audit todo: `CRM_RESKIN_FIGMA_AUDIT_TODO.md` on `simon/crm-reskin-figma-parity` in pandora.