### PR TITLE
feat(ChatMessage): add ChatMessage component

### DIFF
--- a/src/components/ChatMessage/ChatMessage.stories.tsx
+++ b/src/components/ChatMessage/ChatMessage.stories.tsx
@@ -1,0 +1,182 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ChatMessage } from "./ChatMessage";
+
+const AVATAR = "https://i.pravatar.cc/80?img=47";
+
+const meta = {
+  title: "Components/ChatMessage",
+  component: ChatMessage,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18206-9841&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    user: { control: "inline-radio", options: ["sender", "receiver"] },
+    variant: { control: "inline-radio", options: ["text", "typing", "audio", "deleted"] },
+    status: { control: "inline-radio", options: ["delivered", "read"] },
+    online: { control: "boolean" },
+    showAvatar: { control: "boolean" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-[444px] max-w-full px-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ChatMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    user: "receiver",
+    message: "Placeholder message.",
+    time: "16:00",
+    avatarSrc: AVATAR,
+    online: true,
+  },
+};
+
+export const Sender: Story = {
+  args: {
+    user: "sender",
+    message: "Placeholder message.",
+    time: "16:00",
+    status: "read",
+  },
+};
+
+export const LongMessage: Story = {
+  args: {
+    user: "receiver",
+    message:
+      "Hey! Just wanted to give you a quick update on everything we talked about earlier today. I've gone through all of the notes, applied the changes you suggested, and double-checked every detail. Let me know if there's anything else you'd like me to adjust before we finalise and send it over tomorrow.",
+    time: "16:00",
+    avatarSrc: AVATAR,
+    online: true,
+  },
+};
+
+export const Typing: Story = {
+  args: {
+    user: "receiver",
+    variant: "typing",
+    avatarSrc: AVATAR,
+    online: true,
+  },
+};
+
+export const Audio: Story = {
+  args: {
+    user: "sender",
+    variant: "audio",
+    audioDuration: "0:05",
+    time: "16:00",
+    status: "read",
+  },
+};
+
+export const Deleted: Story = {
+  args: {
+    user: "receiver",
+    variant: "deleted",
+    time: "16:00",
+    avatarSrc: AVATAR,
+    online: true,
+  },
+};
+
+/** Every variant, for both sender and receiver, as it appears in the design. */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <ChatMessage user="sender" variant="typing" />
+      <ChatMessage user="receiver" variant="typing" avatarSrc={AVATAR} online />
+      <ChatMessage
+        user="receiver"
+        message="Placeholder message."
+        time="16:00"
+        avatarSrc={AVATAR}
+        online
+      />
+      <ChatMessage user="sender" message="Placeholder message." time="16:00" />
+      <ChatMessage
+        user="receiver"
+        message="Placeholder message sits here, please change me."
+        time="16:00"
+        avatarSrc={AVATAR}
+        online
+      />
+      <ChatMessage
+        user="sender"
+        message="Placeholder message sits here, please change me."
+        time="16:00"
+      />
+      <ChatMessage
+        user="receiver"
+        variant="audio"
+        audioDuration="0:05"
+        time="16:00"
+        avatarSrc={AVATAR}
+        online
+      />
+      <ChatMessage user="sender" variant="audio" audioDuration="0:05" time="16:00" />
+      <ChatMessage user="receiver" variant="deleted" time="16:00" avatarSrc={AVATAR} online />
+      <ChatMessage user="sender" variant="deleted" time="16:00" />
+    </div>
+  ),
+};
+
+/** The blue read receipt shown once a sender message has been read. */
+export const ReadReceipt: Story = {
+  args: {
+    user: "sender",
+    message: "Placeholder message.",
+    time: "16:00",
+    status: "read",
+  },
+};
+
+/** A short conversation showing grouped bubbles and avatar reservation. */
+export const Conversation: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <ChatMessage
+        user="receiver"
+        message="Hey! Are you free later?"
+        time="15:58"
+        avatarSrc={AVATAR}
+        online
+      />
+      <ChatMessage user="sender" message="Yeah, after 5." time="15:59" status="read" />
+      <ChatMessage
+        user="sender"
+        message="Want to grab something to eat around the corner?"
+        time="15:59"
+        status="read"
+      />
+      <ChatMessage user="receiver" variant="typing" avatarSrc={AVATAR} online />
+      <ChatMessage
+        user="receiver"
+        variant="audio"
+        audioDuration="0:12"
+        time="16:01"
+        avatarSrc={AVATAR}
+        online
+      />
+      <ChatMessage user="receiver" variant="deleted" time="16:02" showAvatar={false} />
+      <ChatMessage
+        user="sender"
+        message="Perfect, see you there!"
+        time="16:03"
+        status="delivered"
+      />
+    </div>
+  ),
+};

