### PR TITLE
feat(Dialog): expose overlay customization on DialogContent

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -689,6 +689,29 @@ export const WithoutPortal: Story = {
   },
 };
 
+export const CustomOverlay: Story = {
+  name: "Custom Overlay (backdrop blur)",
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open Dialog</Button>
+      </DialogTrigger>
+      <DialogContent overlayProps={{ className: "backdrop-blur-xl" }}>
+        <DialogHeader>
+          <DialogTitle>Custom overlay</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <DialogDescription>
+            `overlayProps` forwards to the default overlay, letting consumers apply a custom
+            backdrop treatment (e.g. the v2 Modal backdrop blur) without replacing it.
+          </DialogDescription>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: openDialog,
+};
+
 export const RemoveMembers: Story = {
   name: "Remove Members",
   render: () => (

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -204,6 +204,14 @@ describe("Dialog", () => {
       expect(baseElement.querySelector(".bg-background-overlay-default")).not.toBeInTheDocument();
     });
 
+    it("forwards overlayProps to the overlay", () => {
+      const { baseElement } = renderDialog({
+        overlayProps: { className: "backdrop-blur-xl" },
+      });
+      const overlay = baseElement.querySelector(".bg-background-overlay-default");
+      expect(overlay).toHaveClass("backdrop-blur-xl");
+    });
+
     it("renders inline when portal is false", () => {
       render(
         <div data-testid="dialog-host">

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -94,6 +94,8 @@ export interface DialogContentProps
    * @default "sheet"
    */
   mobilePresentation?: "sheet" | "card";
+  /** Props forwarded to the default {@link DialogOverlay} when `overlay` is `true`. */
+  overlayProps?: DialogOverlayProps;
 }
 
 const SIZE_CLASSES: Record<NonNullable<DialogContentProps["size"]>, string> = {
@@ -147,6 +149,7 @@ export const DialogContent = React.forwardRef<
       portal = true,
       showMobileHandle = true,
       mobilePresentation = "sheet",
+      overlayProps,
       style,
       onOpenAutoFocus,
       ...props
@@ -155,7 +158,7 @@ export const DialogContent = React.forwardRef<
   ) => {
     const content = (
       <>
-        {overlay && <DialogOverlay />}
+        {overlay && <DialogOverlay {...overlayProps} />}
         <DialogPrimitive.Content
           ref={ref}
           style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}


### PR DESCRIPTION
## Summary
- Adds `overlayProps` to `DialogContentProps`, forwarded to the internal `DialogOverlay` when `overlay` is true — mirrors the existing `DrawerContent` overlay-customization API (same prop name/shape) so the surface stays symmetric between `Dialog` and `Drawer`.
- Purely additive: no behavior or default-styling change when the prop is omitted.

## Motivation
- Long-standing flag **R-18**: the Figma V2 Modal spec (fileKey `S8zFdcOjt4qN4PrwntuCdt`, node `17250:5111`) calls for overlay color `#15151599` + `backdrop-blur` 20px on the Modal backdrop, but `DialogContent` currently renders its own Radix overlay with no way for consumers to customize it (verified on `@fanvue/ui` 3.13.0).
- Downstream: `fanv-ui-internal`'s `SchedulePostModal` has an R-18 code comment blocked on this exact gap.
- `DrawerContent` already exposes `overlayProps`; this PR brings `DialogContent` to parity.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `biome check` on changed files — clean
- [x] `vitest run src/components/Dialog/Dialog.test.tsx` — 27/27 passing, including new `forwards overlayProps to the overlay` test
- [x] Added `CustomOverlay` Storybook story demonstrating `overlayProps` with a custom backdrop-blur class
- Not bumping package version — release is handled by release-please / a human, per repo convention.