### PR TITLE
fix(Tabs): keep asChild tab a single interactive control

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -276,3 +276,26 @@ export const AllStates: Story = {
     </div>
   ),
 };
+
+export const AsLinks: Story = {
+  name: "As Navigation Links (asChild)",
+  render: () => (
+    // Navigation tabs: each trigger renders as a real anchor via `asChild`, so
+    // it behaves like a link (right-click, open-in-new-tab, router prefetch)
+    // while still getting tab styling and the active indicator. Swap the `<a>`
+    // for your framework's link component (e.g. next/link).
+    <Tabs value="tab1">
+      <TabsList alignLeft aria-label="Sections">
+        <TabsTrigger value="tab1" asChild>
+          <a href="#photos">Photos</a>
+        </TabsTrigger>
+        <TabsTrigger value="tab2" asChild>
+          <a href="#videos">Videos</a>
+        </TabsTrigger>
+        <TabsTrigger value="tab3" asChild>
+          <a href="#posts">Posts</a>
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  ),
+};

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -78,6 +78,30 @@ describe("Tabs", () => {
       expect(screen.getByRole("tab")).toHaveClass("custom-trigger");
     });
 
+    it("renders the tab as its child element when asChild (e.g. a link)", () => {
+      render(
+        <Tabs value="tab1">
+          <TabsList>
+            <TabsTrigger value="tab1" asChild>
+              <a href="/tab1">Tab 1</a>
+            </TabsTrigger>
+            <TabsTrigger value="tab2" asChild>
+              <a href="/tab2">Tab 2</a>
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>,
+      );
+      // The anchor itself is the tab: it carries role="tab" and keeps its href,
+      // so it stays a single interactive control (no nested button/link).
+      const tab = screen.getByRole("tab", { name: "Tab 1" });
+      expect(tab.tagName).toBe("A");
+      expect(tab).toHaveAttribute("href", "/tab1");
+      expect(tab).toHaveClass("cursor-pointer");
+      // The label is still wrapped in the truncate span (inside the anchor) so
+      // long labels ellipsise and TabsList can measure the indicator width.
+      expect(tab.querySelector("span.truncate")).not.toBeNull();
+    });
+
     it("applies custom className to TabsContent", () => {
       render(
         <Tabs defaultValue="t">
@@ -189,6 +213,31 @@ describe("Tabs", () => {
   describe("accessibility", () => {
     it("has no accessibility violations", async () => {
       const { container } = renderTabs();
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations for asChild link tabs", async () => {
+      // `asChild` must make the link itself the tab (role="tab"), not wrap it in
+      // a span — otherwise the link nests inside the tab and axe flags
+      // `nested-interactive`. Both panels are mounted so each tab's
+      // `aria-controls` resolves.
+      const { container } = render(
+        <Tabs value="tab1">
+          <TabsList aria-label="Sections">
+            <TabsTrigger value="tab1" asChild>
+              <a href="/tab1">Tab 1</a>
+            </TabsTrigger>
+            <TabsTrigger value="tab2" asChild>
+              <a href="/tab2">Tab 2</a>
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="tab1">Panel 1</TabsContent>
+          <TabsContent value="tab2" forceMount>
+            Panel 2
+          </TabsContent>
+        </Tabs>,
+      );
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });

--- a/src/components/Tabs/TabsTrigger.tsx
+++ b/src/components/Tabs/TabsTrigger.tsx
@@ -5,35 +5,65 @@ import { cn } from "../../utils/cn";
 /** Props for the {@link TabsTrigger} button component. */
 export type TabsTriggerProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>;
 
-/** An interactive tab button that activates its associated {@link TabsContent} panel when clicked. */
+/**
+ * An interactive tab that activates its associated {@link TabsContent} panel.
+ *
+ * Renders a `<button>` by default. Pass `asChild` to render the tab as another
+ * element — e.g. a router link for navigation tabs (`<TabsTrigger asChild><Link
+ * href="…">…</Link></TabsTrigger>`). With `asChild` the child element becomes
+ * the tab itself (receiving `role="tab"` and focus management), so the tab
+ * stays a single interactive control rather than nesting one inside the other.
+ */
 export const TabsTrigger = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.Trigger>,
   TabsTriggerProps
->(({ className, children, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex min-w-0 items-center justify-center",
-      "typography-body-default-16px-semibold cursor-pointer",
-      "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
-      "data-[orientation=horizontal]:px-4 data-[orientation=horizontal]:py-3",
-      "data-[orientation=vertical]:justify-start data-[orientation=vertical]:px-4 data-[orientation=vertical]:py-3",
-      "data-[state=active]:text-content-primary",
-      "data-[state=inactive]:text-content-tertiary",
-      "data-[state=active]:hover:text-content-primary/70",
-      "data-[state=inactive]:hover:text-content-primary",
-      "data-[state=active]:active:text-content-primary/70",
-      "data-[state=inactive]:active:text-content-primary",
-      "data-disabled:pointer-events-none",
-      "data-disabled:data-[state=active]:text-content-tertiary",
-      "data-disabled:data-[state=inactive]:text-neutral-alphas-200",
-      "focus-visible:shadow-focus-ring focus-visible:outline-none",
-      className,
-    )}
-    {...props}
-  >
-    <span className="min-w-0 truncate">{children}</span>
-  </TabsPrimitive.Trigger>
-));
+>(({ className, children, asChild, ...props }, ref) => {
+  const label = <span className="min-w-0 truncate">{children}</span>;
+
+  // The `min-w-0 truncate` span keeps long labels ellipsised and lets
+  // TabsList measure the active indicator against the label width. With
+  // `asChild` the consumer's element becomes the tab, so wrap *its* children
+  // in that span (rather than wrapping the element) — the tab stays a single
+  // interactive control (no nested link/button) while behaviour matches the
+  // default button tab.
+  const content =
+    asChild && React.isValidElement(children)
+      ? React.cloneElement(
+          children,
+          undefined,
+          <span className="min-w-0 truncate">
+            {(children.props as { children?: React.ReactNode }).children}
+          </span>,
+        )
+      : label;
+
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      asChild={asChild}
+      className={cn(
+        "inline-flex min-w-0 items-center justify-center",
+        "typography-body-default-16px-semibold cursor-pointer",
+        "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
+        "data-[orientation=horizontal]:px-4 data-[orientation=horizontal]:py-3",
+        "data-[orientation=vertical]:justify-start data-[orientation=vertical]:px-4 data-[orientation=vertical]:py-3",
+        "data-[state=active]:text-content-primary",
+        "data-[state=inactive]:text-content-tertiary",
+        "data-[state=active]:hover:text-content-primary/70",
+        "data-[state=inactive]:hover:text-content-primary",
+        "data-[state=active]:active:text-content-primary/70",
+        "data-[state=inactive]:active:text-content-primary",
+        "data-disabled:pointer-events-none",
+        "data-disabled:data-[state=active]:text-content-tertiary",
+        "data-disabled:data-[state=inactive]:text-neutral-alphas-200",
+        "focus-visible:shadow-focus-ring focus-visible:outline-none",
+        className,
+      )}
+      {...props}
+    >
+      {content}
+    </TabsPrimitive.Trigger>
+  );
+});
 
 TabsTrigger.displayName = "TabsTrigger";


### PR DESCRIPTION
## Why

`TabsTrigger` always wrapped its children in an inner `<span className="min-w-0 truncate">`. With `asChild`, Radix's `Slot` merges the tab semantics (`role="tab"`, focus management) onto **that span** — not onto the consumer's element. So a navigation tab

```tsx
<TabsTrigger asChild><Link href="…">…</Link></TabsTrigger>
```

renders `span[role=tab] > a[href]` — two nested interactive controls, which axe flags as `nested-interactive`. This is a latent issue in every current `asChild` link-tab usage (e.g. `ConnectManagerTabs` in `@fanvue/ui-internal`); it just wasn't caught because those tab bars aren't axe-tested.

## What

- With `asChild`, clone the child so the `min-w-0 truncate` span wraps **its** children instead of the element itself — i.e. `<a><span>…</span></a>`. The consumer's element becomes the tab (a single interactive control, no nesting), while the label still truncates and `TabsList` can still measure the active indicator against the label width.
- Button tabs are unchanged.
- Adds a Storybook story (`As Navigation Links`) and tests: the anchor carries `role="tab"` + `href` + the inner truncate span, and an axe test confirms no `nested-interactive` violation.

## Context

Unblocks `@fanvue/ui-internal` migrating its InviteManage tab bars from a hand-rolled component to the native `Tabs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)