### PR TITLE
feat(PageSelector): add V2 page selector component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,7 @@ import {
   MoreVerticalIcon,
   NewMessageIcon,
   OpenIcon,
+  PageSelector,
   Pagination,
   PasswordField,
   PauseIcon,
@@ -1816,7 +1817,8 @@ function EmptyStateDemo() {
           description={
             <span className="text-content-tertiary">
               Title and description as custom nodes (e.g. i18n with line breaks or{" "}
-              <code className="typography-body-small-14px-regular">Trans</code>).
+              <code className="typography-body-small-14px-regular">Trans</code>
+              ).
             </span>
           }
           primaryAction={
@@ -2436,10 +2438,26 @@ function AutocompleteDemo() {
           placeholder="Find a product or price..."
           options={[
             { value: "__new__", label: "+ Create new product", pinned: true },
-            { value: "price:demo-1", label: "$19.99 (one-off)", groupId: "demo-product" },
-            { value: "price:demo-2", label: "$9.99 / month", groupId: "demo-product" },
-            { value: "price:pro-1", label: "$99.00 / year", groupId: "pro-plan" },
-            { value: "price:pro-2", label: "$29.00 / month", groupId: "pro-plan" },
+            {
+              value: "price:demo-1",
+              label: "$19.99 (one-off)",
+              groupId: "demo-product",
+            },
+            {
+              value: "price:demo-2",
+              label: "$9.99 / month",
+              groupId: "demo-product",
+            },
+            {
+              value: "price:pro-1",
+              label: "$99.00 / year",
+              groupId: "pro-plan",
+            },
+            {
+              value: "price:pro-2",
+              label: "$29.00 / month",
+              groupId: "pro-plan",
+            },
           ]}
           groups={[
             { id: "demo-product", label: "Demo Product" },
@@ -3398,10 +3416,26 @@ function TableDemo() {
                 </TableHeader>
                 <TableBody>
                   {[
-                    { purchases: "$0.00", status: "Active", variant: "green" as const },
-                    { purchases: "$0.00", status: "Active", variant: "green" as const },
-                    { purchases: "$156.25", status: "Inactive", variant: "red" as const },
-                    { purchases: "$0.00", status: "Warning", variant: "gold" as const },
+                    {
+                      purchases: "$0.00",
+                      status: "Active",
+                      variant: "green" as const,
+                    },
+                    {
+                      purchases: "$0.00",
+                      status: "Active",
+                      variant: "green" as const,
+                    },
+                    {
+                      purchases: "$156.25",
+                      status: "Inactive",
+                      variant: "red" as const,
+                    },
+                    {
+                      purchases: "$0.00",
+                      status: "Warning",
+                      variant: "gold" as const,
+                    },
                   ].map((row, index) => (
                     <TableRow key={`condensed-${row.status}-${index}`}>
                       <TableCell intent="sideLabel">Product Name</TableCell>
@@ -3891,6 +3925,28 @@ function PaginationDemo() {
     <div id="pagination" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-header-heading-sm mb-4">Pagination</h2>
       <PaginationShowcase />
+    </div>
+  );
+}
+
+function PageSelectorShowcase() {
+  const [page, setPage] = useState(1);
+  const [loopPage, setLoopPage] = useState(1);
+
+  return (
+    <div className="flex flex-col items-start gap-6">
+      <PageSelector totalPages={3} currentPage={page} onPageChange={setPage} />
+      <PageSelector loop totalPages={3} currentPage={loopPage} onPageChange={setLoopPage} />
+      <PageSelector totalPages={3} currentPage={2} disabled />
+    </div>
+  );
+}
+
+function PageSelectorDemo() {
+  return (
+    <div id="pageselector" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Page Selector</h2>
+      <PageSelectorShowcase />
     </div>
   );
 }
@@ -5061,7 +5117,11 @@ function CreatorTileDemo() {
           <div key={aspectRatio} className="flex w-[280px] flex-col gap-2">
             <CreatorTile
               background={<img src={sampleImage} alt="" loading="lazy" />}
-              avatar={{ src: sampleAvatar, alt: "Aitana Lopez", fallback: "AL" }}
+              avatar={{
+                src: sampleAvatar,
+                alt: "Aitana Lopez",
+                fallback: "AL",
+              }}
               name="Aitana Lopez"
               tagline="@fit_aitana"
               action={
@@ -5367,6 +5427,7 @@ function App() {
 
             {/* Pagination */}
             <PaginationDemo />
+            <PageSelectorDemo />
 
             {/* Profile Status */}
             <ProfileStatusDemo />

--- a/src/components/PageSelector/PageSelector.stories.tsx
+++ b/src/components/PageSelector/PageSelector.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { PageSelector } from "./PageSelector";
+
+const meta = {
+  title: "Components/PageSelector",
+  component: PageSelector,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/fDlJj7bf7KXQlibPoujgaC/Creator---AI-Features?node-id=6267-38772&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    totalPages: {
+      control: { type: "number", min: 1 },
+    },
+    currentPage: {
+      control: { type: "number", min: 1 },
+    },
+    loop: {
+      control: "boolean",
+    },
+    disabled: {
+      control: "boolean",
+    },
+  },
+} satisfies Meta<typeof PageSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    totalPages: 3,
+    currentPage: 1,
+  },
+};
+
+export const MiddlePage: Story = {
+  args: {
+    totalPages: 3,
+    currentPage: 2,
+  },
+};
+
+export const Looping: Story = {
+  args: {
+    totalPages: 3,
+    currentPage: 1,
+    loop: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    totalPages: 3,
+    currentPage: 2,
+    disabled: true,
+  },
+};
+
+export const CustomLabel: Story = {
+  args: {
+    totalPages: 5,
+    currentPage: 2,
+    formatLabel: (current, total) => `Page ${current} / ${total}`,
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    totalPages: 3,
+    currentPage: 1,
+  },
+  render: function InteractiveRender() {
+    const [page, setPage] = useState(1);
+    return <PageSelector totalPages={3} currentPage={page} onPageChange={setPage} />;
+  },
+};

--- a/src/components/PageSelector/PageSelector.test.tsx
+++ b/src/components/PageSelector/PageSelector.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { PageSelector } from "./PageSelector";
+
+describe("PageSelector", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      const { container } = render(
+        <PageSelector className="custom-class" totalPages={3} currentPage={1} />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("renders the current-of-total indicator", () => {
+      render(<PageSelector totalPages={3} currentPage={2} />);
+      expect(screen.getByText("2 of 3")).toBeInTheDocument();
+    });
+
+    it("supports a custom label formatter", () => {
+      render(
+        <PageSelector totalPages={3} currentPage={2} formatLabel={(c, t) => `Page ${c} / ${t}`} />,
+      );
+      expect(screen.getByText("Page 2 / 3")).toBeInTheDocument();
+    });
+
+    it("advances with the next button", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<PageSelector totalPages={3} currentPage={1} onPageChange={handleChange} />);
+      await user.click(screen.getByRole("button", { name: "Next page" }));
+      expect(handleChange).toHaveBeenCalledWith(2);
+    });
+
+    it("goes back with the previous button", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<PageSelector totalPages={3} currentPage={2} onPageChange={handleChange} />);
+      await user.click(screen.getByRole("button", { name: "Previous page" }));
+      expect(handleChange).toHaveBeenCalledWith(1);
+    });
+
+    it("forwards ref", () => {
+      const ref = React.createRef<HTMLElement>();
+      render(<PageSelector ref={ref} totalPages={3} currentPage={1} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+    });
+  });
+
+  describe("bounds", () => {
+    it("disables previous on the first page", () => {
+      render(<PageSelector totalPages={3} currentPage={1} />);
+      expect(screen.getByRole("button", { name: "Previous page" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Next page" })).toBeEnabled();
+    });
+
+    it("disables next on the last page", () => {
+      render(<PageSelector totalPages={3} currentPage={3} />);
+      expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Previous page" })).toBeEnabled();
+    });
+
+    it("does not fire onPageChange past the bounds", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<PageSelector totalPages={3} currentPage={1} onPageChange={handleChange} />);
+      await user.click(screen.getByRole("button", { name: "Previous page" }));
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loop", () => {
+    it("wraps from the last page to the first", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<PageSelector loop totalPages={3} currentPage={3} onPageChange={handleChange} />);
+      await user.click(screen.getByRole("button", { name: "Next page" }));
+      expect(handleChange).toHaveBeenCalledWith(1);
+    });
+
+    it("wraps from the first page to the last", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<PageSelector loop totalPages={3} currentPage={1} onPageChange={handleChange} />);
+      await user.click(screen.getByRole("button", { name: "Previous page" }));
+      expect(handleChange).toHaveBeenCalledWith(3);
+    });
+
+    it("keeps both arrows enabled at the bounds when looping", () => {
+      render(<PageSelector loop totalPages={3} currentPage={1} />);
+      expect(screen.getByRole("button", { name: "Previous page" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Next page" })).toBeEnabled();
+    });
+  });
+
+  describe("disabled", () => {
+    it("disables both arrows", () => {
+      render(<PageSelector disabled totalPages={3} currentPage={2} />);
+      expect(screen.getByRole("button", { name: "Previous page" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled();
+    });
+
+    it("does not fire onPageChange when disabled", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<PageSelector disabled totalPages={3} currentPage={2} onPageChange={handleChange} />);
+      await user.click(screen.getByRole("button", { name: "Next page" }));
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(<PageSelector totalPages={3} currentPage={2} />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("exposes a navigation landmark with the default label", () => {
+      render(<PageSelector totalPages={3} currentPage={1} />);
+      expect(screen.getByRole("navigation", { name: "Page selector" })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/PageSelector/PageSelector.tsx
+++ b/src/components/PageSelector/PageSelector.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { ChevronLeftIcon } from "../Icons/ChevronLeftIcon";
+import { ChevronRightIcon } from "../Icons/ChevronRightIcon";
+
+export interface PageSelectorProps extends Omit<React.HTMLAttributes<HTMLElement>, "onChange"> {
+  /** Total number of pages. */
+  totalPages: number;
+  /** Current active page (1-indexed). */
+  currentPage: number;
+  /** Callback fired when the active page changes. Receives the new 1-indexed page number. */
+  onPageChange?: (page: number) => void;
+  /** Whether reaching either end wraps around to the other. @default false */
+  loop?: boolean;
+  /** Whether the control is disabled. @default false */
+  disabled?: boolean;
+  /** Accessible label for the `<nav>` landmark. @default "Page selector" */
+  ariaLabel?: string;
+  /** Accessible label for the previous-page button. @default "Previous page" */
+  previousLabel?: string;
+  /** Accessible label for the next-page button. @default "Next page" */
+  nextLabel?: string;
+  /** Formats the indicator between the arrows. @default (current, total) => \`${current} of ${total}\` */
+  formatLabel?: (currentPage: number, totalPages: number) => string;
+}
+
+const arrowClasses = cn(
+  "flex shrink-0 cursor-pointer items-center justify-center rounded-xs p-1 text-content-primary [&>svg]:size-4",
+  "hover:bg-brand-primary-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent",
+  "focus-visible:shadow-focus-ring focus-visible:outline-none motion-safe:transition-colors motion-safe:duration-150",
+);
+
+/**
+ * A compact control for stepping through a small, known set of pages one at a
+ * time, showing the position as "current of total" between a back and forward
+ * arrow. Use when the total is small and the exact page number matters less
+ * than moving between them, such as flicking through generated variants or a
+ * short carousel. Reach for `Pagination` instead when consumers need to jump
+ * to a specific numbered page.
+ *
+ * @example
+ * ```tsx
+ * <PageSelector totalPages={3} currentPage={page} onPageChange={setPage} />
+ * ```
+ */
+export const PageSelector = React.forwardRef<HTMLElement, PageSelectorProps>(
+  (
+    {
+      className,
+      totalPages,
+      currentPage,
+      onPageChange,
+      loop = false,
+      disabled = false,
+      ariaLabel = "Page selector",
+      previousLabel = "Previous page",
+      nextLabel = "Next page",
+      formatLabel = (current, total) => `${current} of ${total}`,
+      ...props
+    },
+    ref,
+  ) => {
+    const atStart = currentPage <= 1;
+    const atEnd = currentPage >= totalPages;
+    const prevDisabled = disabled || (atStart && !loop);
+    const nextDisabled = disabled || (atEnd && !loop);
+
+    const goTo = (page: number) => {
+      const wrapped = loop ? ((page - 1 + totalPages) % totalPages) + 1 : page;
+      if (wrapped < 1 || wrapped > totalPages || wrapped === currentPage) return;
+      onPageChange?.(wrapped);
+    };
+
+    return (
+      <nav
+        ref={ref}
+        aria-label={ariaLabel}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-sm border border-border-primary bg-surface-secondary p-1",
+          className,
+        )}
+        {...props}
+      >
+        <button
+          type="button"
+          aria-label={previousLabel}
+          disabled={prevDisabled}
+          onClick={() => goTo(currentPage - 1)}
+          className={arrowClasses}
+        >
+          <ChevronLeftIcon />
+        </button>
+
+        <span
+          aria-live="polite"
+          className="typography-description-12px-semibold px-2 py-1 text-center text-content-primary tabular-nums"
+        >
+          {formatLabel(currentPage, totalPages)}
+        </span>
+
+        <button
+          type="button"
+          aria-label={nextLabel}
+          disabled={nextDisabled}
+          onClick={() => goTo(currentPage + 1)}
+          className={arrowClasses}
+        >
+          <ChevronRightIcon />
+        </button>
+      </nav>
+    );
+  },
+);
+
+PageSelector.displayName = "PageSelector";

--- a/src/index.ts
+++ b/src/index.ts
@@ -572,6 +572,8 @@ export type {
   OnlineBlinkingIconSize,
 } from "./components/OnlineBlinkingIcon/OnlineBlinkingIcon";
 export { OnlineBlinkingIcon } from "./components/OnlineBlinkingIcon/OnlineBlinkingIcon";
+export type { PageSelectorProps } from "./components/PageSelector/PageSelector";
+export { PageSelector } from "./components/PageSelector/PageSelector";
 export type {
   PaginationProps,
   PaginationVariant,
@@ -601,7 +603,10 @@ export type { RadioLayout, RadioProps } from "./components/Radio/Radio";
 export { Radio } from "./components/Radio/Radio";
 export type { RadioGroupProps } from "./components/RadioGroup/RadioGroup";
 export { RadioGroup } from "./components/RadioGroup/RadioGroup";
-export type { RatingCount, RatingSummaryProps } from "./components/RatingSummary/RatingSummary";
+export type {
+  RatingCount,
+  RatingSummaryProps,
+} from "./components/RatingSummary/RatingSummary";
 export { RatingSummary } from "./components/RatingSummary/RatingSummary";
 export type { ReviewCardProps } from "./components/ReviewCard/ReviewCard";
 export { ReviewCard } from "./components/ReviewCard/ReviewCard";
@@ -768,7 +773,10 @@ export type { UserDisplayNameProps } from "./components/UserDisplayName/UserDisp
 export { UserDisplayName } from "./components/UserDisplayName/UserDisplayName";
 export type { UserHandleProps } from "./components/UserHandle/UserHandle";
 export { UserHandle } from "./components/UserHandle/UserHandle";
-export type { UserItemProps, UserItemUser } from "./components/UserItem/UserItem";
+export type {
+  UserItemProps,
+  UserItemUser,
+} from "./components/UserItem/UserItem";
 export { UserItem } from "./components/UserItem/UserItem";
 export { cn } from "./utils/cn";
 export { getInitials } from "./utils/getInitials";


### PR DESCRIPTION
Adds a `PageSelector` V2 component: a compact "N of M" pager (back arrow, indicator, forward arrow) in a bordered pill, for stepping through a small known set of pages one at a time. Fills the gap between `Pagination` (jump to a numbered page) and `MobileStepper` (dots/progress wizard nav). Controlled `currentPage`/`totalPages` with `onPageChange`, optional `loop`, `disabled`, and customisable `formatLabel`/aria labels. Covers all states in Storybook, with unit tests and an App.tsx demo.

Implements Figma "V2 Page Selector" ([node 6267-38772](https://www.figma.com/design/fDlJj7bf7KXQlibPoujgaC/Creator---AI-Features?node-id=6267-38772&m=dev)).