### PR TITLE
fix(dialog): add vertical gap between title and description (ENG-12175)

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -69,6 +69,29 @@ export const Default: Story = {
   play: openDialog,
 };
 
+export const WithHeaderDescription: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open Dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Assign creator</DialogTitle>
+          <DialogDescription>Choose a creator to assign to this account.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary">Cancel</Button>
+          </DialogClose>
+          <Button>Assign</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: openDialog,
+};
+
 export const AllStatesV2: Story = {
   name: "All states (v2)",
   parameters: { design: { type: "figma", url: V2_FIGMA_URL } },

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -269,7 +269,7 @@ export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
             aria-label={backLabel}
           />
         )}
-        <div className="min-w-0 flex-1">{children}</div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">{children}</div>
         {showClose && (
           <DialogPrimitive.Close asChild>
             <IconButton


### PR DESCRIPTION
## Summary
- Fixes [ENG-12175](https://linear.app/fanvue/issue/ENG-12175): Title and subtitle render flush together in `DialogHeader` (affects many agency dialogs — Assign Creator, Remove Team Members, Invite Team Members, etc.)
- Root cause: `DialogHeader`'s inner wrapper div (`src/components/Dialog/Dialog.tsx`) had no vertical gap between children, unlike the sibling `DrawerHeader` which already solves this.
- Fix: change the wrapper from `min-w-0 flex-1` to `flex min-w-0 flex-1 flex-col gap-1.5`, matching the existing `DrawerHeader` convention exactly (same gap token, same flex treatment).
- Added a new `WithHeaderDescription` story exercising `DialogTitle` + `DialogDescription` together inside `DialogHeader` (the exact pattern used by `AssignCreatorsDialog` and other affected dialogs) — none of the existing stories place both children in `DialogHeader` together, so this gives Chromatic visual coverage of the fix and guards against regression.

## Test plan
- [x] `pnpm exec biome check src/components/Dialog/` — passes
- [x] `pnpm exec tsc --noEmit` — passes
- [x] `pnpm exec vitest run src/components/Dialog/Dialog.test.tsx` — 26/26 tests pass
- [ ] Chromatic visual review on the new `WithHeaderDescription` story confirms title/subtitle spacing