### PR TITLE
fix(DatePicker): separate consecutive disabled date backgrounds

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -212,7 +212,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
             weekday:
               "flex h-[30px] w-10 flex-1 items-center justify-center typography-body-small-14px-regular text-content-secondary",
             week: "flex",
-            day: "relative flex w-10 flex-1 items-center justify-center",
+            day: "relative flex flex-1 items-center justify-center p-0.5",
             hidden: "hidden",
           }}
           components={{


### PR DESCRIPTION
Adds 2px padding to each day cell so consecutive disabled dates render as separate rounded pills matching Figma instead of one continuous gray bar, while range highlighting stays continuous.