### PR TITLE
feat(ProgressBar): add V2 brand/mono variants and stepped progress (ENG-10627)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,6 +172,7 @@ import {
   PrivacyIcon,
   ProfileStatus,
   ProgressBar,
+  ProgressBarSteps,
   Radio,
   RadioGroup,
   RatingSummary,
@@ -3972,6 +3973,17 @@ function ProgressBarDemo() {
     <div id="progressbar" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-header-heading-sm mb-4">Progress Bar</h2>
       <div className="flex max-w-md flex-col gap-6">
+        {/* V2 Brand / Mono */}
+        <ProgressBar value={60} variant="brand" />
+        <ProgressBar value={60} variant="mono" />
+        <ProgressBar value={60} size="small" variant="brand" />
+        <ProgressBar value={60} size="small" variant="mono" />
+
+        {/* V2 stepped progress */}
+        <ProgressBarSteps steps={4} value={1} variant="brand" />
+        <ProgressBarSteps steps={4} value={2} variant="mono" />
+        <ProgressBarSteps steps={6} value={3} size="small" variant="brand" />
+
         {/* Default variant — color-coded by value */}
         <ProgressBar value={20} />
         <ProgressBar value={60} />

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -9,14 +9,14 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=1624-9666",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18411-91424",
     },
   },
   tags: ["autodocs"],
   argTypes: {
     value: { control: { type: "range", min: 0, max: 100 } },
     size: { control: "select", options: ["default", "small"] },
-    variant: { control: "select", options: ["default", "generic", "neutral"] },
+    variant: { control: "select", options: ["brand", "mono", "default", "generic", "neutral"] },
     showCompletion: { control: "boolean" },
     title: { control: "text" },
     stepsLabel: { control: "text" },
@@ -34,6 +34,36 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     value: 60,
+  },
+};
+
+export const Brand: Story = {
+  args: {
+    value: 60,
+    variant: "brand",
+  },
+};
+
+export const Mono: Story = {
+  args: {
+    value: 60,
+    variant: "mono",
+  },
+};
+
+export const BrandSmall: Story = {
+  args: {
+    value: 60,
+    size: "small",
+    variant: "brand",
+  },
+};
+
+export const MonoSmall: Story = {
+  args: {
+    value: 60,
+    size: "small",
+    variant: "mono",
   },
 };
 

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -3,15 +3,22 @@ import { cn } from "@/utils/cn";
 
 /** Track height — `"default"` (12px) or `"small"` (6px). */
 export type ProgressBarSize = "default" | "small";
-/** Colour mode — `"default"` uses red/yellow/green by value, `"generic"` always uses brand green, `"neutral"` uses a theme-aware inverse colour. */
-export type ProgressBarVariant = "default" | "generic" | "neutral";
+/**
+ * Colour mode.
+ * - `"brand"` — V2 brand (green) fill on a tinted track.
+ * - `"mono"` — V2 monochrome fill on a tinted track (theme-aware).
+ * - `"default"` — legacy value-coded red/yellow/green.
+ * - `"generic"` — legacy solid brand green on a neutral track.
+ * - `"neutral"` — legacy theme-aware inverse colour on a neutral track.
+ */
+export type ProgressBarVariant = "brand" | "mono" | "default" | "generic" | "neutral";
 
 export interface ProgressBarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   /** Current progress value, clamped to 0–100. */
   value: number;
   /** Track height — `"default"` (12px) or `"small"` (6px). @default "default" */
   size?: ProgressBarSize;
-  /** Colour mode — `"default"` is colour-coded by value, `"generic"` always uses brand green, `"neutral"` uses a theme-aware inverse colour. @default "default" */
+  /** Colour mode. Prefer `"brand"` or `"mono"` (V2); `"default"`/`"generic"`/`"neutral"` are legacy. @default "default" */
   variant?: ProgressBarVariant;
   /** Title content shown at the top-left of the bar. */
   title?: React.ReactNode;
