### PR TITLE
fix(Dialog): dynamic viewport height + safe-area padding (ENG-12221)

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -654,6 +654,57 @@ export const MobileSheet: Story = {
   play: openDialog,
 };
 
+export const MobileSheetTallContent: Story = {
+  name: "Mobile Sheet — Tall Content (ENG-12221)",
+  tags: ["!autodocs"],
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+    chromatic: {
+      modes: {
+        "light-mobile": { theme: "light", viewport: 375 },
+      },
+    },
+  },
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open Dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Dialog Title</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <p className="typography-body-default-16px-regular mb-3 text-content-secondary">
+            Regression coverage for ENG-12221: on iOS in-app browsers (e.g. Instagram),{" "}
+            <code>vh</code> reports taller than the actually-visible viewport, squishing/clipping
+            sheet content. The sheet is capped by the <code>dialog-max-h-dynamic</code> utility (
+            <code>85dvh</code> with an <code>85vh</code> fallback), stays scrollable, and its bottom
+            padding grows for the safe-area / home-indicator inset instead of clipping the footer
+            buttons.
+          </p>
+          {Array.from({ length: 12 }, (_, i) => `paragraph-${i + 1}`).map((id) => (
+            <p
+              key={id}
+              className="typography-body-default-16px-regular mb-4 text-content-secondary"
+            >
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua.
+            </p>
+          ))}
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary">Cancel</Button>
+          </DialogClose>
+          <Button>Accept</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: openDialog,
+};
+
 export const WithoutPortal: Story = {
   name: "Without Portal",
   render: () => (

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -181,6 +181,41 @@ describe("Dialog", () => {
       expect(document.querySelector(".bg-icons-tertiary")).not.toBeInTheDocument();
     });
 
+    // ENG-12221: iOS in-app browsers (e.g. Instagram) report a `vh` taller than
+    // the actually-visible viewport, so a static `max-h-[85vh]` squishes/clips
+    // dialog content. `dialog-max-h-dynamic` (base.css) declares `max-height`
+    // twice in one rule — `85vh` then `85dvh` — so unsupported-unit browsers keep
+    // the `vh` fallback while modern browsers use the accurate `dvh` value.
+    it("uses the dynamic-viewport-height utility on all mobile presentations", () => {
+      const { rerender } = renderDialog();
+      expect(screen.getByRole("dialog")).toHaveClass("dialog-max-h-dynamic");
+
+      rerender(
+        <Dialog defaultOpen>
+          <DialogContent mobilePresentation="card">
+            <DialogHeader>
+              <DialogTitle>Card</DialogTitle>
+            </DialogHeader>
+          </DialogContent>
+        </Dialog>,
+      );
+      expect(screen.getByRole("dialog")).toHaveClass("dialog-max-h-dynamic");
+    });
+
+    it("pads the bottom sheet for the safe-area inset", () => {
+      renderDialog();
+      expect(screen.getByRole("dialog")).toHaveClass(
+        "pb-[calc(1rem+env(safe-area-inset-bottom,0px))]",
+      );
+    });
+
+    it("does not pad the floating card for the safe-area inset", () => {
+      renderDialog({ mobilePresentation: "card" });
+      expect(screen.getByRole("dialog")).not.toHaveClass(
+        "pb-[calc(1rem+env(safe-area-inset-bottom,0px))]",
+      );
+    });
+
     it("supports controlled open state", async () => {
       const onOpenChange = vi.fn();
       const user = userEvent.setup();

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -177,19 +177,20 @@ export const DialogContent = React.forwardRef<
             mobilePresentation === "card"
               ? // Floating confirmation card (v2-modal): 16px side margins, vertically centered, 32px radius
                 cn(
-                  "inset-x-4 top-1/2 max-h-[85vh] -translate-y-1/2 rounded-xl p-6",
+                  "dialog-max-h-dynamic inset-x-4 top-1/2 -translate-y-1/2 rounded-xl p-6",
                   "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
                   "sm:inset-x-auto",
                 )
               : // Bottom sheet pinned to the viewport bottom edge
                 cn(
-                  "inset-x-0 bottom-0 max-h-[85vh] w-full rounded-t-xl p-4 pt-3",
+                  "dialog-max-h-dynamic inset-x-0 bottom-0 w-full rounded-t-xl p-4 pt-3",
+                  "pb-[calc(1rem+env(safe-area-inset-bottom,0px))]",
                   "data-[state=open]:slide-in-from-bottom-full",
                   "data-[state=closed]:slide-out-to-bottom-full",
                   "sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=open]:zoom-in-95",
                   "sm:data-[state=closed]:slide-out-to-bottom-0 sm:data-[state=closed]:zoom-out-95",
                 ),
-            "sm:inset-auto sm:top-1/2 sm:left-1/2 sm:max-h-[85vh] sm:w-full sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:p-6",
+            "sm:dialog-max-h-dynamic sm:inset-auto sm:top-1/2 sm:left-1/2 sm:w-full sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:p-6",
             "duration-200",
             SIZE_CLASSES[size],
             className,

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -136,6 +136,21 @@
   animation: accordion-collapse 200ms ease-out;
 }
 
+/*
+ * `dvh` reflects the browser chrome actually on screen (e.g. iOS in-app browsers
+ * like Instagram, which report a `vh` taller than what's visible once chrome +
+ * home-indicator inset are subtracted). `dvh` support is what's missing on older
+ * engines, not `vh`, so the fallback must be declared second: an unsupported unit
+ * makes only that declaration invalid, and the browser keeps the prior valid one.
+ * This has to stay a single CSS rule with two declarations — two separate Tailwind
+ * utility classes (`max-h-[85vh] max-h-[85dvh]`) share one `tailwind-merge` conflict
+ * group, so `cn()`/`twMerge` would drop the `vh` one and destroy the fallback.
+ */
+@utility dialog-max-h-dynamic {
+  max-height: 85vh;
+  max-height: 85dvh;
+}
+
 /* Static tokens not in Figma — manually maintained for now */
 @utility typography-medium-caption-xs {
   font-size: 0.625rem;


### PR DESCRIPTION
## Summary

Linear: https://linear.app/fanvue/issue/ENG-12221

Fixes the "squished" half of ENG-12221 ("Fan signup drawer squished + stuck open on mobile web"). This PR addresses the squish only — the "stuck open" bug is a separate root cause (three unsynchronized `<AuthDialog>` mount points in `pandora`) fixed in a companion PR.

**Root cause:** `DialogContent` (`src/components/Dialog/Dialog.tsx`) sizes the mobile sheet/card/desktop variants with a static `max-h-[85vh]` (3 occurrences) and never pads for the bottom safe area. iOS in-app browsers (e.g. Instagram's in-app browser) report a `vh` taller than the actually-visible viewport once browser chrome + the home-indicator inset are subtracted, so the sheet renders taller than what's visible — squishing/clipping content.

**Fix — `vh`/`dvh` fallback technique:**

Added a `dialog-max-h-dynamic` `@utility` in `src/styles/base.css` that declares `max-height` **twice in one CSS rule**:

```css
@utility dialog-max-h-dynamic {
  max-height: 85vh;
  max-height: 85dvh;
}
```

This is the only correct way to get "modern unit with legacy fallback" here. An unsupported CSS unit invalidates *only that declaration* — the browser silently keeps the previously-declared valid one. So browsers without `dvh` support fall back to `85vh`, and modern browsers use the accurate `85dvh`.

Crucially, this **must** be a single CSS rule and not two stacked Tailwind utility classes (`max-h-[85vh] max-h-[85dvh]`). Both classes fall into the same `tailwind-merge` conflict group, so `cn()`/`twMerge` would treat them as conflicting and drop the `85vh` one entirely — destroying the fallback and leaving nothing for browsers that don't support `dvh`. Only a real two-declaration CSS rule (via Tailwind v4's `@utility`) preserves both.

All three `max-h-[85vh]` occurrences in `Dialog.tsx` (card variant, sheet variant, shared `sm:` desktop variant) now use `dialog-max-h-dynamic` (with the existing `sm:` prefix preserved where applicable — Tailwind v4 `@utility` classes support variants).

**Also:** added safe-area bottom padding to the mobile sheet variant (`pb-[calc(1rem+env(safe-area-inset-bottom,0px))]`, alongside the existing `p-4 pt-3`), following the exact pattern already used in `BottomNavigation.tsx` / `MobileStepper.tsx`, so footer content isn't clipped by the home-indicator inset.

## Test plan
- [x] `pnpm lint` (scoped to changed files) — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run src/components/Dialog/Dialog.test.tsx` — 30/30 passing, including new regression tests asserting `dialog-max-h-dynamic` is applied on both sheet and card presentations, and the safe-area padding class is present on the sheet variant only
- [x] Extended the mobile-viewport Storybook story (`Dialog.stories.tsx` → `MobileSheetTallContent`) with tall content at a 375px viewport for visual regression coverage
- [ ] CI (lint/typecheck/test/build) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)