### PR TITLE
feat(TextField): add V2 side label type and align TextArea treatment (ENG-10613)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -435,6 +435,20 @@ function TextFieldShowcase() {
         placeholder="Placeholder"
         autoComplete="off"
       />
+      <TextField label="Side label (prefix)" leftLabel="$" placeholder="0.00" autoComplete="off" />
+      <TextField
+        label="Side label (suffix)"
+        rightLabel="USD"
+        placeholder="0.00"
+        autoComplete="off"
+      />
+      <TextField
+        label="Side label (both)"
+        leftLabel="$"
+        rightLabel="/ month"
+        defaultValue="9.99"
+        autoComplete="off"
+      />
       <TextField
         label="Error"
         placeholder="Placeholder"

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -67,8 +67,8 @@ const CLEAR_BUTTON_RIGHT: Record<TextAreaSize, string> = {
 
 function getContainerClassName(size: TextAreaSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative rounded-sm border bg-neutral-alphas-50 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
-    error ? "border-error-content" : "border-transparent",
+    "relative rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    error ? "border-error-content" : "border-border-primary",
     !disabled && !error && "hover:border-neutral-alphas-400",
     CONTAINER_MIN_HEIGHT[size],
     disabled && "opacity-50",
@@ -82,7 +82,7 @@ function getTextareaClassName(
   resizable: boolean,
 ) {
   return cn(
-    "h-full w-full bg-transparent text-content-primary no-underline placeholder:text-content-secondary focus:outline-none disabled:cursor-not-allowed",
+    "h-full w-full bg-transparent text-content-primary no-underline placeholder:text-content-tertiary focus:outline-none disabled:cursor-not-allowed",
     resizable ? "resize-y" : "resize-none",
     !hasMinRows && "min-h-[80px]",
     TEXTAREA_SIZE_CLASSES[size],
@@ -251,7 +251,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         {label && (
           <label
             htmlFor={inputId}
-            className="typography-description-12px-semibold px-1 pt-1 pb-2 text-content-primary"
+            className="typography-description-12px-semibold pb-2 text-content-primary"
           >
             {label}
           </label>

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof TextField> = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=4262-17626&m=dev",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16633-67897",
     },
   },
   tags: ["autodocs"],
@@ -45,6 +45,12 @@ const meta: Meta<typeof TextField> = {
     },
     fullWidth: {
       control: "boolean",
+    },
+    leftLabel: {
+      control: "text",
+    },
+    rightLabel: {
+      control: "text",
     },
   },
   decorators: [
@@ -129,6 +135,56 @@ export const WithBothIcons: Story = {
     leftIcon: <HomeIcon />,
     rightIcon: <InfoCircleIcon />,
   },
+};
+
+export const SideLabelPrefix: Story = {
+  name: "Side Label (prefix)",
+  args: {
+    label: "Price",
+    leftLabel: "$",
+    placeholder: "0.00",
+  },
+};
+
+export const SideLabelSuffix: Story = {
+  name: "Side Label (suffix)",
+  args: {
+    label: "Amount",
+    rightLabel: "USD",
+    placeholder: "0.00",
+  },
+};
+
+export const SideLabelBoth: Story = {
+  name: "Side Label (prefix + suffix)",
+  args: {
+    label: "Rate",
+    leftLabel: "$",
+    rightLabel: "/ month",
+    placeholder: "0.00",
+    defaultValue: "9.99",
+  },
+};
+
+export const SideLabelWithIcon: Story = {
+  name: "Side Label with icon",
+  args: {
+    label: "Website",
+    leftIcon: <HomeIcon />,
+    rightLabel: ".fanvue.com",
+    placeholder: "your-handle",
+  },
+};
+
+export const SideLabelSizes: Story = {
+  name: "Side Label (all sizes)",
+  render: () => (
+    <div className="flex w-[375px] flex-col gap-4">
+      <TextField size="48" label="Size 48" leftLabel="$" rightLabel="USD" placeholder="0.00" />
+      <TextField size="40" label="Size 40" leftLabel="$" rightLabel="USD" placeholder="0.00" />
+      <TextField size="32" label="Size 32" leftLabel="$" rightLabel="USD" placeholder="0.00" />
+    </div>
+  ),
 };
 
 export const Validated: Story = {

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -189,6 +189,39 @@ describe("TextField", () => {
       const { container } = render(<TextField label="Price" leftLabel="$" rightLabel="USD" />);
       expect(await axe(container)).toHaveNoViolations();
     });
+
+    it("associates side labels with the input via aria-describedby", () => {
+      render(<TextField id="rate" aria-label="Rate" leftLabel="$" rightLabel="USD" />);
+      const input = screen.getByRole("textbox");
+      const describedBy = input.getAttribute("aria-describedby") ?? "";
+      expect(describedBy).toContain("rate-left-label");
+      expect(describedBy).toContain("rate-right-label");
+      expect(screen.getByText("$")).toHaveAttribute("id", "rate-left-label");
+      expect(screen.getByText("USD")).toHaveAttribute("id", "rate-right-label");
+    });
+
+    it("appends the helper text id after the side labels", () => {
+      render(<TextField id="rate" aria-label="Rate" leftLabel="$" helperText="Monthly amount" />);
+      expect(screen.getByRole("textbox")).toHaveAttribute(
+        "aria-describedby",
+        "rate-left-label rate-helper",
+      );
+    });
+
+    it("focuses the input when clicking a leading adornment or side label", async () => {
+      const user = userEvent.setup();
+      render(
+        <TextField aria-label="Price" leftIcon={<HomeIcon />} leftLabel="$" rightLabel="USD" />,
+      );
+      const input = screen.getByRole("textbox");
+
+      await user.click(screen.getByText("$"));
+      expect(input).toHaveFocus();
+
+      input.blur();
+      await user.click(screen.getByText("USD"));
+      expect(input).toHaveFocus();
+    });
   });
 
   describe("user interaction", () => {

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -167,6 +167,30 @@ describe("TextField", () => {
     });
   });
 
+  describe("side labels", () => {
+    it("renders a left (prefix) side label", () => {
+      render(<TextField aria-label="Price" leftLabel="$" />);
+      expect(screen.getByText("$")).toBeInTheDocument();
+    });
+
+    it("renders a right (suffix) side label", () => {
+      render(<TextField aria-label="Amount" rightLabel="USD" />);
+      expect(screen.getByText("USD")).toBeInTheDocument();
+    });
+
+    it("renders both side labels alongside the input", () => {
+      render(<TextField aria-label="Rate" leftLabel="$" rightLabel="/ mo" />);
+      expect(screen.getByText("$")).toBeInTheDocument();
+      expect(screen.getByText("/ mo")).toBeInTheDocument();
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    it("has no accessibility violations with side labels", async () => {
+      const { container } = render(<TextField label="Price" leftLabel="$" rightLabel="USD" />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
   describe("user interaction", () => {
     it("allows typing in the input", async () => {
       const user = userEvent.setup();

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -83,10 +83,12 @@ function LeadingIcon({ children }: { children?: React.ReactNode }) {
 }
 
 function SideLabel({
+  id,
   size,
   align,
   children,
 }: {
+  id?: string;
   size: TextFieldSize;
   align: "left" | "right";
   children?: React.ReactNode;
@@ -94,6 +96,7 @@ function SideLabel({
   if (!children) return null;
   return (
     <span
+      id={id}
       className={cn(
         "shrink-0 select-none whitespace-nowrap text-content-tertiary",
         align === "right" && "text-right",
@@ -116,7 +119,9 @@ function TrailingAdornment({
   return (
     <span className="flex shrink-0 items-center gap-2 text-content-secondary">
       {rightIcon && (
-        <span className="flex size-4 shrink-0 items-center justify-center">{rightIcon}</span>
+        <span data-tf-interactive="" className="flex size-4 shrink-0 items-center justify-center">
+          {rightIcon}
+        </span>
       )}
       {validated && (
         <span className="pointer-events-none flex size-4 shrink-0 items-center justify-center">
@@ -205,7 +210,39 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     const generatedId = React.useId();
     const inputId = id || generatedId;
     const helperTextId = `${inputId}-helper`;
+    const leftLabelId = `${inputId}-left-label`;
+    const rightLabelId = `${inputId}-right-label`;
     const bottomText = error && errorMessage ? errorMessage : helperText;
+
+    const describedBy =
+      [
+        leftLabel != null ? leftLabelId : null,
+        rightLabel != null ? rightLabelId : null,
+        bottomText ? helperTextId : null,
+      ]
+        .filter(Boolean)
+        .join(" ") || undefined;
+
+    const innerRef = React.useRef<HTMLInputElement>(null);
+    const setRefs = React.useCallback(
+      (node: HTMLInputElement | null) => {
+        innerRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) (ref as React.MutableRefObject<HTMLInputElement | null>).current = node;
+      },
+      [ref],
+    );
+
+    // Keep clicks on the non-interactive adornments (icons, side labels, padding)
+    // focusing the input, matching the old absolute/pointer-events-none layout.
+    const handleContainerMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      const target = event.target as HTMLElement;
+      if (target === innerRef.current) return;
+      if (target.closest("[data-tf-interactive]")) return;
+      event.preventDefault();
+      innerRef.current?.focus();
+    };
 
     warnMissingAccessibleName(label, props["aria-label"], props["aria-labelledby"]);
 
@@ -224,17 +261,21 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           </label>
         )}
 
-        <div className={getContainerClassName(size, error, disabled)}>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: focus bridge delegates pointer clicks on adornments to the input */}
+        <div
+          className={getContainerClassName(size, error, disabled)}
+          onMouseDown={handleContainerMouseDown}
+        >
           <LeadingIcon>{leftIcon}</LeadingIcon>
-          <SideLabel size={size} align="left">
+          <SideLabel id={leftLabelId} size={size} align="left">
             {leftLabel}
           </SideLabel>
 
           <input
-            ref={ref}
+            ref={setRefs}
             id={inputId}
             disabled={disabled}
-            aria-describedby={bottomText ? helperTextId : undefined}
+            aria-describedby={describedBy}
             aria-invalid={error || undefined}
             className={cn(
               "h-full min-w-0 flex-1 bg-transparent text-content-primary no-underline placeholder:text-content-tertiary focus:outline-none disabled:cursor-not-allowed",
@@ -244,7 +285,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             {...props}
           />
 
-          <SideLabel size={size} align="right">
+          <SideLabel id={rightLabelId} size={size} align="right">
             {rightLabel}
           </SideLabel>
           <TrailingAdornment rightIcon={rightIcon} validated={validated} />

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -23,6 +23,10 @@ export interface TextFieldProps
   leftIcon?: React.ReactNode;
   /** Icon element displayed at the right side of the input. */
   rightIcon?: React.ReactNode;
+  /** Fixed, non-editable label pinned inside the left edge of the field — for a prefix such as a currency symbol or country code. */
+  leftLabel?: React.ReactNode;
+  /** Fixed, non-editable label pinned inside the right edge of the field — for a unit or suffix such as a currency code or domain. */
+  rightLabel?: React.ReactNode;
   /** Whether the text field stretches to fill its container width. @default false */
   fullWidth?: boolean;
 }
@@ -33,33 +37,35 @@ const CONTAINER_HEIGHT: Record<TextFieldSize, string> = {
   "32": "h-8",
 };
 
-const INPUT_SIZE_CLASSES: Record<TextFieldSize, string> = {
-  "48": "py-3 typography-body-default-16px-regular autofill-body-lg",
-  "40": "py-2 typography-body-default-16px-regular autofill-body-lg",
-  "32": "py-2 typography-body-small-14px-regular autofill-body-md",
-};
-
-const INPUT_PL: Record<TextFieldSize, { default: string; withIcon: string }> = {
-  "48": { default: "pl-4", withIcon: "pl-10" },
-  "40": { default: "pl-4", withIcon: "pl-10" },
-  "32": { default: "pl-3", withIcon: "pl-9" },
-};
-
-const INPUT_PR: Record<TextFieldSize, { default: string; withIcon: string }> = {
-  "48": { default: "pr-4", withIcon: "pr-10" },
-  "40": { default: "pr-4", withIcon: "pr-10" },
-  "32": { default: "pr-3", withIcon: "pr-9" },
-};
-
-const ICON_INSET: Record<TextFieldSize, string> = {
+const CONTAINER_PADDING_X: Record<TextFieldSize, string> = {
   "48": "px-4",
   "40": "px-4",
   "32": "px-3",
 };
 
+const CONTAINER_GAP: Record<TextFieldSize, string> = {
+  "48": "gap-2.5",
+  "40": "gap-2.5",
+  "32": "gap-2",
+};
+
+const INPUT_TYPOGRAPHY: Record<TextFieldSize, string> = {
+  "48": "typography-body-default-16px-regular autofill-body-lg",
+  "40": "typography-body-default-16px-regular autofill-body-lg",
+  "32": "typography-body-small-14px-regular autofill-body-md",
+};
+
+const SIDE_LABEL_TYPOGRAPHY: Record<TextFieldSize, string> = {
+  "48": "typography-body-default-16px-regular",
+  "40": "typography-body-default-16px-regular",
+  "32": "typography-body-small-14px-regular",
+};
+
 function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative overflow-hidden rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    "relative flex items-center overflow-hidden rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    CONTAINER_PADDING_X[size],
+    CONTAINER_GAP[size],
     error ? "border-error-content" : "border-border-primary",
     !disabled && !error && "hover:border-neutral-alphas-400",
     CONTAINER_HEIGHT[size],
@@ -67,12 +73,57 @@ function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: b
   );
 }
 
-function getInputClassName(size: TextFieldSize, hasLeftIcon: boolean, hasRightIcon: boolean) {
-  return cn(
-    "h-full w-full rounded-sm bg-transparent text-content-primary no-underline placeholder:text-content-tertiary focus:outline-none disabled:cursor-not-allowed",
-    INPUT_SIZE_CLASSES[size],
-    hasLeftIcon ? INPUT_PL[size].withIcon : INPUT_PL[size].default,
-    hasRightIcon ? INPUT_PR[size].withIcon : INPUT_PR[size].default,
+function LeadingIcon({ children }: { children?: React.ReactNode }) {
+  if (!children) return null;
+  return (
+    <span className="pointer-events-none flex size-4 shrink-0 items-center justify-center text-content-secondary">
+      {children}
+    </span>
+  );
+}
+
+function SideLabel({
+  size,
+  align,
+  children,
+}: {
+  size: TextFieldSize;
+  align: "left" | "right";
+  children?: React.ReactNode;
+}) {
+  if (!children) return null;
+  return (
+    <span
+      className={cn(
+        "shrink-0 select-none whitespace-nowrap text-content-tertiary",
+        align === "right" && "text-right",
+        SIDE_LABEL_TYPOGRAPHY[size],
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function TrailingAdornment({
+  rightIcon,
+  validated,
+}: {
+  rightIcon?: React.ReactNode;
+  validated: boolean;
+}) {
+  if (!rightIcon && !validated) return null;
+  return (
+    <span className="flex shrink-0 items-center gap-2 text-content-secondary">
+      {rightIcon && (
+        <span className="flex size-4 shrink-0 items-center justify-center">{rightIcon}</span>
+      )}
+      {validated && (
+        <span className="pointer-events-none flex size-4 shrink-0 items-center justify-center">
+          <CheckOutlineIcon className="text-success-content" />
+        </span>
+      )}
+    </span>
   );
 }
 
@@ -109,10 +160,11 @@ function warnMissingAccessibleName(label?: string, ariaLabel?: string, ariaLabel
 }
 
 /**
- * A text input field with optional label, helper/error text, and icon slots.
+ * A text input field with optional label, helper/error text, icon slots, and side labels.
  *
- * Provide at least one of `label`, `aria-label`, or `aria-labelledby` for
- * accessibility — a console warning is emitted in development if none are set.
+ * Use `leftLabel` / `rightLabel` for fixed unit or prefix affordances (currency symbol,
+ * country code, domain suffix). Provide at least one of `label`, `aria-label`, or
+ * `aria-labelledby` for accessibility — a console warning is emitted in development if none are set.
  *
  * @example
  * ```tsx
@@ -122,6 +174,11 @@ function warnMissingAccessibleName(label?: string, ariaLabel?: string, ariaLabel
  *   error={!!emailError}
  *   errorMessage={emailError}
  * />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <TextField label="Price" leftLabel="$" rightLabel="USD" placeholder="0.00" />
  * ```
  */
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
@@ -135,6 +192,8 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       validated = false,
       leftIcon,
       rightIcon,
+      leftLabel,
+      rightLabel,
       className,
       id,
       disabled,
@@ -166,6 +225,11 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         )}
 
         <div className={getContainerClassName(size, error, disabled)}>
+          <LeadingIcon>{leftIcon}</LeadingIcon>
+          <SideLabel size={size} align="left">
+            {leftLabel}
+          </SideLabel>
+
           <input
             ref={ref}
             id={inputId}
@@ -173,40 +237,17 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             aria-describedby={bottomText ? helperTextId : undefined}
             aria-invalid={error || undefined}
             className={cn(
-              getInputClassName(size, !!leftIcon, !!(rightIcon || validated)),
+              "h-full min-w-0 flex-1 bg-transparent text-content-primary no-underline placeholder:text-content-tertiary focus:outline-none disabled:cursor-not-allowed",
+              INPUT_TYPOGRAPHY[size],
               "[&[type='search']::-webkit-search-cancel-button]:hidden [&[type='search']::-webkit-search-cancel-button]:appearance-none",
             )}
             {...props}
           />
 
-          {leftIcon && (
-            <div
-              className={cn(
-                "pointer-events-none absolute inset-y-0 left-0 flex items-center text-content-secondary",
-                ICON_INSET[size],
-              )}
-            >
-              <div className="flex size-4 shrink-0 items-center justify-center">{leftIcon}</div>
-            </div>
-          )}
-
-          {(rightIcon || validated) && (
-            <div
-              className={cn(
-                "absolute inset-y-0 right-0 flex items-center gap-2 text-content-secondary",
-                ICON_INSET[size],
-              )}
-            >
-              {rightIcon && (
-                <div className="flex size-4 shrink-0 items-center justify-center">{rightIcon}</div>
-              )}
-              {validated && (
-                <div className="pointer-events-none flex size-4 shrink-0 items-center justify-center">
-                  <CheckOutlineIcon className="text-success-content" />
-                </div>
-              )}
-            </div>
-          )}
+          <SideLabel size={size} align="right">
+            {rightLabel}
+          </SideLabel>
+          <TrailingAdornment rightIcon={rightIcon} validated={validated} />
         </div>
 
         {bottomText && (


### PR DESCRIPTION
## Summary

Migrates the Text Fields (`TextField` / `TextArea` / `PasswordField`) to V2 Input Fields, closing the last gap from the V1→V2 audit: the **Side Label** type. ([ENG-10613](https://linear.app/fanvue/issue/ENG-10613))

- **TextField** — migrated to the V2 flex layout and added the **Side Label** type via new additive props `leftLabel` / `rightLabel` (fixed, non-editable prefix/suffix for a currency symbol, country code, unit or domain). The base filled treatment (`inputs-primary` fill + `border-primary`) was already V2-correct and is preserved, along with all existing states (helper/error/validated/disabled/icons).
- **TextArea** — aligned to the V2 input treatment: `inputs-primary` fill + subtle `border-primary` (it was previously borderless `neutral-alphas`), plus placeholder/label consistency with `TextField`.
- **PasswordField** — inherits all of the above through the `TextField` wrapper; no API change.
- Added stories (Side Label prefix/suffix/both, with-icon, all sizes), unit + a11y tests, and an `App.tsx` demo. Updated the story Figma link to the V2 Input Fields node.

**No breaking changes** — the migration is purely additive to the public API.

## Visual evidence

**Side Label — all sizes (prefix `$` + suffix `USD`)**

![Side label sizes](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-textfield-v2/textfield-v2/tf-sidelabel-sizes.png)

**Side Label — prefix + suffix**

![Side label both](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-textfield-v2/textfield-v2/tf-sidelabel-both.png)

**Side Label — with leading icon**

![Side label with icon](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-textfield-v2/textfield-v2/tf-sidelabel-icon.png)

**TextField — base states (unchanged)**

![TextField states](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-textfield-v2/textfield-v2/tf-all-states.png)

**TextArea — V2 treatment (now filled + bordered)**

![TextArea states](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-textfield-v2/textfield-v2/ta-all-states.png)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (biome)
- [x] Unit + a11y tests (`TextField` / `TextArea` / `PasswordField`) — 125 passed
- [x] `pnpm build`
- [ ] Storybook story (browser) tests in CI
- [ ] Design review of Side Label against V2 Figma

Made with [Cursor](https://cursor.com)