### PR TITLE
feat(SubscribeButton): add dedicated V2 subscribe button (ENG-11784)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,6 +202,7 @@ import {
   Stepper,
   StepperStep,
   StopIcon,
+  SubscribeButton,
   SuccessIcon,
   SunIcon,
   Support2Icon,
@@ -2199,6 +2200,39 @@ function LinkDemo() {
             </Link>
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function SubscribeButtonDemo() {
+  return (
+    <div id="subscribebutton" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Subscribe Button</h2>
+      <div className="flex flex-wrap items-center gap-4">
+        <SubscribeButton variant="primary" price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="secondary" price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="tertiary" price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="outline" price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="brand" price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="primary" price="$9.99/mo" />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 rounded-xs bg-surface-primary-inverted p-4">
+        <SubscribeButton variant="primary" negative price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="secondary" negative price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="tertiary" negative price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton variant="outline" negative price="$9.99/mo" discount="$19.99" />
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <SubscribeButton size="48" price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton size="40" price="$9.99/mo" discount="$19.99" />
+        <SubscribeButton size="32" price="$9.99/mo" discount="$19.99" />
+      </div>
+
+      <div className="w-80">
+        <SubscribeButton variant="brand" fullWidth price="$9.99/mo" discount="$19.99" />
       </div>
     </div>
   );
@@ -5250,6 +5284,7 @@ function App() {
     { id: "badge", label: "Badge" },
     { id: "bottom-navigation", label: "Bottom Navigation" },
     { id: "button", label: "Button" },
+    { id: "subscribebutton", label: "Subscribe Button" },
     { id: "card", label: "Card" },
     { id: "charts", label: "Charts" },
     { id: "checkbox", label: "Checkbox" },
@@ -5429,6 +5464,9 @@ function App() {
 
             {/* Button */}
             <ButtonDemo />
+
+            {/* Subscribe Button */}
+            <SubscribeButtonDemo />
 
             {/* Badge */}
             <BadgeDemo />

--- a/src/components/SubscribeButton/SubscribeButton.stories.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SubscribeButton } from "./SubscribeButton";
+
+const meta = {
+  title: "Components/SubscribeButton",
+  component: SubscribeButton,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16800-10417",
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    children: "Join now",
+    price: "$9.99/mo",
+    discount: "$19.99",
+    variant: "primary",
+    size: "48",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary", "tertiary", "outline", "brand"],
+    },
+    size: {
+      control: "select",
+      options: ["48", "40", "32"],
+    },
+    negative: { control: "boolean" },
+    fullWidth: { control: "boolean" },
+  },
+} satisfies Meta<typeof SubscribeButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Brand: Story = {
+  args: { variant: "brand" },
+};
+
+export const WithoutDiscount: Story = {
+  args: { discount: undefined },
+};
+
+export const FullWidth: Story = {
+  args: { fullWidth: true },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      <SubscribeButton {...args} variant="primary" />
+      <SubscribeButton {...args} variant="secondary" />
+      <SubscribeButton {...args} variant="tertiary" />
+      <SubscribeButton {...args} variant="outline" />
+      <SubscribeButton {...args} variant="brand" />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex flex-col items-start gap-3">
+      <SubscribeButton {...args} size="48" />
+      <SubscribeButton {...args} size="40" />
+      <SubscribeButton {...args} size="32" />
+    </div>
+  ),
+};
+
+export const Negative: Story = {
+  args: { negative: true },
+  parameters: { backgrounds: { default: "dark" } },
+  decorators: [
+    (Story) => (
+      <div className="rounded-2xl bg-neutral-900 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      <SubscribeButton {...args} variant="primary" />
+      <SubscribeButton {...args} variant="secondary" />
+      <SubscribeButton {...args} variant="tertiary" />
+      <SubscribeButton {...args} variant="outline" />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/src/components/SubscribeButton/SubscribeButton.test.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { SubscribeButton } from "./SubscribeButton";
+
+describe("SubscribeButton", () => {
+  describe("API", () => {
+    it("renders the label, price, and struck-through discount", () => {
+      render(
+        <SubscribeButton price="$9.99/mo" discount="$19.99">
+          Join now
+        </SubscribeButton>,
+      );
+      expect(screen.getByText("Join now")).toBeInTheDocument();
+      expect(screen.getByText("$9.99/mo")).toBeInTheDocument();
+      expect(screen.getByText("$19.99")).toHaveClass("line-through");
+    });
+
+    it('defaults the label to "Join now"', () => {
+      render(<SubscribeButton price="$9.99/mo" />);
+      expect(screen.getByText("Join now")).toBeInTheDocument();
+    });
+
+    it("applies a custom className", () => {
+      render(
+        <SubscribeButton className="custom" price="$9.99/mo">
+          Subscribe
+        </SubscribeButton>,
+      );
+      expect(screen.getByRole("button")).toHaveClass("custom");
+    });
+
+    it("forwards ref to the underlying button", () => {
+      const ref = { current: null as HTMLButtonElement | null };
+      render(
+        <SubscribeButton ref={ref} price="$9.99/mo">
+          Subscribe
+        </SubscribeButton>,
+      );
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    it("fires onClick", async () => {
+      const onClick = vi.fn();
+      render(
+        <SubscribeButton price="$9.99/mo" onClick={onClick}>
+          Subscribe
+        </SubscribeButton>,
+      );
+      screen.getByRole("button").click();
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it("disables interaction when disabled", () => {
+      render(
+        <SubscribeButton disabled price="$9.99/mo">
+          Subscribe
+        </SubscribeButton>,
+      );
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+  });
+
+  describe("accessible name", () => {
+    it("derives the name from the label and pricing", () => {
+      render(
+        <SubscribeButton price="$9.99/mo" discount="$19.99">
+          Join now
+        </SubscribeButton>,
+      );
+      expect(
+        screen.getByRole("button", { name: "Join now, $9.99/mo, was $19.99" }),
+      ).toBeInTheDocument();
+    });
+
+    it("respects a caller-provided aria-label", () => {
+      render(
+        <SubscribeButton aria-label="Start membership" price="$9.99/mo">
+          Join now
+        </SubscribeButton>,
+      );
+      expect(screen.getByRole("button", { name: "Start membership" })).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(
+        <SubscribeButton price="$9.99/mo" discount="$19.99">
+          Join now
+        </SubscribeButton>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/SubscribeButton/SubscribeButton.tsx
+++ b/src/components/SubscribeButton/SubscribeButton.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { Button, type ButtonProps } from "../Button/Button";
+
+/** Visual style variant of the subscribe button. Mirrors the V2 Subscribe Button "Type" set (`brand` is Figma's "Upsell"). */
+export type SubscribeButtonVariant = "primary" | "secondary" | "tertiary" | "outline" | "brand";
+
+/** Height of the subscribe button in pixels. */
+export type SubscribeButtonSize = "48" | "40" | "32";
+
+export interface SubscribeButtonProps
+  extends Omit<
+    ButtonProps,
+    "variant" | "size" | "price" | "discount" | "leftIcon" | "rightIcon" | "asChild"
+  > {
+  /** Visual style variant. `brand` is the Figma "Upsell" (green) type. @default "primary" */
+  variant?: SubscribeButtonVariant;
+  /** Height of the button in pixels. @default "48" */
+  size?: SubscribeButtonSize;
+  /** Current price shown on the trailing side (e.g. `"$9.99/mo"`). */
+  price: string;
+  /** Previous price rendered struck-through before {@link SubscribeButtonProps.price}. */
+  discount?: string;
+  /** Leading action label. @default "Join now" */
+  children?: React.ReactNode;
+}
+
+const OLD_PRICE_TYPOGRAPHY: Record<SubscribeButtonSize, string> = {
+  "48": "typography-body-small-14px-regular",
+  "40": "typography-body-small-14px-regular",
+  "32": "typography-description-12px-regular",
+};
+
+function warnMissingAccessibleName(hasTextLabel: boolean, ariaLabel?: string) {
+  if (process.env.NODE_ENV !== "production" && !hasTextLabel && !ariaLabel) {
+    console.warn(
+      "SubscribeButton: no accessible name could be derived from a string `children`. Pass an `aria-label` so the action and price are announced.",
+    );
+  }
+}
+
+/**
+ * A subscription / purchase button pairing an action label with the current
+ * price and an optional struck-through previous price. Built on {@link Button},
+ * so it inherits the same variants, sizes, `negative` dark-surface treatment,
+ * `fullWidth`, loading, and disabled behaviour.
+ *
+ * The accessible name defaults to the label plus pricing (e.g. `"Join now, $9.99,
+ * was $19.99"`); pass `aria-label` to override.
+ *
+ * @example
+ * ```tsx
+ * <SubscribeButton price="$9.99/mo" discount="$19.99" variant="brand" fullWidth>
+ *   Join now
+ * </SubscribeButton>
+ * ```
+ */
+export const SubscribeButton = React.forwardRef<HTMLButtonElement, SubscribeButtonProps>(
+  ({ variant = "primary", size = "48", price, discount, children = "Join now", ...props }, ref) => {
+    const labelText = typeof children === "string" ? children : undefined;
+    warnMissingAccessibleName(Boolean(labelText?.trim()), props["aria-label"]);
+
+    const accessibleName =
+      props["aria-label"] ??
+      [labelText, price, discount ? `was ${discount}` : null].filter(Boolean).join(", ");
+
+    return (
+      <Button ref={ref} variant={variant} size={size} {...props} aria-label={accessibleName}>
+        <span className="min-w-0 flex-1 truncate text-left">{children}</span>
+        <span className="flex shrink-0 items-center gap-2" aria-hidden="true">
+          {discount && (
+            <span className={cn(OLD_PRICE_TYPOGRAPHY[size], "line-through")}>{discount}</span>
+          )}
+          <span>{price}</span>
+        </span>
+      </Button>
+    );
+  },
+);
+
+SubscribeButton.displayName = "SubscribeButton";

--- a/src/index.ts
+++ b/src/index.ts
@@ -541,7 +541,6 @@ export type { WifiOffIconProps } from "./components/Icons/WifiOffIcon";
 export { WifiOffIcon } from "./components/Icons/WifiOffIcon";
 export { WifiOnIcon } from "./components/Icons/WifiOnIcon";
 export { WrenchIcon } from "./components/Icons/WrenchIcon";
-
 export type {
   InfoBoxAction,
   InfoBoxContentProps,
@@ -680,6 +679,12 @@ export type {
   StepperStepState,
 } from "./components/Stepper/StepperStep";
 export { StepperStep } from "./components/Stepper/StepperStep";
+export type {
+  SubscribeButtonProps,
+  SubscribeButtonSize,
+  SubscribeButtonVariant,
+} from "./components/SubscribeButton/SubscribeButton";
+export { SubscribeButton } from "./components/SubscribeButton/SubscribeButton";
 export type { SwitchProps, SwitchSize } from "./components/Switch/Switch";
 export { Switch } from "./components/Switch/Switch";
 export type {


### PR DESCRIPTION
## Summary

Adds a dedicated **`SubscribeButton`** component (Linear [ENG-11784](https://linear.app/fanvue/issue/ENG-11784)), extracting the subscription/purchase button into its own component instead of the `price`/`discount` props folded into `Button`.

- Built on top of `Button`, so it inherits the same variants, sizes, `negative` dark-surface treatment, `fullWidth`, loading and disabled behaviour — **no new variant system, non-breaking**.
- Pairs a leading action label (default `"Join now"`) with a trailing price cluster: struck-through discount + current price.
- Variants: `primary` / `secondary` / `tertiary` / `outline` / `brand` (Figma "Upsell"). Sizes: `48` / `40` / `32`.
- Accessible name defaults to label + pricing (e.g. `"Join now, $9.99/mo, was $19.99"`); overridable via `aria-label`.
- `Button.price` / `Button.discount` left intact for backward compatibility (a follow-up can deprecate them in favour of `SubscribeButton`).

Matches the [V2 Subscribe Button Figma](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16800-10417) 1:1.

## Visual evidence

**Variants** (primary / secondary / tertiary / outline / brand)

![variants](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-subscribebutton-v2/screenshots/sub-variants.png)

**Negative** (on a dark surface)

![negative](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-subscribebutton-v2/screenshots/sub-negative.png)

**Sizes** (48 / 40 / 32)

![sizes](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-subscribebutton-v2/screenshots/sub-sizes.png)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (new files clean)
- [x] `pnpm build`
- [x] Unit + a11y tests (9 passing) — label/price/discount rendering, default label, className/ref passthrough, onClick, disabled, accessible name, axe
- [x] Stories for all variants / sizes / negative / fullWidth / disabled
- [ ] After Chromatic publishes, link the story in Figma via the Storybook Connect plugin

## Notes

- Design-token aside (came up while auditing this area): the semantically-named `buttons/switch/active` token still points at the V1 value; unrelated to this PR but flagged for the SwitchToggle → Segmented Control migration.

Made with [Cursor](https://cursor.com)