@@ -56,12 +63,37 @@ function getDefaultTextColor(value: number): string {
 function resolveColors(
   variant: ProgressBarVariant,
   value: number,
-): { barColor: string; textColor: string } {
+): { barColor: string; textColor: string; trackColor: string } {
+  const neutralTrack = "bg-neutral-alphas-50";
+  if (variant === "brand")
+    return {
+      barColor: "bg-progress-bar-brand-active",
+      textColor: "text-brand-primary-default",
+      trackColor: "bg-progress-bar-brand-inactive",
+    };
+  if (variant === "mono")
+    return {
+      barColor: "bg-progress-bar-mono-active",
+      textColor: "text-content-primary",
+      trackColor: "bg-progress-bar-mono-inactive",
+    };
   if (variant === "neutral")
-    return { barColor: "bg-content-tertiary", textColor: "text-content-tertiary" };
+    return {
+      barColor: "bg-content-tertiary",
+      textColor: "text-content-tertiary",
+      trackColor: neutralTrack,
+    };
   if (variant === "generic")
-    return { barColor: "bg-brand-primary-default", textColor: "text-brand-primary-default" };
-  return { barColor: getDefaultBarColor(value), textColor: getDefaultTextColor(value) };
+    return {
+      barColor: "bg-brand-primary-default",
+      textColor: "text-brand-primary-default",
+      trackColor: neutralTrack,
+    };
+  return {
+    barColor: getDefaultBarColor(value),
+    textColor: getDefaultTextColor(value),
+    trackColor: neutralTrack,
+  };
 }
 
 /**
@@ -95,7 +127,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   ) => {
     const clampedValue = Math.min(100, Math.max(0, value));
     const isSmall = size === "small";
-    const { barColor, textColor } = resolveColors(variant, clampedValue);
+    const { barColor, textColor, trackColor } = resolveColors(variant, clampedValue);
 
     const showHeader = title != null || showCompletion || stepsLabel != null;
     const showFooter = leftIcon != null || helperLeft != null || helperRight != null;
@@ -132,7 +164,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuetext={ariaValueText}
-          className={cn("relative w-full rounded-full bg-neutral-alphas-50", TRACK_HEIGHT[size])}
+          className={cn("relative w-full rounded-full", trackColor, TRACK_HEIGHT[size])}
         >
           <div
             className={cn(

--- a/src/components/ProgressBar/ProgressBarItem.tsx
+++ b/src/components/ProgressBar/ProgressBarItem.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+
+/** Colour mode for a progress bar item — brand green or theme-aware monochrome. */
+export type ProgressBarItemVariant = "brand" | "mono";
+/** Pill thickness — `"default"` (8px) or `"small"` (4px). */
+export type ProgressBarItemSize = "default" | "small";
+
+export interface ProgressBarItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Whether this item is filled (completed). @default false */
+  active?: boolean;
+  /** Colour mode. @default "brand" */
+  variant?: ProgressBarItemVariant;
+  /** Pill thickness — `"default"` (8px) or `"small"` (4px). @default "default" */
+  size?: ProgressBarItemSize;
+}
+
+const ACTIVE_COLOR: Record<ProgressBarItemVariant, string> = {
+  brand: "bg-progress-bar-brand-active",
+  mono: "bg-progress-bar-mono-active",
+};
+
+const INACTIVE_COLOR: Record<ProgressBarItemVariant, string> = {
+  brand: "bg-progress-bar-brand-inactive",
+  mono: "bg-progress-bar-mono-inactive",
+};
+
+/**
+ * A single rounded segment used to compose a stepped progress indicator. Render
+ * a row of these (see {@link ProgressBarSteps}) to represent discrete steps.
+ *
+ * @example
+ * ```tsx
+ * <ProgressBarItem active variant="brand" />
+ * ```
+ */
+export const ProgressBarItem = React.forwardRef<HTMLDivElement, ProgressBarItemProps>(
+  ({ active = false, variant = "brand", size = "default", className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "w-full rounded-full",
+        size === "small" ? "h-1" : "h-2",
+        active ? ACTIVE_COLOR[variant] : INACTIVE_COLOR[variant],
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+ProgressBarItem.displayName = "ProgressBarItem";

--- a/src/components/ProgressBar/ProgressBarSteps.stories.tsx
+++ b/src/components/ProgressBar/ProgressBarSteps.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ProgressBarSteps } from "./ProgressBarSteps";
+
+const meta = {
+  title: "Components/ProgressBarSteps",
+  component: ProgressBarSteps,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18411-91424",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    steps: { control: { type: "number", min: 1, max: 12 } },
+    value: { control: { type: "number", min: 0, max: 12 } },
+    size: { control: "select", options: ["default", "small"] },
+    variant: { control: "select", options: ["brand", "mono"] },
+  },
+  args: {
+    className: "w-[300px]",
+    steps: 4,
+    value: 1,
+  },
+} satisfies Meta<typeof ProgressBarSteps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Brand: Story = {
+  args: {
+    variant: "brand",
+  },
+};
+
+export const Mono: Story = {
+  args: {
+    variant: "mono",
+  },
+};
+
+export const BrandSmall: Story = {
+  args: {
+    variant: "brand",
+    size: "small",
+  },
+};
+
+export const MonoSmall: Story = {
+  args: {
+    variant: "mono",
+    size: "small",
+  },
+};
+
+export const HalfComplete: Story = {
+  args: {
+    steps: 6,
+    value: 3,
+    variant: "brand",
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    steps: 4,
+    value: 4,
+    variant: "brand",
+  },
+};

--- a/src/components/ProgressBar/ProgressBarSteps.test.tsx
+++ b/src/components/ProgressBar/ProgressBarSteps.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { ProgressBarItem } from "./ProgressBarItem";
+import { ProgressBarSteps } from "./ProgressBarSteps";
+
+describe("ProgressBarSteps", () => {
+  describe("API", () => {
+    it("renders one segment per step", () => {
+      const { container } = render(<ProgressBarSteps steps={5} value={2} />);
+      const track = screen.getByRole("progressbar");
+      expect(track.childElementCount).toBe(5);
+      expect(container).toBeTruthy();
+    });
+
+    it("clamps value to the 0-steps range", () => {
+      const { rerender } = render(<ProgressBarSteps steps={4} value={10} />);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "4");
+
+      rerender(<ProgressBarSteps steps={4} value={-2} />);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
+    });
+
+    it("treats a steps count below 1 as a single step", () => {
+      render(<ProgressBarSteps steps={0} value={0} />);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuemax", "1");
+    });
+
+    it("forwards ref correctly", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<ProgressBarSteps ref={ref} steps={3} value={1} />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(
+        <ProgressBarSteps steps={3} value={1} className="custom-class" />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("sets progressbar aria attributes", () => {
+      render(<ProgressBarSteps steps={4} value={2} ariaValueText="Step 2 of 4" />);
+      const track = screen.getByRole("progressbar");
+      expect(track).toHaveAttribute("aria-valuemin", "0");
+      expect(track).toHaveAttribute("aria-valuemax", "4");
+      expect(track).toHaveAttribute("aria-valuenow", "2");
+      expect(track).toHaveAttribute("aria-valuetext", "Step 2 of 4");
+    });
+
+    it("uses a custom ariaLabel when provided", () => {
+      render(<ProgressBarSteps steps={4} value={2} ariaLabel="Onboarding" />);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-label", "Onboarding");
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = render(<ProgressBarSteps steps={4} value={2} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});
+
+describe("ProgressBarItem", () => {
+  it("forwards ref and applies custom className", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(<ProgressBarItem ref={ref} active className="custom-item" />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(container.firstChild).toHaveClass("custom-item");
+  });
+
+  it("uses the active colour when active and the inactive colour otherwise", () => {
+    const { container, rerender } = render(<ProgressBarItem active variant="brand" />);
+    expect(container.firstChild).toHaveClass("bg-progress-bar-brand-active");
+
+    rerender(<ProgressBarItem variant="brand" />);
+    expect(container.firstChild).toHaveClass("bg-progress-bar-brand-inactive");
+  });
+});

--- a/src/components/ProgressBar/ProgressBarSteps.tsx
+++ b/src/components/ProgressBar/ProgressBarSteps.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+import {
+  ProgressBarItem,
+  type ProgressBarItemSize,
+  type ProgressBarItemVariant,
+} from "./ProgressBarItem";
+
+export interface ProgressBarStepsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Total number of steps (segments). Values below 1 are treated as 1. */
+  steps: number;
+  /** Number of completed steps, clamped to `0`–`steps`. */
+  value: number;
+  /** Colour mode. @default "brand" */
+  variant?: ProgressBarItemVariant;
+  /** Pill thickness — `"default"` (8px) or `"small"` (4px). @default "default" */
+  size?: ProgressBarItemSize;
+  /** Accessible label for the `progressbar` role. @default "Progress" */
+  ariaLabel?: string;
+  /** Human-readable text alternative for the current value (e.g. "Step 2 of 4"). */
+  ariaValueText?: string;
+}
+
+/**
+ * A segmented (stepped) progress indicator built from {@link ProgressBarItem}
+ * pills. Fills the first `value` of `steps` segments.
+ *
+ * @example
+ * ```tsx
+ * <ProgressBarSteps steps={4} value={2} variant="brand" />
+ * ```
+ */
+export const ProgressBarSteps = React.forwardRef<HTMLDivElement, ProgressBarStepsProps>(
+  (
+    {
+      steps,
+      value,
+      variant = "brand",
+      size = "default",
+      ariaLabel,
+      ariaValueText,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const total = Math.max(1, Math.floor(steps));
+    const completed = Math.min(total, Math.max(0, Math.floor(value)));
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-label={ariaLabel ?? "Progress"}
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={completed}
+        aria-valuetext={ariaValueText}
+        className={cn("flex w-full items-center gap-1", className)}
+        {...props}
+      >
+        {Array.from({ length: total }, (_, index) => (
+          <ProgressBarItem
+            key={index}
+            active={index < completed}
+            variant={variant}
+            size={size}
+            className="flex-1"
+          />
+        ))}
+      </div>
+    );
+  },
+);
+
+ProgressBarSteps.displayName = "ProgressBarSteps";

--- a/src/index.ts
+++ b/src/index.ts
@@ -595,6 +595,14 @@ export type {
   ProgressBarVariant,
 } from "./components/ProgressBar/ProgressBar";
 export { ProgressBar } from "./components/ProgressBar/ProgressBar";
+export type {
+  ProgressBarItemProps,
+  ProgressBarItemSize,
+  ProgressBarItemVariant,
+} from "./components/ProgressBar/ProgressBarItem";
+export { ProgressBarItem } from "./components/ProgressBar/ProgressBarItem";
+export type { ProgressBarStepsProps } from "./components/ProgressBar/ProgressBarSteps";
+export { ProgressBarSteps } from "./components/ProgressBar/ProgressBarSteps";
 export type { RadioLayout, RadioProps } from "./components/Radio/Radio";
 export { Radio } from "./components/Radio/Radio";
 export type { RadioGroupProps } from "./components/RadioGroup/RadioGroup";


### PR DESCRIPTION
## Summary

Migrates ProgressBar to the **V2 design** ([Figma](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18411-91424)). V2 drops the value-coded red/yellow/green scheme in favour of **Brand** and **Mono** progress tokens, and adds a segmented/stepped structure built from a **Progress Bar Item** primitive. All changes are **additive** — existing props and variants keep working, so there are **no breaking changes** to the public API.

### Continuous `ProgressBar`

- New `variant="brand"` and `variant="mono"` colour modes using the `progress-bar-*` design tokens (theme-aware fill + tinted track).
- Legacy `default` / `generic` / `neutral` variants are retained for backward compatibility (JSDoc now steers consumers to `brand` / `mono`).

### New `ProgressBarItem` + `ProgressBarSteps`

- **`ProgressBarItem`** — a single rounded segment (`active`, `variant`, `size`).
- **`ProgressBarSteps`** — a stepped progress bar that fills the first `value` of `steps` segments; exposes a `progressbar` role with `aria-valuemin/max/now`.

## Visual evidence

**Continuous — Brand / Mono**

![continuous brand](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-progressbar-v2/pb-continuous-brand.png)
![continuous mono](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-progressbar-v2/pb-continuous-mono.png)

**Stepped — Brand / Mono / partial**

![steps brand](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-progressbar-v2/pb-steps-brand.png)
![steps mono](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-progressbar-v2/pb-steps-mono.png)
![steps half](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-progressbar-v2/pb-steps-half.png)

## Changes

- `ProgressBar.tsx` — `brand` / `mono` variants; track colour now variant-driven.
- `ProgressBarItem.tsx`, `ProgressBarSteps.tsx` — new components (+ stories, tests).
- `ProgressBar.stories.tsx` — Brand/Mono stories; `design` link updated to the V2 node.
- `index.ts` — export the new components and types.
- `App.tsx` — V2 brand/mono + stepped demos.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (48/48 ProgressBar tests)
- [x] `pnpm build`
- [x] Visual verification in Storybook (screenshots above)

Closes ENG-10627

Made with [Cursor](https://cursor.com)