### PR TITLE
feat(SegmentedControl): add V2 segmented control component (ENG-12057)

### DIFF
--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,173 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import type { SegmentedControlSize, SegmentedControlVariant } from "./SegmentedControl";
+import { SegmentedControl } from "./SegmentedControl";
+
+const meta = {
+  title: "Components/SegmentedControl",
+  component: SegmentedControl,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16965-105414&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["32", "40", "48"],
+    },
+    variant: {
+      control: "inline-radio",
+      options: ["hug", "fill"],
+    },
+    disabled: {
+      control: "boolean",
+    },
+  },
+} satisfies Meta<typeof SegmentedControl>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const twoOptions = [
+  { label: "Net", value: "net" },
+  { label: "Gross", value: "gross" },
+];
+
+const threeOptions = [
+  { label: "Net", value: "net" },
+  { label: "Gross", value: "gross" },
+  { label: "Total", value: "total" },
+];
+
+export const Default: Story = {
+  args: {
+    options: twoOptions,
+    size: "32",
+    variant: "hug",
+    "aria-label": "Amount type",
+  },
+};
+
+export const ThreeOptions: Story = {
+  args: {
+    options: threeOptions,
+    size: "32",
+    variant: "hug",
+    "aria-label": "Amount type",
+  },
+};
+
+export const Fill: Story = {
+  args: {
+    options: twoOptions,
+    size: "32",
+    variant: "fill",
+    "aria-label": "Amount type",
+  },
+  render: (args) => (
+    <div style={{ width: 480 }}>
+      <SegmentedControl {...args} />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    options: twoOptions,
+    disabled: true,
+    "aria-label": "Amount type",
+  },
+};
+
+export const Controlled: Story = {
+  args: {
+    options: threeOptions,
+    "aria-label": "Amount type",
+  },
+  render: function ControlledRender() {
+    const [value, setValue] = useState("net");
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <SegmentedControl
+          options={threeOptions}
+          value={value}
+          onChange={setValue}
+          aria-label="Amount type"
+        />
+        <span className="typography-body-small-14px-regular text-content-secondary">
+          Selected: {value}
+        </span>
+      </div>
+    );
+  },
+};
+
+export const Sizes: Story = {
+  args: {
+    options: twoOptions,
+    "aria-label": "Amount type",
+  },
+  render: () => (
+    <div className="flex flex-col items-start gap-4">
+      {(["32", "40", "48"] as const).map((size) => (
+        <div key={size} className="flex flex-col items-start gap-2">
+          <span className="typography-body-small-14px-semibold text-content-secondary">
+            {size}px
+          </span>
+          <SegmentedControl size={size} options={twoOptions} aria-label={`${size}px control`} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Every combination in the Figma variant sheet: hug/fill × 32/40/48px × 2/3 options. */
+export const AllVariants: Story = {
+  args: {
+    options: twoOptions,
+    "aria-label": "Amount type",
+  },
+  parameters: { layout: "padded" },
+  render: () => {
+    const sizes: SegmentedControlSize[] = ["32", "40", "48"];
+    const variants: SegmentedControlVariant[] = ["hug", "fill"];
+    return (
+      <div className="flex flex-col items-start gap-8">
+        {variants.map((variant) => (
+          <div key={variant} className="flex flex-col items-start gap-4">
+            <span className="typography-body-default-16px-semibold text-content-primary capitalize">
+              {variant}
+            </span>
+            {sizes.map((size) => (
+              <div
+                key={size}
+                className="flex flex-col items-start gap-3"
+                style={{ width: variant === "fill" ? 560 : "auto" }}
+              >
+                <span className="typography-description-12px-regular text-content-secondary">
+                  {size}px
+                </span>
+                <SegmentedControl
+                  size={size}
+                  variant={variant}
+                  options={twoOptions}
+                  aria-label={`${variant} ${size}px two options`}
+                />
+                <SegmentedControl
+                  size={size}
+                  variant={variant}
+                  options={threeOptions}
+                  aria-label={`${variant} ${size}px three options`}
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,243 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { SegmentedControl } from "./SegmentedControl";
+
+const twoOptions = [
+  { label: "Net", value: "net" },
+  { label: "Gross", value: "gross" },
+];
+
+const threeOptions = [
+  { label: "Net", value: "net" },
+  { label: "Gross", value: "gross" },
+  { label: "Total", value: "total" },
+];
+
+describe("SegmentedControl", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      const { container } = render(
+        <SegmentedControl className="custom-class" options={twoOptions} aria-label="Amount" />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("renders one radio per option", () => {
+      render(<SegmentedControl options={threeOptions} aria-label="Amount" />);
+      expect(screen.getAllByRole("radio")).toHaveLength(3);
+    });
+
+    it("selects first option by default (uncontrolled)", () => {
+      render(<SegmentedControl options={twoOptions} aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveAttribute("aria-checked", "true");
+      expect(radios[1]).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("supports defaultValue", () => {
+      render(<SegmentedControl options={twoOptions} defaultValue="gross" aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveAttribute("aria-checked", "false");
+      expect(radios[1]).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("can be controlled", () => {
+      const { rerender } = render(
+        <SegmentedControl options={twoOptions} value="net" aria-label="Amount" />,
+      );
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveAttribute("aria-checked", "true");
+
+      rerender(<SegmentedControl options={twoOptions} value="gross" aria-label="Amount" />);
+      expect(radios[0]).toHaveAttribute("aria-checked", "false");
+      expect(radios[1]).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("calls onChange when a segment is selected", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<SegmentedControl options={twoOptions} onChange={handleChange} aria-label="Amount" />);
+      await user.click(screen.getByText("Gross"));
+      expect(handleChange).toHaveBeenCalledWith("gross");
+    });
+
+    it("does not fire onChange when clicking the already-selected segment", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<SegmentedControl options={twoOptions} onChange={handleChange} aria-label="Amount" />);
+      await user.click(screen.getByText("Net"));
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it("disables interaction when disabled", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <SegmentedControl
+          disabled
+          options={twoOptions}
+          onChange={handleChange}
+          aria-label="Amount"
+        />,
+      );
+      await user.click(screen.getByText("Gross"));
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it("forwards ref", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<SegmentedControl ref={ref} options={twoOptions} aria-label="Amount" />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+  });
+
+  describe("variants", () => {
+    it("applies fill layout to segments", () => {
+      render(<SegmentedControl variant="fill" options={twoOptions} aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveClass("flex-1");
+    });
+
+    it("applies hug layout to segments by default", () => {
+      render(<SegmentedControl options={twoOptions} aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveClass("shrink-0");
+    });
+
+    it("applies the typography class for the given size", () => {
+      render(<SegmentedControl size="48" options={twoOptions} aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveClass("typography-body-default-16px-semibold");
+    });
+  });
+
+  describe("keyboard navigation", () => {
+    it("moves focus and selects with ArrowRight", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<SegmentedControl options={twoOptions} onChange={handleChange} aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+
+      radios[0]?.focus();
+      await user.keyboard("{ArrowRight}");
+
+      expect(handleChange).toHaveBeenCalledWith("gross");
+      expect(radios[1]).toHaveFocus();
+    });
+
+    it("moves focus and selects with ArrowLeft", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <SegmentedControl
+          options={twoOptions}
+          defaultValue="gross"
+          onChange={handleChange}
+          aria-label="Amount"
+        />,
+      );
+      const radios = screen.getAllByRole("radio");
+
+      radios[1]?.focus();
+      await user.keyboard("{ArrowLeft}");
+
+      expect(handleChange).toHaveBeenCalledWith("net");
+      expect(radios[0]).toHaveFocus();
+    });
+
+    it("wraps to the first option from the last with ArrowRight (three options)", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <SegmentedControl
+          options={threeOptions}
+          defaultValue="total"
+          onChange={handleChange}
+          aria-label="Amount"
+        />,
+      );
+      const radios = screen.getAllByRole("radio");
+
+      radios[2]?.focus();
+      await user.keyboard("{ArrowRight}");
+
+      expect(handleChange).toHaveBeenCalledWith("net");
+      expect(radios[0]).toHaveFocus();
+    });
+
+    it("does not navigate when disabled", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <SegmentedControl
+          disabled
+          options={twoOptions}
+          onChange={handleChange}
+          aria-label="Amount"
+        />,
+      );
+      const radios = screen.getAllByRole("radio");
+
+      radios[0]?.focus();
+      await user.keyboard("{ArrowRight}");
+
+      expect(handleChange).not.toHaveBeenCalled();
+      expect(radios[0]).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("sets tabIndex={0} on selected and tabIndex={-1} on unselected", () => {
+      render(<SegmentedControl options={threeOptions} aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveAttribute("tabIndex", "0");
+      expect(radios[1]).toHaveAttribute("tabIndex", "-1");
+      expect(radios[2]).toHaveAttribute("tabIndex", "-1");
+    });
+
+    it("falls back to first option tabbable when value matches no option", () => {
+      render(<SegmentedControl options={twoOptions} value="stale" aria-label="Amount" />);
+      const radios = screen.getAllByRole("radio");
+      expect(radios[0]).toHaveAttribute("tabIndex", "0");
+      expect(radios[1]).toHaveAttribute("tabIndex", "-1");
+    });
+  });
+
+  describe("accessibility", () => {
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = render(
+        <SegmentedControl options={threeOptions} aria-label="Amount type" />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("warns in dev when no accessible name is provided", () => {
+      render(<SegmentedControl options={twoOptions} />);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no accessible name provided"),
+      );
+    });
+
+    it("does not warn when aria-label is provided", () => {
+      render(<SegmentedControl options={twoOptions} aria-label="Amount" />);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when aria-labelledby is provided", () => {
+      render(<SegmentedControl options={twoOptions} aria-labelledby="external-label" />);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,174 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Height of the segmented control in pixels. */
+export type SegmentedControlSize = "32" | "40" | "48";
+
+/**
+ * Segment layout.
+ * - `"hug"`: each segment is sized to its content.
+ * - `"fill"`: the control spans the full width of its container and each segment grows equally.
+ */
+export type SegmentedControlVariant = "hug" | "fill";
+
+/** Describes one selectable segment. */
+export interface SegmentedControlOption {
+  /** Display label for the segment. */
+  label: string;
+  /** Value identifier returned via `onChange`. */
+  value: string;
+}
+
+export interface SegmentedControlProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onChange"> {
+  /** Height of the control in pixels. @default "32" */
+  size?: SegmentedControlSize;
+  /** Segment layout. @default "hug" */
+  variant?: SegmentedControlVariant;
+  /** The selectable segments. Designed for two or three mutually exclusive options. */
+  options: SegmentedControlOption[];
+  /** Currently selected value (controlled). */
+  value?: string;
+  /** Initially selected value (uncontrolled). Defaults to the first option. */
+  defaultValue?: string;
+  /** Callback fired when the selected value changes. */
+  onChange?: (value: string) => void;
+  /** Whether the control is disabled. @default false */
+  disabled?: boolean;
+}
+
+/** Padding and typography per size. Combined with the container's `p-1` these hit the 32/40/48px heights. */
+const sizeClasses: Record<SegmentedControlSize, string> = {
+  "32": "px-2 py-1 typography-description-12px-semibold",
+  "40": "px-3 py-1.75 typography-body-small-14px-semibold",
+  "48": "px-4 py-2 typography-body-default-16px-semibold",
+};
+
+function warnMissingAccessibleName(ariaLabel?: string, ariaLabelledBy?: string) {
+  if (process.env.NODE_ENV !== "production") {
+    if (!ariaLabel && !ariaLabelledBy) {
+      console.warn(
+        "SegmentedControl: no accessible name provided. Pass an `aria-label` or `aria-labelledby` prop.",
+      );
+    }
+  }
+}
+
+/**
+ * A compact selector for choosing between two or three mutually exclusive
+ * options where the choice affects the content immediately below it. Use
+ * instead of tabs when the options are more like settings or filters than
+ * navigation, such as toggling a list/grid view or a monthly/annual price.
+ *
+ * Rendered as a `radiogroup` with roving-tabindex keyboard navigation. Supports
+ * both controlled and uncontrolled usage.
+ *
+ * @example
+ * ```tsx
+ * <SegmentedControl
+ *   options={[
+ *     { label: "Net", value: "net" },
+ *     { label: "Gross", value: "gross" },
+ *   ]}
+ *   value={amount}
+ *   onChange={setAmount}
+ *   aria-label="Amount type"
+ * />
+ * ```
+ */
+export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>(
+  (
+    {
+      className,
+      size = "32",
+      variant = "hug",
+      options,
+      value: controlledValue,
+      defaultValue,
+      onChange,
+      disabled = false,
+      ...props
+    },
+    ref,
+  ) => {
+    warnMissingAccessibleName(props["aria-label"], props["aria-labelledby"]);
+
+    // Tracks selection for uncontrolled usage; ignored when `value` prop is provided
+    const [internalValue, setInternalValue] = React.useState(defaultValue ?? options[0]?.value);
+    const isControlled = controlledValue !== undefined;
+    const currentValue = isControlled ? controlledValue : internalValue;
+    const anySelected = options.some((o) => o.value === currentValue);
+    const buttonRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+
+    const handleSelect = (optionValue: string) => {
+      if (disabled || optionValue === currentValue) return;
+      if (!isControlled) {
+        setInternalValue(optionValue);
+      }
+      onChange?.(optionValue);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+      const nextIndex =
+        e.key === "ArrowRight" || e.key === "ArrowDown"
+          ? (index + 1) % options.length
+          : e.key === "ArrowLeft" || e.key === "ArrowUp"
+            ? (index - 1 + options.length) % options.length
+            : null;
+      if (nextIndex === null) return;
+      e.preventDefault();
+      const nextOption = options[nextIndex] as SegmentedControlOption;
+      handleSelect(nextOption.value);
+      buttonRefs.current[nextIndex]?.focus();
+    };
+
+    return (
+      <div
+        ref={ref}
+        role="radiogroup"
+        className={cn(
+          "relative items-center rounded-full bg-surface-tertiary p-1",
+          variant === "fill" ? "flex w-full" : "inline-flex",
+          disabled && "cursor-not-allowed opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        {options.map((option, index) => {
+          const isSelected = currentValue === option.value;
+          return (
+            // biome-ignore lint/a11y/useSemanticElements: native radio inputs only allow Tab-focus on the checked item; buttons with roving tabindex give full keyboard navigation
+            <button
+              key={option.value}
+              ref={(el) => {
+                buttonRefs.current[index] = el;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              tabIndex={isSelected || (!anySelected && index === 0) ? 0 : -1}
+              disabled={disabled}
+              onClick={() => handleSelect(option.value)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className={cn(
+                "relative inline-flex min-w-0 cursor-pointer items-center justify-center rounded-full",
+                "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
+                "focus-visible:shadow-focus-ring focus-visible:outline-none",
+                variant === "fill" ? "flex-1" : "shrink-0",
+                sizeClasses[size],
+                isSelected
+                  ? "bg-buttons-primary-default text-content-primary-inverted shadow-sm"
+                  : "text-content-primary hover:bg-buttons-switch-hover",
+                disabled && "pointer-events-none",
+              )}
+            >
+              <span className="min-w-0 truncate">{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+SegmentedControl.displayName = "SegmentedControl";

--- a/src/index.ts
+++ b/src/index.ts
@@ -609,6 +609,13 @@ export type {
 } from "./components/SearchField/SearchField";
 export { SearchField } from "./components/SearchField/SearchField";
 export type {
+  SegmentedControlOption,
+  SegmentedControlProps,
+  SegmentedControlSize,
+  SegmentedControlVariant,
+} from "./components/SegmentedControl/SegmentedControl";
+export { SegmentedControl } from "./components/SegmentedControl/SegmentedControl";
+export type {
   SelectContentProps,
   SelectGroupProps,
   SelectItemProps,


### PR DESCRIPTION
Adds a V2 Segmented Control component with hug/fill layouts, three sizes, and support for two or three options, covering all Figma variants in Storybook.