### PR TITLE
feat(IconButton): migrate to V2 type system (ENG-11780)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2169,6 +2169,22 @@ function IconButtonDemo() {
           <IconButton variant="primary" icon={<HomeIcon />} aria-label="Home" />
           <IconButton variant="secondary" icon={<HomeIcon />} aria-label="Home" />
           <IconButton variant="tertiary" icon={<HomeIcon />} aria-label="Home" />
+          <IconButton variant="outline" icon={<HomeIcon />} aria-label="Home" />
+          <IconButton variant="error" icon={<CrossIcon />} aria-label="Close" />
+          <IconButton variant="black" icon={<HomeIcon />} aria-label="Home" />
+        </div>
+
+        <div className="rounded-xs bg-surface-primary-inverted p-4">
+          <div className="flex flex-wrap items-center gap-4">
+            <IconButton variant="primary" negative icon={<HomeIcon />} aria-label="Home" />
+            <IconButton variant="secondary" negative icon={<HomeIcon />} aria-label="Home" />
+            <IconButton variant="tertiary" negative icon={<HomeIcon />} aria-label="Home" />
+            <IconButton variant="outline" negative icon={<HomeIcon />} aria-label="Home" />
+            <IconButton variant="white" icon={<HomeIcon />} aria-label="Home" />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4">
           <IconButton variant="brand" icon={<HomeIcon />} aria-label="Home" />
           <IconButton variant="tertiaryDestructive" icon={<CrossIcon />} aria-label="Close" />
           <IconButton variant="navTray" icon={<HomeIcon />} aria-label="Home" />
@@ -2185,6 +2201,7 @@ function IconButtonDemo() {
           <IconButton variant="primary" icon={<HomeIcon />} size="24" aria-label="Home" />
           <IconButton variant="primary" icon={<HomeIcon />} size="32" aria-label="Home" />
           <IconButton variant="primary" icon={<HomeIcon />} size="40" aria-label="Home" />
+          <IconButton variant="primary" icon={<HomeIcon />} size="48" aria-label="Home" />
           <IconButton variant="primary" icon={<HomeIcon />} size="52" aria-label="Home" />
           <IconButton variant="primary" icon={<HomeIcon />} size="72" aria-label="Home" />
         </div>

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -111,7 +111,7 @@ describe("Drawer", () => {
       renderDrawer();
       await user.click(screen.getByRole("button", { name: "Open drawer" }));
       const closeButton = screen.getByRole("button", { name: "Close drawer" });
-      expect(closeButton).toHaveClass("size-8", "bg-neutral-alphas-50");
+      expect(closeButton).toHaveClass("size-8", "bg-buttons-secondary-default");
     });
   });
 

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -260,6 +260,32 @@ export const V2Negative: Story = {
   ),
 };
 
+export const FieldsetDisabled: Story = {
+  args: { icon: <HomeIcon />, "aria-label": "Home" },
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "V2 variants pick up the disabled treatment via a CSS `disabled:` fallback, so buttons inside a `<fieldset disabled>` are dimmed even without the `disabled` prop.",
+      },
+    },
+  },
+  render: () => (
+    <fieldset disabled className="flex items-center gap-4 border-0 p-6">
+      {(["primary", "secondary", "tertiary", "outline", "error"] as const).map((variant) => (
+        <IconButton
+          key={variant}
+          variant={variant}
+          size="40"
+          icon={<HomeIcon />}
+          aria-label={`${variant} in disabled fieldset`}
+        />
+      ))}
+    </fieldset>
+  ),
+};
+
 // Primary variants
 export const Primary24: Story = {
   args: {

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -131,7 +131,7 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=87-4400",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16800-8275",
     },
   },
   tags: ["autodocs"],
@@ -142,6 +142,10 @@ const meta = {
         "primary",
         "secondary",
         "tertiary",
+        "outline",
+        "error",
+        "white",
+        "black",
         "brand",
         "contrast",
         "messaging",
@@ -153,8 +157,9 @@ const meta = {
     },
     size: {
       control: "select",
-      options: ["24", "32", "40", "52", "72"],
+      options: ["24", "32", "40", "48", "52", "72"],
     },
+    negative: { control: "boolean" },
     disabled: { control: "boolean" },
     counterValue: { control: "number" },
   },
