### PR TITLE
feat(DropdownMenu): add avatar and count slots for Feature Menu Item (ENG-10612)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2662,7 +2662,43 @@ function DropdownMenuDemo() {
         <DropdownMenuSearchHeaderDemo />
         <DropdownMenuRadioDemo />
         <DropdownMenuSize32Demo />
+        <DropdownMenuFeatureItemDemo />
       </div>
+    </div>
+  );
+}
+
+function DropdownMenuFeatureItemDemo() {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="typography-description-12px-semibold text-content-secondary">
+        Feature items (avatar + count)
+      </span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="secondary" size="40" rightIcon={<ChevronDownIcon />}>
+            Switch account
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-80">
+          <DropdownMenuItem
+            avatar={<Avatar size={24} fallback="JD" />}
+            trailingIcon={<ChevronRightIcon className="size-4" />}
+          >
+            Jane Doe
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            avatar={<Avatar size={24} fallback="AS" />}
+            description="Product designer"
+            count="12"
+          >
+            Alex Smith
+          </DropdownMenuItem>
+          <DropdownMenuItem leadingIcon={<StarIcon className="size-4" />} count="99+">
+            Favourites
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
 import { userEvent, within } from "storybook/test";
+import { Avatar } from "../Avatar/Avatar";
 import { Button } from "../Button/Button";
+import { ChevronRightIcon } from "../Icons/ChevronRightIcon";
 import { EditIcon } from "../Icons/EditIcon";
 import { StarIcon } from "../Icons/StarIcon";
 import { TrashBinIcon } from "../Icons/TrashBinIcon";
@@ -296,6 +298,71 @@ export const SizeMatrix: Story = {
         </DropdownMenuItem>
         <DropdownMenuItem size="32" destructive>
           Error
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const FeatureItems: Story = {
+  play: openMenu,
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-80">
+        <DropdownMenuItem
+          avatar={<Avatar size={24} fallback="JD" />}
+          trailingIcon={<ChevronRightIcon />}
+        >
+          Jane Doe
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          avatar={<Avatar size={24} fallback="AS" />}
+          description="Product designer"
+          count="12"
+        >
+          Alex Smith
+        </DropdownMenuItem>
+        <DropdownMenuItem leadingIcon={<StarIcon />} count="99+">
+          Favourites
+        </DropdownMenuItem>
+        <DropdownMenuItem leadingIcon={<EditIcon />} description="Update your details">
+          Edit profile
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const FeatureItemStates: Story = {
+  play: openMenu,
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-80">
+        <DropdownMenuLabel position="top">Size 40</DropdownMenuLabel>
+        <DropdownMenuItem avatar={<Avatar size={24} fallback="JD" />} count="3">
+          Default
+        </DropdownMenuItem>
+        <DropdownMenuItem avatar={<Avatar size={24} fallback="JD" />} count="3" selected>
+          Selected
+        </DropdownMenuItem>
+        <DropdownMenuItem avatar={<Avatar size={24} fallback="JD" />} count="3" disabled>
+          Disabled
+        </DropdownMenuItem>
+        <DropdownMenuItem leadingIcon={<TrashBinIcon />} count="3" destructive>
+          Error
+        </DropdownMenuItem>
+        <DropdownMenuLabel>Size 32</DropdownMenuLabel>
+        <DropdownMenuItem size="32" avatar={<Avatar size={24} fallback="JD" />} count="3">
+          Default
+        </DropdownMenuItem>
+        <DropdownMenuItem size="32" leadingIcon={<StarIcon />} count="3" selected>
+          Selected
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -546,6 +546,17 @@ describe("DropdownMenuItem", () => {
       expect(screen.queryByTestId("lead")).not.toBeInTheDocument();
     });
 
+    it("tightens padding so a 24px avatar keeps the 32px row height", () => {
+      renderMenu(
+        <DropdownMenuItem size="32" avatar={<span data-testid="avatar">A</span>} data-testid="item">
+          Jane Doe
+        </DropdownMenuItem>,
+      );
+      const item = screen.getByTestId("item");
+      expect(item).toHaveClass("min-h-8", "py-1");
+      expect(item).not.toHaveClass("py-[7px]");
+    });
+
     it("renders the trailing count", () => {
       renderMenu(<DropdownMenuItem count="12">Messages</DropdownMenuItem>);
       expect(screen.getByText("12")).toBeInTheDocument();

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -32,6 +32,19 @@ describe("DropdownMenu", () => {
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
+
+    it("feature item (avatar + count + description) has no a11y violations", async () => {
+      const { container } = renderMenu(
+        <DropdownMenuItem
+          avatar={<span aria-hidden="true">A</span>}
+          count="12"
+          description="Product designer"
+        >
+          Alex Smith
+        </DropdownMenuItem>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 
   describe("API", () => {
@@ -518,6 +531,24 @@ describe("DropdownMenuItem", () => {
       );
       expect(screen.getByTestId("lead")).toBeInTheDocument();
       expect(screen.getByTestId("trail")).toBeInTheDocument();
+    });
+
+    it("renders the avatar in place of the leading icon", () => {
+      renderMenu(
+        <DropdownMenuItem
+          avatar={<span data-testid="avatar">A</span>}
+          leadingIcon={<span data-testid="lead">L</span>}
+        >
+          Jane Doe
+        </DropdownMenuItem>,
+      );
+      expect(screen.getByTestId("avatar")).toBeInTheDocument();
+      expect(screen.queryByTestId("lead")).not.toBeInTheDocument();
+    });
+
+    it("renders the trailing count", () => {
+      renderMenu(<DropdownMenuItem count="12">Messages</DropdownMenuItem>);
+      expect(screen.getByText("12")).toBeInTheDocument();
     });
 
     it("renders a two-line layout with top-aligned icons when description is set", () => {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -351,10 +351,14 @@ export const DropdownMenuItem = React.forwardRef<
   ) => {
     const normalizedSize = SIZE_NORMALIZED[size];
     const hasDescription = description != null;
+    const hasAvatar = avatar != null;
     const itemClassName = cn(
       "group flex w-full cursor-pointer gap-2 rounded-xs px-3 outline-none",
       hasDescription ? "items-start" : "items-center",
       ITEM_SIZE_CLASSES[normalizedSize],
+      // A 24px avatar would push the compact 32px row past its height with the
+      // default padding; tighten it so the avatar variant keeps the 32px contract.
+      hasAvatar && !hasDescription && normalizedSize === "32" && "py-1",
       "data-[highlighted]:bg-neutral-alphas-50",
       "data-[disabled]:cursor-not-allowed data-[disabled]:text-content-disabled",
       destructive && "text-error-content",

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -275,16 +275,29 @@ const ITEM_SELECTED_TYPOGRAPHY: Record<"40" | "32", string> = {
   "32": "typography-body-small-14px-semibold",
 };
 
+const ITEM_COUNT_TYPOGRAPHY: Record<"40" | "32", string> = {
+  "40": "typography-body-default-16px-regular",
+  "32": "typography-body-small-14px-regular",
+};
+
 export interface DropdownMenuItemProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> {
   /** Height of the menu item row. @default "40" */
   size?: DropdownMenuItemSize;
   /** Applies the destructive (error) treatment. Use for irreversible actions. @default false */
   destructive?: boolean;
-  /** Icon (or other node) rendered before the label. */
+  /** Icon (or other node) rendered before the label. Ignored when {@link DropdownMenuItemProps.avatar} is set. */
   leadingIcon?: React.ReactNode;
+  /**
+   * Leading avatar rendered in place of {@link DropdownMenuItemProps.leadingIcon},
+   * for rows that represent a person or account. Pass an `Avatar` sized to `24`.
+   * Takes precedence over `leadingIcon`.
+   */
+  avatar?: React.ReactNode;
   /** Icon (or other node) rendered after the label. */
   trailingIcon?: React.ReactNode;
+  /** Trailing count or number (e.g. an unread total) rendered before {@link DropdownMenuItemProps.trailingIcon}. */
+  count?: React.ReactNode;
   /**
    * Optional secondary text rendered on a second line below the label. When
    * provided, the row switches to a two-line layout and the leading/trailing
@@ -304,6 +317,11 @@ export interface DropdownMenuItemProps
  * <DropdownMenuItem destructive>Delete</DropdownMenuItem>
  * <DropdownMenuItem leadingIcon={<EditIcon />}>Edit</DropdownMenuItem>
  *
+ * // Feature-rich row with an avatar and a trailing count
+ * <DropdownMenuItem avatar={<Avatar size={24} src={src} />} count="12">
+ *   Jane Doe
+ * </DropdownMenuItem>
+ *
  * // As a link
  * <DropdownMenuItem asChild>
  *   <a href="/settings">Settings</a>
@@ -319,7 +337,9 @@ export const DropdownMenuItem = React.forwardRef<
       size = "40",
       destructive,
       leadingIcon,
+      avatar,
       trailingIcon,
+      count,
       description,
       selected,
       className,
@@ -332,7 +352,7 @@ export const DropdownMenuItem = React.forwardRef<
     const normalizedSize = SIZE_NORMALIZED[size];
     const hasDescription = description != null;
     const itemClassName = cn(
-      "flex w-full cursor-pointer gap-2 rounded-xs px-3 outline-none",
+      "group flex w-full cursor-pointer gap-2 rounded-xs px-3 outline-none",
       hasDescription ? "items-start" : "items-center",
       ITEM_SIZE_CLASSES[normalizedSize],
       "data-[highlighted]:bg-neutral-alphas-50",
@@ -358,14 +378,35 @@ export const DropdownMenuItem = React.forwardRef<
     // 24px title line-height vs 16px icon → 4px (pt-1) centres the icon on it.
     const iconAlignClassName = hasDescription ? "flex shrink-0 items-center pt-1" : null;
 
+    const countNode = count != null && (
+      <span
+        className={cn(
+          "shrink-0 tabular-nums",
+          ITEM_COUNT_TYPOGRAPHY[normalizedSize],
+          destructive
+            ? "text-error-content"
+            : selected
+              ? "text-content-primary-inverted"
+              : "text-content-tertiary",
+          "group-data-[disabled]:text-content-disabled",
+        )}
+      >
+        {count}
+      </span>
+    );
+
     return (
       <DropdownMenuPrimitive.Item ref={ref} className={itemClassName} {...props}>
-        {leadingIcon != null &&
+        {avatar != null ? (
+          <span className="shrink-0">{avatar}</span>
+        ) : (
+          leadingIcon != null &&
           (hasDescription ? (
             <span className={iconAlignClassName!}>{leadingIcon}</span>
           ) : (
             leadingIcon
-          ))}
+          ))
+        )}
         {hasDescription ? (
           <span className="flex min-w-0 flex-1 flex-col gap-0.5">
             <span className="truncate">{children}</span>
@@ -381,6 +422,7 @@ export const DropdownMenuItem = React.forwardRef<
         ) : (
           <span className="min-w-0 flex-1 truncate">{children}</span>
         )}
+        {countNode}
         {trailingIcon != null &&
           (hasDescription ? (
             <span className={iconAlignClassName!}>{trailingIcon}</span>


### PR DESCRIPTION
## Summary

Builds the **V2 Feature Menu Item** (ENG-10612). The base Dropdown Menu is already on V2; the only gap was the richer feature-item row. The Figma models this as a single menu-item component with toggles, and the existing `DropdownMenuItem` already covers leading/trailing icons, description, selected, destructive and sizes 40/32. To reach 1:1 without duplicating a near-identical component, `DropdownMenuItem` is extended **additively** with the two missing slots:

- **`avatar`** — leading 24px avatar that replaces the leading icon for rows representing a person/account (takes precedence over `leadingIcon`).
- **`count`** — trailing count/number (e.g. an unread total), rendered before `trailingIcon`, with correct selected (inverted), disabled and error (destructive) treatments.

No breaking changes — both props are optional and existing usage is untouched.

## Visual evidence

Feature items (avatar, description, count, trailing chevron):

![Feature items](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-feature-menu-item-v2/fmi-items.png)

States — default / selected / disabled / error, sizes 40 & 32:

![Feature item states](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-feature-menu-item-v2/fmi-states.png)

## Changes

- `DropdownMenuItem`: add `avatar` and `count` props (`DropdownMenu.tsx`)
- Stories: `FeatureItems`, `FeatureItemStates` (`DropdownMenu.stories.tsx`)
- Tests: avatar-replaces-icon, count render, feature-item a11y (`DropdownMenu.test.tsx`)
- Demo: Feature items column in `App.tsx`

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (DropdownMenu unit — 52 passed)
- [x] `pnpm build`
- [ ] Storybook visual review of the two new stories
- [ ] Confirm 1:1 with Figma V2 Feature Menu Item

Figma: [V2 Feature Menu Item](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16804-79895)

Made with [Cursor](https://cursor.com)