--- a/src/components/ChatMessage/ChatMessage.test.tsx
+++ b/src/components/ChatMessage/ChatMessage.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { ChatMessage } from "./ChatMessage";
+
+describe("ChatMessage", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      const { container } = render(<ChatMessage className="custom-class" message="Hi" />);
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("renders the message text", () => {
+      render(<ChatMessage message="Placeholder message." />);
+      expect(screen.getByText("Placeholder message.")).toBeInTheDocument();
+    });
+
+    it("renders the timestamp", () => {
+      render(<ChatMessage variant="audio" audioDuration="0:05" time="16:00" />);
+      expect(screen.getByText("16:00")).toBeInTheDocument();
+    });
+
+    it("forwards ref", () => {
+      const ref = React.createRef<HTMLDivElement>();
+      render(<ChatMessage ref={ref} message="Hi" />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+  });
+
+  describe("sender vs receiver", () => {
+    it("right-aligns sender messages", () => {
+      const { container } = render(<ChatMessage user="sender" message="Hi" />);
+      expect(container.firstChild).toHaveClass("justify-end");
+    });
+
+    it("left-aligns receiver messages", () => {
+      const { container } = render(<ChatMessage user="receiver" message="Hi" />);
+      expect(container.firstChild).toHaveClass("justify-start");
+    });
+
+    it("renders an avatar for receiver messages", () => {
+      render(<ChatMessage user="receiver" message="Hi" avatarFallback="JD" />);
+      expect(screen.getByTestId("avatar")).toBeInTheDocument();
+    });
+
+    it("does not render an avatar for sender messages", () => {
+      render(<ChatMessage user="sender" message="Hi" />);
+      expect(screen.queryByTestId("avatar")).not.toBeInTheDocument();
+    });
+
+    it("reserves avatar space for receiver messages when the avatar is hidden", () => {
+      render(<ChatMessage user="receiver" message="Hi" showAvatar={false} />);
+      expect(screen.queryByTestId("avatar")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("delivery status", () => {
+    it("shows a delivered tick on sender messages", () => {
+      render(<ChatMessage user="sender" message="Hi" time="16:00" />);
+      expect(screen.getByRole("img", { name: "Delivered" })).toBeInTheDocument();
+    });
+
+    it("shows a read tick when status is read", () => {
+      render(<ChatMessage user="sender" message="Hi" time="16:00" status="read" />);
+      expect(screen.getByRole("img", { name: "Read" })).toBeInTheDocument();
+    });
+
+    it("does not show a tick on receiver messages", () => {
+      render(<ChatMessage user="receiver" message="Hi" time="16:00" />);
+      expect(screen.queryByRole("img", { name: "Delivered" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("typing variant", () => {
+    it("exposes the typing indicator with the default label", () => {
+      render(<ChatMessage user="receiver" variant="typing" />);
+      expect(screen.getByRole("status", { name: "Typing" })).toBeInTheDocument();
+    });
+
+    it("supports a custom typing label", () => {
+      render(<ChatMessage user="receiver" variant="typing" typingLabel="Jane is typing" />);
+      expect(screen.getByRole("status", { name: "Jane is typing" })).toBeInTheDocument();
+    });
+  });
+
+  describe("deleted variant", () => {
+    it("renders the default deleted label", () => {
+      render(<ChatMessage variant="deleted" time="16:00" />);
+      expect(screen.getByText("Message deleted")).toBeInTheDocument();
+      expect(screen.getByText("16:00")).toBeInTheDocument();
+    });
+
+    it("supports a custom deleted label", () => {
+      render(<ChatMessage variant="deleted" deletedLabel="Removed" />);
+      expect(screen.getByText("Removed")).toBeInTheDocument();
+    });
+  });
+
+  describe("audio variant", () => {
+    it("toggles play and pause when uncontrolled", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<ChatMessage variant="audio" audioDuration="0:05" onPlayingChange={handleChange} />);
+
+      const button = screen.getByRole("button", { name: "Play" });
+      await user.click(button);
+
+      expect(handleChange).toHaveBeenCalledWith(true);
+      expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+    });
+
+    it("respects the controlled playing prop", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <ChatMessage variant="audio" audioDuration="0:05" playing onPlayingChange={handleChange} />,
+      );
+
+      const button = screen.getByRole("button", { name: "Pause" });
+      await user.click(button);
+
+      expect(handleChange).toHaveBeenCalledWith(false);
+      // Stays paused because the parent controls the state.
+      expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+    });
+
+    it("renders the duration", () => {
+      render(<ChatMessage variant="audio" audioDuration="1:23" />);
+      expect(screen.getByText("1:23")).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations for a text message", async () => {
+      const { container } = render(
+        <ChatMessage user="sender" message="Placeholder message." time="16:00" status="read" />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations for an audio message", async () => {
+      const { container } = render(
+        <ChatMessage
+          user="receiver"
+          variant="audio"
+          audioDuration="0:05"
+          time="16:00"
+          avatarFallback="JD"
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations for a typing indicator", async () => {
+      const { container } = render(
+        <ChatMessage user="receiver" variant="typing" avatarFallback="JD" />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/ChatMessage/ChatMessage.tsx
+++ b/src/components/ChatMessage/ChatMessage.tsx
@@ -1,0 +1,337 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { Avatar } from "../Avatar/Avatar";
+import { DoubleTickIcon } from "../Icons/DoubleTickIcon";
+import { TrashIcon } from "../Icons/TrashIcon";
+
+/** Who sent the message. */
+export type ChatMessageUser = "sender" | "receiver";
+
+/** The kind of content the message carries. */
+export type ChatMessageVariant = "text" | "typing" | "audio" | "deleted";
+
+/** Delivery status shown alongside sender messages. */
+export type ChatMessageStatus = "delivered" | "read";
+
+export interface ChatMessageProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Who sent the message. `"sender"` is the current user (right-aligned, green
+   * bubble, delivery tick). `"receiver"` is the other party (left-aligned, grey
+   * bubble, with avatar). @default "receiver"
+   */
+  user?: ChatMessageUser;
+  /** The kind of content the message carries. @default "text" */
+  variant?: ChatMessageVariant;
+  /** Message body for the `"text"` variant. Keep it to inline content. */
+  message?: React.ReactNode;
+  /** Timestamp shown with the message, e.g. `"16:00"`. */
+  time?: string;
+  /**
+   * Delivery status shown on sender messages (a double tick). Ignored for
+   * receiver messages. `"read"` renders the tick in the read colour. @default "delivered"
+   */
+  status?: ChatMessageStatus;
+  /** Duration label for the `"audio"` variant, e.g. `"0:05"`. @default "0:00" */
+  audioDuration?: string;
+  /**
+   * Relative bar heights (values `0`–`1`) for the `"audio"` waveform. Defaults
+   * to a flat row of dots matching the unplayed design state.
+   */
+  waveform?: number[];
+  /** Whether the audio is playing (controlled). Pairs with {@link onPlayingChange}. */
+  playing?: boolean;
+  /** Initial playing state when uncontrolled. @default false */
+  defaultPlaying?: boolean;
+  /** Fired when the audio play/pause button is pressed, with the next playing state. */
+  onPlayingChange?: (playing: boolean) => void;
+  /** Render the receiver avatar. Reserves the avatar space when `false` so grouped bubbles stay aligned. @default true */
+  showAvatar?: boolean;
+  /** Avatar image URL for receiver messages. */
+  avatarSrc?: string;
+  /** Avatar alt text. @default "Avatar" */
+  avatarAlt?: string;
+  /** Avatar fallback (initials or icon) shown before the image loads. */
+  avatarFallback?: React.ReactNode;
+  /** Show the online indicator on the receiver avatar. @default false */
+  online?: boolean;
+  /** Accessible label for the typing indicator. @default "Typing" */
+  typingLabel?: string;
+  /** Text shown for the `"deleted"` variant. @default "Message deleted" */
+  deletedLabel?: string;
+  /** Accessible label for the audio play button. @default "Play" */
+  playLabel?: string;
+  /** Accessible label for the audio pause button. @default "Pause" */
+  pauseLabel?: string;
+}
+
+const DEFAULT_WAVEFORM = Array.from({ length: 64 }, () => 0);
+const WAVEFORM_MIN_HEIGHT = 4;
+const WAVEFORM_MAX_HEIGHT = 24;
+
+const bubbleColors: Record<ChatMessageUser, string> = {
+  sender: "bg-messages-background-sender border-messages-background-sender-stroke",
+  receiver: "bg-messages-background-receiver border-messages-background-receiver-2",
+};
+
+/** The timestamp and, for sender messages, the delivery tick. */
+function ChatMessageMeta({
+  time,
+  showTick,
+  status,
+  className,
+}: {
+  time?: string;
+  showTick: boolean;
+  status: ChatMessageStatus;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "typography-description-12px-regular inline-flex items-center gap-1 whitespace-nowrap text-content-secondary leading-none",
+        className,
+      )}
+    >
+      {time ? <time>{time}</time> : null}
+      {showTick ? (
+        // The 24px geometry (stroked) scaled to 16px — the icon's 16px variant
+        // is filled and renders as a blob at this size.
+        <DoubleTickIcon
+          size={24}
+          aria-hidden={false}
+          role="img"
+          aria-label={status === "read" ? "Read" : "Delivered"}
+          className={cn(
+            "size-4 shrink-0",
+            status === "read" ? "text-messages-read" : "text-icons-disabled",
+          )}
+        />
+      ) : null}
+    </span>
+  );
+}
+
+/** Three dots hinting that the other party is composing a message. */
+function TypingIndicator({ label }: { label: string }) {
+  const dot = "size-2 shrink-0 rounded-full motion-safe:animate-bounce";
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: <output> is not appropriate for a typing indicator; role="status" is the correct live-region pattern
+    <span role="status" aria-label={label} className="flex items-center gap-2 px-0.5 py-1">
+      <span className={cn(dot, "bg-content-primary")} />
+      <span className={cn(dot, "bg-neutral-alphas-700 [animation-delay:150ms]")} />
+      <span className={cn(dot, "bg-neutral-alphas-400 [animation-delay:300ms]")} />
+    </span>
+  );
+}
+
+/** A static bar-graph waveform for voice messages. */
+function Waveform({ bars }: { bars: number[] }) {
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden" aria-hidden>
+      {bars.map((amplitude, index) => {
+        const clamped = Math.min(1, Math.max(0, amplitude));
+        const height = WAVEFORM_MIN_HEIGHT + clamped * (WAVEFORM_MAX_HEIGHT - WAVEFORM_MIN_HEIGHT);
+        return (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: bars are positional and have no stable id
+            key={index}
+            className="w-1 shrink-0 rounded-3xs bg-messages-waveform-default"
+            style={{ height }}
+          />
+        );
+      })}
+    </span>
+  );
+}
+
+/** Bare play triangle glyph (the enclosing circle comes from the button). */
+function PlayGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="size-6">
+      <path d="M8 5.14v13.72a1 1 0 0 0 1.54.84l10.28-6.86a1 1 0 0 0 0-1.68L9.54 4.3A1 1 0 0 0 8 5.14Z" />
+    </svg>
+  );
+}
+
+/** Bare pause glyph. */
+function PauseGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="size-6">
+      <rect x="7" y="5" width="3.5" height="14" rx="1" />
+      <rect x="13.5" y="5" width="3.5" height="14" rx="1" />
+    </svg>
+  );
+}
+
+/**
+ * A single chat message rendered as a bubble. Sender messages sit on the right
+ * with a green bubble and a delivery tick; receiver messages sit on the left
+ * with a grey bubble and an avatar. Supports plain text, a typing indicator, a
+ * voice message with waveform, and a deleted-message placeholder.
+ *
+ * Text bubbles place the timestamp inline after short messages and drop it to
+ * the bottom-right corner once the text wraps, so no variant switch is needed
+ * for short versus long content.
+ *
+ * @example
+ * ```tsx
+ * <ChatMessage user="sender" message="On my way!" time="16:00" status="read" />
+ * <ChatMessage user="receiver" message="See you soon" time="16:01" avatarSrc="/jane.jpg" online />
+ * <ChatMessage user="receiver" variant="typing" avatarSrc="/jane.jpg" />
+ * ```
+ */
+export const ChatMessage = React.forwardRef<HTMLDivElement, ChatMessageProps>(
+  (
+    {
+      className,
+      user = "receiver",
+      variant = "text",
+      message,
+      time,
+      status = "delivered",
+      audioDuration = "0:00",
+      waveform,
+      playing,
+      defaultPlaying = false,
+      onPlayingChange,
+      showAvatar = true,
+      avatarSrc,
+      avatarAlt,
+      avatarFallback,
+      online = false,
+      typingLabel = "Typing",
+      deletedLabel = "Message deleted",
+      playLabel = "Play",
+      pauseLabel = "Pause",
+      ...props
+    },
+    ref,
+  ) => {
+    const isSender = user === "sender";
+    const showTick = isSender;
+
+    const [internalPlaying, setInternalPlaying] = React.useState(defaultPlaying);
+    const isPlaying = playing ?? internalPlaying;
+    const togglePlaying = () => {
+      const next = !isPlaying;
+      if (playing === undefined) setInternalPlaying(next);
+      onPlayingChange?.(next);
+    };
+
+    const bubbleBase = cn(
+      "w-fit min-w-0 max-w-full rounded-md border border-solid",
+      bubbleColors[user],
+    );
+    const hasMeta = Boolean(time) || showTick;
+
+    let bubble: React.ReactNode;
+
+    if (variant === "typing") {
+      bubble = (
+        <div className={cn(bubbleBase, "px-3 py-2")}>
+          <TypingIndicator label={typingLabel} />
+        </div>
+      );
+    } else if (variant === "deleted") {
+      bubble = (
+        <div className={cn(bubbleBase, "flex items-baseline gap-6 px-3 py-2 opacity-60")}>
+          <span className="flex items-center gap-2">
+            <TrashIcon size={16} className="shrink-0 text-content-primary" />
+            <span className="typography-body-default-16px-regular whitespace-nowrap text-content-primary">
+              {deletedLabel}
+            </span>
+          </span>
+          {hasMeta ? <ChatMessageMeta time={time} showTick={showTick} status={status} /> : null}
+        </div>
+      );
+    } else if (variant === "audio") {
+      bubble = (
+        <div className={cn(bubbleBase, "flex w-full flex-col p-2")}>
+          <div className="flex w-full flex-col items-start gap-2 px-1">
+            <div className="flex w-full items-center gap-3 pt-1">
+              <button
+                type="button"
+                onClick={togglePlaying}
+                aria-pressed={isPlaying}
+                aria-label={isPlaying ? pauseLabel : playLabel}
+                className={cn(
+                  "flex size-12 shrink-0 items-center justify-center rounded-full bg-buttons-secondary-default text-icons-primary",
+                  "focus-visible:shadow-focus-ring focus-visible:outline-none motion-safe:transition-colors motion-safe:duration-150",
+                )}
+              >
+                {isPlaying ? <PauseGlyph /> : <PlayGlyph />}
+              </button>
+              <Waveform bars={waveform ?? DEFAULT_WAVEFORM} />
+              <span className="typography-body-small-14px-regular whitespace-nowrap text-content-primary">
+                {audioDuration}
+              </span>
+            </div>
+            {hasMeta ? (
+              <ChatMessageMeta
+                time={time}
+                showTick={showTick}
+                status={status}
+                className="self-end"
+              />
+            ) : null}
+          </div>
+        </div>
+      );
+    } else {
+      // "text": the message and timestamp share a wrapping row. A brief message
+      // keeps the time inline (24px gap = the design's Short treatment); once the
+      // text wraps, the time drops to its own line bottom-right (the Default
+      // treatment). No length prop needed — the layout adapts to the content.
+      bubble = (
+        <div className={cn(bubbleBase, "px-3 py-2")}>
+          <div className="flex flex-wrap items-baseline justify-end gap-x-6 gap-y-2">
+            <p className="typography-body-default-16px-regular m-0 min-w-0 break-words text-content-primary">
+              {message}
+            </p>
+            {hasMeta ? (
+              <ChatMessageMeta
+                time={time}
+                showTick={showTick}
+                status={status}
+                className="shrink-0"
+              />
+            ) : null}
+          </div>
+        </div>
+      );
+    }
+
+    const alignItems = variant === "typing" || variant === "deleted" ? "items-center" : "items-end";
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex min-h-10 w-full gap-2",
+          alignItems,
+          isSender ? "justify-end" : "justify-start",
+          className,
+        )}
+        {...props}
+      >
+        {!isSender &&
+          (showAvatar ? (
+            <div className="relative flex shrink-0">
+              <Avatar size={40} src={avatarSrc} alt={avatarAlt} fallback={avatarFallback} />
+              {online ? (
+                <span
+                  aria-hidden="true"
+                  className="absolute right-0 bottom-0 size-2.5 rounded-full border border-border-background bg-messages-status-active"
+                />
+              ) : null}
+            </div>
+          ) : (
+            <div aria-hidden="true" className="w-10 shrink-0" />
+          ))}
+        {bubble}
+      </div>
+    );
+  },
+);
+
+ChatMessage.displayName = "ChatMessage";

--- a/src/components/ChatMessage/ChatMessage.tsx
+++ b/src/components/ChatMessage/ChatMessage.tsx
@@ -1,16 +1,13 @@
 import * as React from "react";
-import { cn } from "../../utils/cn";
+import { cn } from "@/utils/cn";
 import { Avatar } from "../Avatar/Avatar";
 import { DoubleTickIcon } from "../Icons/DoubleTickIcon";
 import { TrashIcon } from "../Icons/TrashIcon";
 
-/** Who sent the message. */
 export type ChatMessageUser = "sender" | "receiver";
 
-/** The kind of content the message carries. */
 export type ChatMessageVariant = "text" | "typing" | "audio" | "deleted";
 
-/** Delivery status shown alongside sender messages. */
 export type ChatMessageStatus = "delivered" | "read";
 
 export interface ChatMessageProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -73,7 +70,6 @@ const bubbleColors: Record<ChatMessageUser, string> = {
   receiver: "bg-messages-background-receiver border-messages-background-receiver-2",
 };
 
-/** The timestamp and, for sender messages, the delivery tick. */
 function ChatMessageMeta({
   time,
   showTick,
@@ -111,7 +107,6 @@ function ChatMessageMeta({
   );
 }
 
-/** Three dots hinting that the other party is composing a message. */
 function TypingIndicator({ label }: { label: string }) {
   const dot = "size-2 shrink-0 rounded-full motion-safe:animate-bounce";
   return (
@@ -124,7 +119,6 @@ function TypingIndicator({ label }: { label: string }) {
   );
 }
 
-/** A static bar-graph waveform for voice messages. */
 function Waveform({ bars }: { bars: number[] }) {
   return (
     <span className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden" aria-hidden>
@@ -144,7 +138,6 @@ function Waveform({ bars }: { bars: number[] }) {
   );
 }
 
-/** Bare play triangle glyph (the enclosing circle comes from the button). */
 function PlayGlyph() {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="size-6">
@@ -153,7 +146,6 @@ function PlayGlyph() {
   );
 }
 
-/** Bare pause glyph. */
 function PauseGlyph() {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="size-6">

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,13 @@ export type {
 } from "./components/ChatInput/ChatInput";
 export { ChatInput } from "./components/ChatInput/ChatInput";
 export type {
+  ChatMessageProps,
+  ChatMessageStatus,
+  ChatMessageUser,
+  ChatMessageVariant,
+} from "./components/ChatMessage/ChatMessage";
+export { ChatMessage } from "./components/ChatMessage/ChatMessage";
+export type {
   CheckboxProps,
   CheckboxSize,
 } from "./components/Checkbox/Checkbox";


### PR DESCRIPTION
Adds a ChatMessage component to the design system covering sender and receiver bubbles, short and long text, voice notes with a waveform player, the typing indicator, deleted-message placeholders, and delivery receipts.