### PR TITLE
feat(MediaStatusIndicator): add V2 media status indicator (ENG-11798)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,6 +147,7 @@ import {
   Logo,
   LogoutIcon,
   LoveIcon,
+  MediaStatusIndicator,
   MegaphoneIcon,
   MenuCloseIcon,
   MenuIcon,
@@ -925,6 +926,24 @@ function ToastDemo() {
         onOpenChange={(open: boolean) => !open && hideToast("messageToast")}
       />
       <ToastViewport />
+    </div>
+  );
+}
+
+function MediaStatusIndicatorDemo() {
+  return (
+    <div id="mediastatusindicator" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Media Status Indicator</h2>
+      <div className="flex flex-wrap items-center gap-4">
+        <MediaStatusIndicator status="default" />
+        <MediaStatusIndicator status="removed" />
+        <MediaStatusIndicator status="sensitive" />
+      </div>
+      <div className="relative size-40 overflow-hidden rounded-lg bg-neutral-800">
+        <div className="absolute top-2 right-2">
+          <MediaStatusIndicator status="sensitive" />
+        </div>
+      </div>
     </div>
   );
 }
@@ -5290,6 +5309,7 @@ function App() {
     { id: "link", label: "Link" },
     { id: "loader", label: "Loader" },
     { id: "logo", label: "Logo" },
+    { id: "mediastatusindicator", label: "Media Status Indicator" },
     { id: "stepper", label: "Stepper" },
     { id: "mobilestepper", label: "Mobile Stepper" },
     { id: "pagination", label: "Pagination" },
@@ -5413,6 +5433,9 @@ function App() {
           <section className="space-y-8">
             {/* Logo */}
             <LogoDemo />
+
+            {/* Media Status Indicator */}
+            <MediaStatusIndicatorDemo />
 
             {/* Icons */}
             <IconsDemo />

--- a/src/components/MediaStatusIndicator/MediaStatusIndicator.stories.tsx
+++ b/src/components/MediaStatusIndicator/MediaStatusIndicator.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MediaStatusIndicator } from "./MediaStatusIndicator";
+
+const meta = {
+  title: "Components/MediaStatusIndicator",
+  component: MediaStatusIndicator,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18206-16999",
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    status: "default",
+  },
+  argTypes: {
+    status: {
+      control: "select",
+      options: ["default", "removed", "sensitive"],
+    },
+  },
+} satisfies Meta<typeof MediaStatusIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Removed: Story = {
+  args: { status: "removed" },
+};
+
+export const Sensitive: Story = {
+  args: { status: "sensitive" },
+};
+
+export const AllStatuses: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <MediaStatusIndicator status="default" />
+      <MediaStatusIndicator status="removed" />
+      <MediaStatusIndicator status="sensitive" />
+    </div>
+  ),
+};
+
+export const OnMedia: Story = {
+  name: "Overlaid on a thumbnail",
+  render: () => (
+    <div className="relative size-40 overflow-hidden rounded-lg bg-neutral-800">
+      <div className="absolute top-2 right-2">
+        <MediaStatusIndicator status="sensitive" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/MediaStatusIndicator/MediaStatusIndicator.test.tsx
+++ b/src/components/MediaStatusIndicator/MediaStatusIndicator.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { MediaStatusIndicator } from "./MediaStatusIndicator";
+
+describe("MediaStatusIndicator", () => {
+  describe("API", () => {
+    it("exposes a default per-status accessible label", () => {
+      render(<MediaStatusIndicator status="removed" />);
+      expect(screen.getByRole("img", { name: "Removed" })).toBeInTheDocument();
+    });
+
+    it('defaults to the "default" status', () => {
+      render(<MediaStatusIndicator />);
+      expect(screen.getByRole("img", { name: "Flagged" })).toBeInTheDocument();
+    });
+
+    it("uses a custom label when provided", () => {
+      render(<MediaStatusIndicator status="sensitive" label="Hidden content" />);
+      expect(screen.getByRole("img", { name: "Hidden content" })).toBeInTheDocument();
+    });
+
+    it("lets aria-label take precedence over label", () => {
+      render(<MediaStatusIndicator status="removed" label="Ignored" aria-label="Taken down" />);
+      expect(screen.getByRole("img", { name: "Taken down" })).toBeInTheDocument();
+    });
+
+    it("applies a custom className", () => {
+      render(<MediaStatusIndicator className="custom" />);
+      expect(screen.getByRole("img")).toHaveClass("custom");
+    });
+
+    it("forwards ref to the root element", () => {
+      const ref = { current: null as HTMLSpanElement | null };
+      render(<MediaStatusIndicator ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+    });
+  });
+
+  describe("accessibility", () => {
+    it.each([
+      "default",
+      "removed",
+      "sensitive",
+    ] as const)("has no accessibility violations for %s", async (status) => {
+      const { container } = render(<MediaStatusIndicator status={status} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/MediaStatusIndicator/MediaStatusIndicator.tsx
+++ b/src/components/MediaStatusIndicator/MediaStatusIndicator.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { CloseIcon } from "../Icons/CloseIcon";
+import { EyeOffIcon } from "../Icons/EyeOffIcon";
+import { FlagIcon } from "../Icons/FlagIcon";
+
+/**
+ * State represented by the indicator.
+ * - `"default"`: media flagged / pending review (amber).
+ * - `"removed"`: media removed for a policy violation (red).
+ * - `"sensitive"`: sensitive content hidden behind an overlay (dark).
+ */
+export type MediaStatusIndicatorStatus = "default" | "removed" | "sensitive";
+
+export interface MediaStatusIndicatorProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** Which media state to represent. @default "default" */
+  status?: MediaStatusIndicatorStatus;
+  /**
+   * Accessible label announced by assistive tech. Defaults to a per-status
+   * description; pass your own for localisation or extra context.
+   */
+  label?: string;
+}
+
+type StatusConfig = { container: string; icon: React.ReactNode; label: string };
+
+const STATUS_CONFIG: Record<MediaStatusIndicatorStatus, StatusConfig> = {
+  default: {
+    container: "bg-warning-surface text-warning-content",
+    icon: <FlagIcon size={16} filled />,
+    label: "Flagged",
+  },
+  removed: {
+    container: "border border-error-secondary bg-error-negative-content text-content-always-white",
+    icon: <CloseIcon size={16} />,
+    label: "Removed",
+  },
+  sensitive: {
+    container: "bg-buttons-overlay-default text-content-always-white",
+    icon: <EyeOffIcon size={16} filled />,
+    label: "Sensitive content",
+  },
+};
+
+/**
+ * A compact circular indicator that surfaces the moderation state of a piece of
+ * media — flagged, removed, or sensitive. Typically overlaid on a thumbnail or
+ * attachment.
+ *
+ * Renders as `role="img"` with a descriptive `aria-label`; the inner glyph is
+ * decorative.
+ *
+ * @example
+ * ```tsx
+ * <MediaStatusIndicator status="sensitive" />
+ * <MediaStatusIndicator status="removed" label="Removed for violating guidelines" />
+ * ```
+ */
+export const MediaStatusIndicator = React.forwardRef<HTMLSpanElement, MediaStatusIndicatorProps>(
+  ({ status = "default", label, className, ...props }, ref) => {
+    const config = STATUS_CONFIG[status];
+    return (
+      <span
+        ref={ref}
+        role="img"
+        aria-label={props["aria-label"] ?? label ?? config.label}
+        className={cn(
+          "inline-flex items-center justify-center rounded-full p-2 [&>svg]:size-4",
+          config.container,
+          className,
+        )}
+        {...props}
+      >
+        {config.icon}
+      </span>
+    );
+  },
+);
+
+MediaStatusIndicator.displayName = "MediaStatusIndicator";

--- a/src/index.ts
+++ b/src/index.ts
@@ -570,6 +570,11 @@ export type {
 } from "./components/Logo/Logo";
 export { Logo } from "./components/Logo/Logo";
 export type {
+  MediaStatusIndicatorProps,
+  MediaStatusIndicatorStatus,
+} from "./components/MediaStatusIndicator/MediaStatusIndicator";
+export { MediaStatusIndicator } from "./components/MediaStatusIndicator/MediaStatusIndicator";
+export type {
   MobileStepperPosition,
   MobileStepperProps,
   MobileStepperVariant,


### PR DESCRIPTION
## Summary

Adds a new **`MediaStatusIndicator`** component (Linear [ENG-11798](https://linear.app/fanvue/issue/ENG-11798)) — a compact circular icon that surfaces the moderation state of a piece of media, typically overlaid on a thumbnail or attachment.

Three states, 1:1 with the [V2 Media Status Indicator Figma](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18206-16999):

- `default` — flagged / pending review: `FlagIcon` on `warning/surface` (amber)
- `removed` — removed for a violation: `CloseIcon` on `error/negative/content` with an `error/secondary` border (white on red)
- `sensitive` — sensitive content: `EyeOffIcon` on `buttons/overlay/default` (white on translucent dark)

- Rendered as `role="img"` with a descriptive per-status `aria-label` (overridable via `label` / `aria-label`); the inner glyph is decorative.
- Reuses existing design tokens and icons — **no new tokens required**.

## Visual evidence

**States** (default / removed / sensitive)

![states](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-mediastatusindicator-v2/screenshots/msi-all.png)

**Overlaid on a thumbnail**

![on media](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-mediastatusindicator-v2/screenshots/msi-onmedia.png)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (new files clean)
- [x] `pnpm build`
- [x] Unit + a11y tests (9 passing) — default/custom label, aria-label precedence, className/ref passthrough, axe for all 3 states
- [x] Stories for each state, all-statuses, and an on-media overlay
- [ ] After Chromatic publishes, link the story in Figma via the Storybook Connect plugin

Made with [Cursor](https://cursor.com)