@@ -162,6 +167,98 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const v2Variants = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "outline",
+  "error",
+  "white",
+  "black",
+] as const;
+const v2Sizes = ["24", "32", "40", "48"] as const;
+
+export const Outline: Story = {
+  args: { variant: "outline", size: "40", icon: <SettingsIcon />, "aria-label": "Settings" },
+};
+
+export const ErrorVariant: Story = {
+  args: { variant: "error", size: "40", icon: <TrashBinIcon />, "aria-label": "Delete" },
+};
+
+export const White: Story = {
+  args: { variant: "white", size: "40", icon: <HomeIcon />, "aria-label": "Home" },
+  parameters: { backgrounds: { default: "dark" } },
+};
+
+export const Black: Story = {
+  args: { variant: "black", size: "40", icon: <HomeIcon />, "aria-label": "Home" },
+};
+
+export const Primary48: Story = {
+  args: { variant: "primary", size: "48", icon: <HomeIcon />, "aria-label": "Home" },
+};
+
+export const NegativePrimary: Story = {
+  args: {
+    variant: "primary",
+    size: "40",
+    icon: <HomeIcon />,
+    negative: true,
+    "aria-label": "Home",
+  },
+  parameters: { backgrounds: { default: "dark" } },
+};
+
+export const V2Matrix: Story = {
+  args: { icon: <HomeIcon />, "aria-label": "Home" },
+  parameters: { layout: "fullscreen" },
+  render: () => (
+    <div className="flex flex-col gap-6 p-6">
+      {v2Variants.map((variant) => (
+        <div key={variant} className="flex items-center gap-4">
+          <span className="w-20 font-mono text-content-secondary text-xs">{variant}</span>
+          {v2Sizes.map((size) => (
+            <IconButton
+              key={size}
+              variant={variant}
+              size={size}
+              icon={<HomeIcon />}
+              aria-label={`${variant} ${size}`}
+            />
+          ))}
+          <IconButton
+            variant={variant}
+            size="40"
+            icon={<HomeIcon />}
+            aria-label={`${variant} disabled`}
+            disabled
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const V2Negative: Story = {
+  args: { icon: <HomeIcon />, "aria-label": "Home" },
+  parameters: { layout: "fullscreen", backgrounds: { default: "dark" } },
+  render: () => (
+    <div className="flex items-center gap-4 bg-neutral-900 p-6">
+      {(["primary", "secondary", "tertiary", "outline"] as const).map((variant) => (
+        <IconButton
+          key={variant}
+          variant={variant}
+          size="40"
+          negative
+          icon={<HomeIcon />}
+          aria-label={`${variant} negative`}
+        />
+      ))}
+    </div>
+  ),
+};
 
 // Primary variants
 export const Primary24: Story = {

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -32,13 +32,22 @@ describe("IconButton", () => {
   });
 
   describe("V2 variants", () => {
-    it("renders V2 variants as a square (rounded-sm)", () => {
-      render(<IconButton icon={<HomeIcon />} variant="primary" aria-label="Home" />);
-      expect(screen.getByTestId("icon-button")).toHaveClass("rounded-sm");
+    it("squares the 24 size (rounded-xs) for V2 variants", () => {
+      render(<IconButton icon={<HomeIcon />} variant="primary" size="24" aria-label="Home" />);
+      const button = screen.getByTestId("icon-button");
+      expect(button).toHaveClass("rounded-xs");
+      expect(button).not.toHaveClass("rounded-full");
     });
 
-    it("keeps legacy variants circular (rounded-full)", () => {
-      render(<IconButton icon={<HomeIcon />} variant="microphone" aria-label="Mic" />);
+    it("keeps larger V2 sizes circular (rounded-full)", () => {
+      render(<IconButton icon={<HomeIcon />} variant="primary" size="40" aria-label="Home" />);
+      const button = screen.getByTestId("icon-button");
+      expect(button).toHaveClass("rounded-full");
+      expect(button).not.toHaveClass("rounded-xs");
+    });
+
+    it("keeps legacy variants circular at every size", () => {
+      render(<IconButton icon={<HomeIcon />} variant="microphone" size="24" aria-label="Mic" />);
       expect(screen.getByTestId("icon-button")).toHaveClass("rounded-full");
     });
 
@@ -50,6 +59,11 @@ describe("IconButton", () => {
     it("ignores negative on variants that are not negative-aware", () => {
       render(<IconButton icon={<HomeIcon />} variant="error" negative aria-label="Delete" />);
       expect(screen.getByTestId("icon-button")).toHaveClass("bg-buttons-error-default");
+    });
+
+    it("carries a disabled: fallback so fieldset-disabled buttons are styled", () => {
+      render(<IconButton icon={<HomeIcon />} variant="primary" aria-label="Home" />);
+      expect(screen.getByTestId("icon-button")).toHaveClass("disabled:bg-buttons-disabled-default");
     });
   });
 

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -31,6 +31,28 @@ describe("IconButton", () => {
     });
   });
 
+  describe("V2 variants", () => {
+    it("renders V2 variants as a square (rounded-sm)", () => {
+      render(<IconButton icon={<HomeIcon />} variant="primary" aria-label="Home" />);
+      expect(screen.getByTestId("icon-button")).toHaveClass("rounded-sm");
+    });
+
+    it("keeps legacy variants circular (rounded-full)", () => {
+      render(<IconButton icon={<HomeIcon />} variant="microphone" aria-label="Mic" />);
+      expect(screen.getByTestId("icon-button")).toHaveClass("rounded-full");
+    });
+
+    it("applies the negative treatment on negative-aware variants", () => {
+      render(<IconButton icon={<HomeIcon />} variant="primary" negative aria-label="Home" />);
+      expect(screen.getByTestId("icon-button")).toHaveClass("bg-buttons-primary-negative-default");
+    });
+
+    it("ignores negative on variants that are not negative-aware", () => {
+      render(<IconButton icon={<HomeIcon />} variant="error" negative aria-label="Delete" />);
+      expect(screen.getByTestId("icon-button")).toHaveClass("bg-buttons-error-default");
+    });
+  });
+
   describe("counter badge", () => {
     it("shows counter badge when counterShow is true for Tertiary style", () => {
       const { container } = render(

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -31,22 +31,22 @@ describe("IconButton", () => {
     });
   });
 
-  describe("V2 variants", () => {
-    it("squares the 24 size (rounded-xs) for V2 variants", () => {
+  describe("variant styling", () => {
+    it("squares the 24 size (rounded-xs) for size-driven-shape variants", () => {
       render(<IconButton icon={<HomeIcon />} variant="primary" size="24" aria-label="Home" />);
       const button = screen.getByTestId("icon-button");
       expect(button).toHaveClass("rounded-xs");
       expect(button).not.toHaveClass("rounded-full");
     });
 
-    it("keeps larger V2 sizes circular (rounded-full)", () => {
+    it("keeps larger sizes circular (rounded-full)", () => {
       render(<IconButton icon={<HomeIcon />} variant="primary" size="40" aria-label="Home" />);
       const button = screen.getByTestId("icon-button");
       expect(button).toHaveClass("rounded-full");
       expect(button).not.toHaveClass("rounded-xs");
     });
 
-    it("keeps legacy variants circular at every size", () => {
+    it("keeps bespoke variants circular at every size", () => {
       render(<IconButton icon={<HomeIcon />} variant="microphone" size="24" aria-label="Mic" />);
       expect(screen.getByTestId("icon-button")).toHaveClass("rounded-full");
     });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -5,14 +5,13 @@ import { Count, type CountSize } from "../Count/Count";
 /**
  * Visual style variant of the icon button.
  *
- * V2 types: `primary`, `secondary`, `tertiary`, `outline`, `error`, `white`,
- * `black`. `primary`, `secondary`, `tertiary` and `outline` honour the
- * {@link IconButtonProps.negative} prop. Their shape is size-driven — squared at
- * the `24` size, circular otherwise.
+ * `primary`, `secondary`, `tertiary`, `outline`, `error`, `white` and `black`
+ * use the shared button colour tokens and a size-driven shape (squared at the
+ * `24` size, circular otherwise). Of these, `primary`, `secondary`, `tertiary`
+ * and `outline` also honour the {@link IconButtonProps.negative} prop.
  *
- * Legacy types (circular at all sizes, retained for backward compatibility):
- * `brand`, `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`,
- * `microphone`.
+ * `brand`, `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop` and
+ * `microphone` are bespoke variants that stay circular at every size.
  */
 export type IconButtonVariant =
   | "primary"
@@ -61,11 +60,11 @@ const countSizeMap: Record<IconButtonSize, CountSize> = {
 };
 
 /**
- * V2 type-system variants. Their shape is size-driven (see {@link IconButton}):
- * the `24` size is squared (`rounded-xs`), every larger size stays circular.
- * Legacy variants remain circular at all sizes.
+ * Variants whose corner radius is size-driven (see {@link IconButton}): the `24`
+ * size is squared (`rounded-xs`), every larger size stays circular. All other
+ * variants are circular at every size.
  */
-const V2_VARIANTS = new Set<IconButtonVariant>([
+const SIZE_DRIVEN_SHAPE_VARIANTS = new Set<IconButtonVariant>([
   "primary",
   "secondary",
   "tertiary",
@@ -87,6 +86,7 @@ const DISABLED_FILL = "disabled:bg-buttons-disabled-default disabled:text-conten
 const DISABLED_FILL_NEGATIVE =
   "disabled:bg-buttons-disabled-negative disabled:text-content-disabled";
 const DISABLED_TRANSPARENT = "disabled:text-content-disabled";
+const DISABLED_OPACITY = "disabled:opacity-50";
 
 type VariantClasses = {
   default: string;
@@ -96,12 +96,12 @@ type VariantClasses = {
 };
 
 /**
- * V2 icon button styling, mirroring the shared button colour tokens. The
- * disabled treatment is expressed with the CSS `disabled:` variant (not the
- * `disabled` prop) so an ancestor `<fieldset disabled>` is styled too; hover is
- * guarded with `not-disabled:` so it never fights the disabled state.
+ * Icon button styling for every variant. The disabled treatment is expressed
+ * with the CSS `disabled:` variant (not the `disabled` prop) so an ancestor
+ * `<fieldset disabled>` is styled too; hover is guarded with `not-disabled:` so
+ * it never fights the disabled state.
  */
-const V2_VARIANT_CLASSES: Record<string, VariantClasses> = {
+const VARIANT_CLASSES: Record<IconButtonVariant, VariantClasses> = {
   primary: {
     default:
       "bg-buttons-primary-default text-content-primary-inverted not-disabled:hover:bg-buttons-primary-hover not-disabled:active:bg-buttons-primary-hover",
@@ -149,34 +149,49 @@ const V2_VARIANT_CLASSES: Record<string, VariantClasses> = {
       "bg-buttons-always-black-default text-content-always-white not-disabled:hover:bg-buttons-always-black-hover not-disabled:active:bg-buttons-always-black-hover",
     disabled: DISABLED_FILL,
   },
-};
-
-/** Legacy (pre-V2) icon button styling, kept for backward compatibility. */
-const LEGACY_VARIANT_CLASSES: Record<string, string> = {
-  brand:
-    "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black disabled:opacity-50",
-  contrast:
-    "bg-transparent text-content-always-white hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50",
-  messaging:
-    "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black disabled:opacity-50",
-  navTray:
-    "bg-transparent text-content-primary hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50",
-  tertiaryDestructive:
-    "bg-transparent text-error-content hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50",
-  stop: "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black disabled:opacity-50",
-  microphone:
-    "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black disabled:opacity-50",
+  brand: {
+    default:
+      "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black",
+    disabled: DISABLED_OPACITY,
+  },
+  contrast: {
+    default:
+      "bg-transparent text-content-always-white hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted",
+    disabled: DISABLED_OPACITY,
+  },
+  messaging: {
+    default:
+      "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black",
+    disabled: DISABLED_OPACITY,
+  },
+  navTray: {
+    default:
+      "bg-transparent text-content-primary hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted",
+    disabled: DISABLED_OPACITY,
+  },
+  tertiaryDestructive: {
+    default:
+      "bg-transparent text-error-content hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted",
+    disabled: DISABLED_OPACITY,
+  },
+  stop: {
+    default:
+      "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black",
+    disabled: DISABLED_OPACITY,
+  },
+  microphone: {
+    default:
+      "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black",
+    disabled: DISABLED_OPACITY,
+  },
 };
 
 function getVariantClasses(variant: IconButtonVariant, negative: boolean): string {
-  const v2 = V2_VARIANT_CLASSES[variant];
-  if (v2) {
-    const isNegative = NEGATIVE_AWARE_VARIANTS.has(variant) && negative;
-    const base = (isNegative && v2.negative) || v2.default;
-    const disabledClasses = (isNegative && v2.negativeDisabled) || v2.disabled;
-    return cn(base, disabledClasses);
-  }
-  return LEGACY_VARIANT_CLASSES[variant] ?? "";
+  const classes = VARIANT_CLASSES[variant];
+  const isNegative = NEGATIVE_AWARE_VARIANTS.has(variant) && negative;
+  const base = (isNegative && classes.negative) || classes.default;
+  const disabledClasses = (isNegative && classes.negativeDisabled) || classes.disabled;
+  return cn(base, disabledClasses);
 }
 
 export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -200,8 +215,10 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  * icon alone (e.g. close, send). Always pair with an `aria-label` for
  * accessibility.
  *
- * Shape follows the V2 spec: the `24` size is squared (`rounded-xs`), every
- * larger size is circular. Legacy variants stay circular at all sizes.
+ * Shape is size-driven for the standard variants: the `24` size is squared
+ * (`rounded-xs`), every larger size is circular. Bespoke variants (`brand`,
+ * `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`,
+ * `microphone`) stay circular at all sizes.
  *
  * @example
  * ```tsx
@@ -240,7 +257,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           "relative inline-flex shrink-0 items-center justify-center focus-visible:outline-none",
           "cursor-pointer transition-all duration-150 ease-in-out disabled:cursor-default",
           "focus-visible:shadow-focus-ring",
-          V2_VARIANTS.has(variant) && size === "24" ? "rounded-xs" : "rounded-full",
+          SIZE_DRIVEN_SHAPE_VARIANTS.has(variant) && size === "24" ? "rounded-xs" : "rounded-full",
           sizeVariants[size],
           getVariantClasses(variant, negative),
           className,

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -5,12 +5,13 @@ import { Count, type CountSize } from "../Count/Count";
 /**
  * Visual style variant of the icon button.
  *
- * V2 types (square): `primary`, `secondary`, `tertiary`, `outline`, `error`,
- * `white`, `black`. `primary`, `secondary`, `tertiary` and `outline` honour the
- * {@link IconButtonProps.negative} prop.
+ * V2 types: `primary`, `secondary`, `tertiary`, `outline`, `error`, `white`,
+ * `black`. `primary`, `secondary`, `tertiary` and `outline` honour the
+ * {@link IconButtonProps.negative} prop. Their shape is size-driven — squared at
+ * the `24` size, circular otherwise.
  *
- * Legacy types (circular, retained for backward compatibility): `brand`,
- * `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`,
+ * Legacy types (circular at all sizes, retained for backward compatibility):
+ * `brand`, `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`,
  * `microphone`.
  */
 export type IconButtonVariant =
@@ -35,7 +36,7 @@ export type IconButtonSize = "24" | "32" | "40" | "48" | "52" | "72";
 const iconSizeVariants: Record<IconButtonSize, string> = {
   24: "[&>svg]:size-4",
   32: "[&>svg]:size-4",
-  40: "[&>svg]:size-6",
+  40: "[&>svg]:size-4",
   48: "[&>svg]:size-6",
   52: "[&>svg]:size-7",
   72: "[&>svg]:size-8",
@@ -59,8 +60,12 @@ const countSizeMap: Record<IconButtonSize, CountSize> = {
   72: "32",
 };
 
-/** V2 variants render as a square (rounded-sm); legacy variants stay circular. */
-const SQUARE_VARIANTS = new Set<IconButtonVariant>([
+/**
+ * V2 type-system variants. Their shape is size-driven (see {@link IconButton}):
+ * the `24` size is squared (`rounded-xs`), every larger size stays circular.
+ * Legacy variants remain circular at all sizes.
+ */
+const V2_VARIANTS = new Set<IconButtonVariant>([
   "primary",
   "secondary",
   "tertiary",
@@ -78,9 +83,10 @@ const NEGATIVE_AWARE_VARIANTS = new Set<IconButtonVariant>([
   "outline",
 ]);
 
-const DISABLED_FILL = "bg-buttons-disabled-default text-content-disabled";
-const DISABLED_FILL_NEGATIVE = "bg-buttons-disabled-negative text-content-disabled";
-const DISABLED_TRANSPARENT = "bg-transparent text-content-disabled";
+const DISABLED_FILL = "disabled:bg-buttons-disabled-default disabled:text-content-disabled";
+const DISABLED_FILL_NEGATIVE =
+  "disabled:bg-buttons-disabled-negative disabled:text-content-disabled";
+const DISABLED_TRANSPARENT = "disabled:text-content-disabled";
 
 type VariantClasses = {
   default: string;
@@ -89,54 +95,58 @@ type VariantClasses = {
   negativeDisabled?: string;
 };
 
-/** V2 icon button styling, mirroring the shared button colour tokens. */
+/**
+ * V2 icon button styling, mirroring the shared button colour tokens. The
+ * disabled treatment is expressed with the CSS `disabled:` variant (not the
+ * `disabled` prop) so an ancestor `<fieldset disabled>` is styled too; hover is
+ * guarded with `not-disabled:` so it never fights the disabled state.
+ */
 const V2_VARIANT_CLASSES: Record<string, VariantClasses> = {
   primary: {
     default:
-      "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-primary-hover not-disabled:active:bg-buttons-primary-hover",
+      "bg-buttons-primary-default text-content-primary-inverted not-disabled:hover:bg-buttons-primary-hover not-disabled:active:bg-buttons-primary-hover",
     disabled: DISABLED_FILL,
     negative:
-      "bg-buttons-primary-negative-default text-content-primary hover:bg-buttons-primary-negative-hover not-disabled:active:bg-buttons-primary-negative-hover",
+      "bg-buttons-primary-negative-default text-content-primary not-disabled:hover:bg-buttons-primary-negative-hover not-disabled:active:bg-buttons-primary-negative-hover",
     negativeDisabled: DISABLED_FILL_NEGATIVE,
   },
   secondary: {
     default:
-      "bg-buttons-secondary-default text-content-primary hover:bg-buttons-secondary-hover not-disabled:active:bg-buttons-secondary-hover",
+      "bg-buttons-secondary-default text-content-primary not-disabled:hover:bg-buttons-secondary-hover not-disabled:active:bg-buttons-secondary-hover",
     disabled: DISABLED_FILL,
     negative:
-      "bg-buttons-secondary-negative-default text-content-primary-inverted hover:bg-buttons-secondary-negative-hover not-disabled:active:bg-buttons-secondary-negative-hover",
+      "bg-buttons-secondary-negative-default text-content-primary-inverted not-disabled:hover:bg-buttons-secondary-negative-hover not-disabled:active:bg-buttons-secondary-negative-hover",
     negativeDisabled: DISABLED_FILL_NEGATIVE,
   },
   tertiary: {
     default:
-      "bg-transparent text-content-primary hover:bg-buttons-tertiary-hover not-disabled:active:bg-buttons-tertiary-hover",
+      "bg-transparent text-content-primary not-disabled:hover:bg-buttons-tertiary-hover not-disabled:active:bg-buttons-tertiary-hover",
     disabled: DISABLED_TRANSPARENT,
     negative:
-      "bg-transparent text-content-primary-inverted hover:bg-buttons-tertiary-negative-hover not-disabled:active:bg-buttons-tertiary-negative-hover",
+      "bg-transparent text-content-primary-inverted not-disabled:hover:bg-buttons-tertiary-negative-hover not-disabled:active:bg-buttons-tertiary-negative-hover",
     negativeDisabled: DISABLED_TRANSPARENT,
   },
   outline: {
     default:
-      "border border-buttons-outline-default bg-transparent text-content-primary hover:bg-buttons-outline-hover not-disabled:active:bg-buttons-outline-hover",
-    disabled: "border border-buttons-disabled-default bg-transparent text-content-disabled",
+      "border border-buttons-outline-default bg-transparent text-content-primary not-disabled:hover:bg-buttons-outline-hover not-disabled:active:bg-buttons-outline-hover",
+    disabled: "disabled:border-buttons-disabled-default disabled:text-content-disabled",
     negative:
-      "border border-buttons-outline-negative-default bg-transparent text-content-primary-inverted hover:bg-buttons-outline-negative-hover not-disabled:active:bg-buttons-outline-negative-hover",
-    negativeDisabled:
-      "border border-buttons-disabled-negative bg-transparent text-content-disabled",
+      "border border-buttons-outline-negative-default bg-transparent text-content-primary-inverted not-disabled:hover:bg-buttons-outline-negative-hover not-disabled:active:bg-buttons-outline-negative-hover",
+    negativeDisabled: "disabled:border-buttons-disabled-negative disabled:text-content-disabled",
   },
   error: {
     default:
-      "bg-buttons-error-default text-content-always-white hover:bg-buttons-error-hover not-disabled:active:bg-buttons-error-hover",
+      "bg-buttons-error-default text-content-always-white not-disabled:hover:bg-buttons-error-hover not-disabled:active:bg-buttons-error-hover",
     disabled: DISABLED_FILL,
   },
   white: {
     default:
-      "bg-buttons-always-white-default text-content-always-black hover:bg-buttons-always-white-hover not-disabled:active:bg-buttons-always-white-hover",
+      "bg-buttons-always-white-default text-content-always-black not-disabled:hover:bg-buttons-always-white-hover not-disabled:active:bg-buttons-always-white-hover",
     disabled: DISABLED_FILL,
   },
   black: {
     default:
-      "bg-buttons-always-black-default text-content-always-white hover:bg-buttons-always-black-hover not-disabled:active:bg-buttons-always-black-hover",
+      "bg-buttons-always-black-default text-content-always-white not-disabled:hover:bg-buttons-always-black-hover not-disabled:active:bg-buttons-always-black-hover",
     disabled: DISABLED_FILL,
   },
 };
@@ -158,16 +168,13 @@ const LEGACY_VARIANT_CLASSES: Record<string, string> = {
     "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black disabled:opacity-50",
 };
 
-function getVariantClasses(
-  variant: IconButtonVariant,
-  negative: boolean,
-  disabled: boolean,
-): string {
+function getVariantClasses(variant: IconButtonVariant, negative: boolean): string {
   const v2 = V2_VARIANT_CLASSES[variant];
   if (v2) {
     const isNegative = NEGATIVE_AWARE_VARIANTS.has(variant) && negative;
-    if (disabled) return (isNegative && v2.negativeDisabled) || v2.disabled;
-    return (isNegative && v2.negative) || v2.default;
+    const base = (isNegative && v2.negative) || v2.default;
+    const disabledClasses = (isNegative && v2.negativeDisabled) || v2.disabled;
+    return cn(base, disabledClasses);
   }
   return LEGACY_VARIANT_CLASSES[variant] ?? "";
 }
@@ -189,9 +196,12 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
 }
 
 /**
- * A square button containing only an icon (legacy variants remain circular).
- * Use when an action can be represented by an icon alone (e.g. close, send).
- * Always pair with an `aria-label` for accessibility.
+ * A button containing only an icon. Use when an action can be represented by an
+ * icon alone (e.g. close, send). Always pair with an `aria-label` for
+ * accessibility.
+ *
+ * Shape follows the V2 spec: the `24` size is squared (`rounded-xs`), every
+ * larger size is circular. Legacy variants stay circular at all sizes.
  *
  * @example
  * ```tsx
@@ -230,9 +240,9 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           "relative inline-flex shrink-0 items-center justify-center focus-visible:outline-none",
           "cursor-pointer transition-all duration-150 ease-in-out disabled:cursor-default",
           "focus-visible:shadow-focus-ring",
-          SQUARE_VARIANTS.has(variant) ? "rounded-sm" : "rounded-full",
+          V2_VARIANTS.has(variant) && size === "24" ? "rounded-xs" : "rounded-full",
           sizeVariants[size],
-          getVariantClasses(variant, negative, disabled),
+          getVariantClasses(variant, negative),
           className,
         )}
         {...props}

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -2,57 +2,25 @@ import * as React from "react";
 import { cn } from "../../utils/cn";
 import { Count, type CountSize } from "../Count/Count";
 
-const iconButtonVariants = {
-  primary:
-    "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-primary-hover not-disabled:active:bg-buttons-primary-hover disabled:opacity-50 focus-visible:shadow-focus-ring",
-  secondary:
-    "bg-neutral-alphas-50 text-icons-primary hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50 focus-visible:shadow-focus-ring",
-  tertiary:
-    "bg-transparent text-content-primary hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50 focus-visible:shadow-focus-ring",
-  brand:
-    "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black disabled:opacity-50 focus-visible:shadow-focus-ring",
-  contrast:
-    "bg-transparent text-content-always-white hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50 focus-visible:shadow-focus-ring",
-  messaging:
-    "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black disabled:opacity-50 focus-visible:shadow-focus-ring",
-  navTray:
-    "bg-transparent text-content-primary hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50 focus-visible:shadow-focus-ring",
-  tertiaryDestructive:
-    "bg-transparent text-error-content hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50 focus-visible:shadow-focus-ring",
-  stop: "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black disabled:opacity-50 focus-visible:shadow-focus-ring",
-  microphone:
-    "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black disabled:opacity-50 focus-visible:shadow-focus-ring",
-};
-
-const iconSizeVariants = {
-  24: "[&>svg]:size-4",
-  32: "[&>svg]:size-4",
-  40: "[&>svg]:size-6",
-  52: "[&>svg]:size-7",
-  72: "[&>svg]:size-8",
-} as const;
-
-const sizeVariants = {
-  24: "size-6 p-1",
-  32: "size-8 p-1.5",
-  40: "size-10 p-[10px]",
-  52: "size-[52px] p-2",
-  72: "size-[72px] p-4",
-} as const;
-
-const countSizeMap: Record<string, CountSize> = {
-  24: "16",
-  32: "24",
-  40: "32",
-  52: "32",
-  72: "32",
-};
-
-/** Visual style variant of the icon button. */
+/**
+ * Visual style variant of the icon button.
+ *
+ * V2 types (square): `primary`, `secondary`, `tertiary`, `outline`, `error`,
+ * `white`, `black`. `primary`, `secondary`, `tertiary` and `outline` honour the
+ * {@link IconButtonProps.negative} prop.
+ *
+ * Legacy types (circular, retained for backward compatibility): `brand`,
+ * `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`,
+ * `microphone`.
+ */
 export type IconButtonVariant =
   | "primary"
   | "secondary"
   | "tertiary"
+  | "outline"
+  | "error"
+  | "white"
+  | "black"
   | "brand"
   | "contrast"
   | "messaging"
@@ -62,7 +30,147 @@ export type IconButtonVariant =
   | "microphone";
 
 /** Icon button size in pixels. */
-export type IconButtonSize = "24" | "32" | "40" | "52" | "72";
+export type IconButtonSize = "24" | "32" | "40" | "48" | "52" | "72";
+
+const iconSizeVariants: Record<IconButtonSize, string> = {
+  24: "[&>svg]:size-4",
+  32: "[&>svg]:size-4",
+  40: "[&>svg]:size-6",
+  48: "[&>svg]:size-6",
+  52: "[&>svg]:size-7",
+  72: "[&>svg]:size-8",
+};
+
+const sizeVariants: Record<IconButtonSize, string> = {
+  24: "size-6 p-1",
+  32: "size-8 p-1.5",
+  40: "size-10 p-[10px]",
+  48: "size-12 p-3",
+  52: "size-[52px] p-2",
+  72: "size-[72px] p-4",
+};
+
+const countSizeMap: Record<IconButtonSize, CountSize> = {
+  24: "16",
+  32: "24",
+  40: "32",
+  48: "32",
+  52: "32",
+  72: "32",
+};
+
+/** V2 variants render as a square (rounded-sm); legacy variants stay circular. */
+const SQUARE_VARIANTS = new Set<IconButtonVariant>([
+  "primary",
+  "secondary",
+  "tertiary",
+  "outline",
+  "error",
+  "white",
+  "black",
+]);
+
+/** Variants that honour the `negative` (dark-surface) treatment. */
+const NEGATIVE_AWARE_VARIANTS = new Set<IconButtonVariant>([
+  "primary",
+  "secondary",
+  "tertiary",
+  "outline",
+]);
+
+const DISABLED_FILL = "bg-buttons-disabled-default text-content-disabled";
+const DISABLED_FILL_NEGATIVE = "bg-buttons-disabled-negative text-content-disabled";
+const DISABLED_TRANSPARENT = "bg-transparent text-content-disabled";
+
+type VariantClasses = {
+  default: string;
+  disabled: string;
+  negative?: string;
+  negativeDisabled?: string;
+};
+
+/** V2 icon button styling, mirroring the shared button colour tokens. */
+const V2_VARIANT_CLASSES: Record<string, VariantClasses> = {
+  primary: {
+    default:
+      "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-primary-hover not-disabled:active:bg-buttons-primary-hover",
+    disabled: DISABLED_FILL,
+    negative:
+      "bg-buttons-primary-negative-default text-content-primary hover:bg-buttons-primary-negative-hover not-disabled:active:bg-buttons-primary-negative-hover",
+    negativeDisabled: DISABLED_FILL_NEGATIVE,
+  },
+  secondary: {
+    default:
+      "bg-buttons-secondary-default text-content-primary hover:bg-buttons-secondary-hover not-disabled:active:bg-buttons-secondary-hover",
+    disabled: DISABLED_FILL,
+    negative:
+      "bg-buttons-secondary-negative-default text-content-primary-inverted hover:bg-buttons-secondary-negative-hover not-disabled:active:bg-buttons-secondary-negative-hover",
+    negativeDisabled: DISABLED_FILL_NEGATIVE,
+  },
+  tertiary: {
+    default:
+      "bg-transparent text-content-primary hover:bg-buttons-tertiary-hover not-disabled:active:bg-buttons-tertiary-hover",
+    disabled: DISABLED_TRANSPARENT,
+    negative:
+      "bg-transparent text-content-primary-inverted hover:bg-buttons-tertiary-negative-hover not-disabled:active:bg-buttons-tertiary-negative-hover",
+    negativeDisabled: DISABLED_TRANSPARENT,
+  },
+  outline: {
+    default:
+      "border border-buttons-outline-default bg-transparent text-content-primary hover:bg-buttons-outline-hover not-disabled:active:bg-buttons-outline-hover",
+    disabled: "border border-buttons-disabled-default bg-transparent text-content-disabled",
+    negative:
+      "border border-buttons-outline-negative-default bg-transparent text-content-primary-inverted hover:bg-buttons-outline-negative-hover not-disabled:active:bg-buttons-outline-negative-hover",
+    negativeDisabled:
+      "border border-buttons-disabled-negative bg-transparent text-content-disabled",
+  },
+  error: {
+    default:
+      "bg-buttons-error-default text-content-always-white hover:bg-buttons-error-hover not-disabled:active:bg-buttons-error-hover",
+    disabled: DISABLED_FILL,
+  },
+  white: {
+    default:
+      "bg-buttons-always-white-default text-content-always-black hover:bg-buttons-always-white-hover not-disabled:active:bg-buttons-always-white-hover",
+    disabled: DISABLED_FILL,
+  },
+  black: {
+    default:
+      "bg-buttons-always-black-default text-content-always-white hover:bg-buttons-always-black-hover not-disabled:active:bg-buttons-always-black-hover",
+    disabled: DISABLED_FILL,
+  },
+};
+
+/** Legacy (pre-V2) icon button styling, kept for backward compatibility. */
+const LEGACY_VARIANT_CLASSES: Record<string, string> = {
+  brand:
+    "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black disabled:opacity-50",
+  contrast:
+    "bg-transparent text-content-always-white hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50",
+  messaging:
+    "bg-content-always-black text-brand-primary-default hover:bg-brand-primary-default hover:text-content-always-black not-disabled:active:bg-brand-primary-default not-disabled:active:text-content-always-black disabled:opacity-50",
+  navTray:
+    "bg-transparent text-content-primary hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50",
+  tertiaryDestructive:
+    "bg-transparent text-error-content hover:bg-brand-primary-muted not-disabled:active:bg-brand-primary-muted disabled:opacity-50",
+  stop: "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black disabled:opacity-50",
+  microphone:
+    "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black disabled:opacity-50",
+};
+
+function getVariantClasses(
+  variant: IconButtonVariant,
+  negative: boolean,
+  disabled: boolean,
+): string {
+  const v2 = V2_VARIANT_CLASSES[variant];
+  if (v2) {
+    const isNegative = NEGATIVE_AWARE_VARIANTS.has(variant) && negative;
+    if (disabled) return (isNegative && v2.negativeDisabled) || v2.disabled;
+    return (isNegative && v2.negative) || v2.default;
+  }
+  return LEGACY_VARIANT_CLASSES[variant] ?? "";
+}
 
 export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual style variant of the icon button. @default "primary" */
@@ -71,14 +179,19 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   size?: IconButtonSize;
   /** Icon element to render inside the button. */
   icon: React.ReactNode;
-  /** When provided, displays a {@link Count} badge at the top-right corner (tertiary & navTray variants only). */
+  /**
+   * Forces the dark-surface treatment regardless of theme. Only honoured on the
+   * `primary`, `secondary`, `tertiary`, and `outline` variants. @default false
+   */
+  negative?: boolean;
+  /** When provided, displays a {@link Count} badge at the top-right corner. */
   counterValue?: number;
 }
 
 /**
- * A circular button containing only an icon. Use when an action can be
- * represented by an icon alone (e.g. close, send, mic). Pair with an
- * `aria-label` for accessibility.
+ * A square button containing only an icon (legacy variants remain circular).
+ * Use when an action can be represented by an icon alone (e.g. close, send).
+ * Always pair with an `aria-label` for accessibility.
  *
  * @example
  * ```tsx
@@ -87,7 +200,16 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  */
 export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
-    { className, variant = "primary", size = "40", icon, counterValue, disabled = false, ...props },
+    {
+      className,
+      variant = "primary",
+      size = "40",
+      icon,
+      counterValue,
+      negative = false,
+      disabled = false,
+      ...props
+    },
     ref,
   ) => {
     if (process.env.NODE_ENV !== "production") {
@@ -105,14 +227,12 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         data-testid="icon-button"
         disabled={disabled}
         className={cn(
-          // Base styles
           "relative inline-flex shrink-0 items-center justify-center focus-visible:outline-none",
-          "cursor-pointer rounded-full transition-all duration-150 ease-in-out disabled:cursor-default",
-          // Size variants
+          "cursor-pointer transition-all duration-150 ease-in-out disabled:cursor-default",
+          "focus-visible:shadow-focus-ring",
+          SQUARE_VARIANTS.has(variant) ? "rounded-sm" : "rounded-full",
           sizeVariants[size],
-          // Variant styles
-          iconButtonVariants[variant],
-          // Manual CSS overrides
+          getVariantClasses(variant, negative, disabled),
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary

Migrates `IconButton` to the standardised **V2 Button Icon** type system while preserving the public API.

- `primary` / `secondary` / `tertiary` now use the shared button colour tokens and gain a `negative` dark-surface treatment (along with new `outline`).
- **Shape is size-driven, per the V2 Figma:** only the **`24`** size is squared (`rounded-xs`); `32` / `40` / `48` stay **circular** (`rounded-full`). (Earlier revisions squared every V2 size — corrected after design review.)
- New variants: **`outline`**, **`error`**, **`white`**, **`black`**.
- New **`negative`** prop (honoured on `primary` / `secondary` / `tertiary` / `outline`, mirroring `Button`).
- New **`48`** size (V2 spec); existing `24/32/40/52/72` retained. The `40` icon is now `16px` to match the spec (`48` keeps its `24px` icon).
- Bespoke legacy variants (`brand`, `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`, `microphone`) are **unchanged and stay circular** for backward compatibility.

**No public API removals** — the migration is additive.

### Deferred (follow-ups)
- **`upsell`** variant: no `buttons-upsell-*` design tokens exist yet.
- **`ai`** variant: owned by ENG-10621 (AI Button Style).

## Visual evidence

V2 variants × sizes (24/32/40/48) + disabled — note the squared `24` and circular `32/40/48`:

![V2 matrix](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-iconbutton-v2/ib-v2-matrix.png)

`negative` treatment on a dark surface (primary / secondary / tertiary / outline):

![V2 negative](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-iconbutton-v2/ib-v2-negative.png)

Disabled via an ancestor `<fieldset disabled>` (no `disabled` prop) — all variants dim correctly, addressing the Codex P2 note:

![Fieldset disabled](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-iconbutton-v2/ib-fieldset-disabled.png)

## Changes
- `IconButton.tsx` — V2 token-based variant map, `negative` prop, size-driven shape (`24` squared / larger circular), `48` size, `40` icon at 16px, and CSS `disabled:` fallbacks so `<fieldset disabled>` is styled.
- `IconButton.stories.tsx` — V2 stories (matrix, negative, per-variant, fieldset-disabled), size `48`, V2 Figma link.
- `IconButton.test.tsx` — size-driven shape and disabled-fallback behaviour.
- `App.tsx` — V2 demo rows (variants, negative, size `48`).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test src/components/IconButton` + `Drawer` (43 passed)
- [x] `pnpm build`
- [ ] Design review against V2 Figma (size-driven shape / tokens)

Closes ENG-11780

Made with [Cursor](https://cursor.com)
