### PR TITLE
fix(Dialog): top-align header buttons so close button tracks the title

### DIFF
--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -104,6 +104,13 @@ describe("Dialog", () => {
       expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
     });
 
+    it("top-aligns header buttons so the close button tracks the title's first line", () => {
+      renderDialog();
+      const header = screen.getByRole("button", { name: "Close" }).parentElement;
+      expect(header).toHaveClass("items-start");
+      expect(header).not.toHaveClass("items-center");
+    });
+
     it("applies custom className to content", () => {
       renderDialog({ className: "custom-dialog" });
       expect(document.querySelector(".custom-dialog")).toBeInTheDocument();

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -260,7 +260,10 @@ export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
     return (
       <div
         ref={ref}
-        className={cn("flex shrink-0 items-center justify-end gap-4", className)}
+        // items-start (not items-center) so the back/close buttons align to the
+        // title's first line; otherwise they float to the vertical center of a
+        // multi-line title + description column.
+        className={cn("flex shrink-0 items-start justify-end gap-4", className)}
         {...props}
       >
         {shouldShowBack && (


### PR DESCRIPTION
## Summary

Dialog close buttons float in the vertical **middle** of the title on every dialog whose header has a title **+ description** — reported across many agency dialogs (ENG-12175, ENG-12098).

**Root cause:** `DialogHeader` laid its row out with `items-center`. The back/close `IconButton`s are 32px tall; the title line is 24px. With `items-center`, the buttons centre against the *whole* title+description column, so on a multi-line header the X drifts to the middle of the block instead of sitting beside the title's first line.

**Fix:** switch the header row from `items-center` → `items-start` so the back and close buttons align to the top (the title's first line) regardless of description length. One-line change in the shared base component + a regression test. The existing `WithHeaderDescription` story is the visual repro.

## Why here (base component) and not per-dialog

`@fanvue/ui-internal` #278 (ENG-12098) previously worked around this for a single dialog by passing `<DialogHeader className="items-start">` on `RemoveTeamMembersDialog`. That left every other dialog broken. Fixing the base `DialogHeader` fixes all consumers at once.

**Follow-up (release-gated):** once this ships in `@fanvue/ui` and pandora bumps to it, the now-redundant `className="items-start"` override on `RemoveTeamMembersDialog.tsx` in `fanv-ui-internal` should be removed.

## Test plan
- [x] `vitest run src/components/Dialog/Dialog.test.tsx` — 31 passed, incl. new "top-aligns header buttons" test
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on changed files
- [ ] Visual check: Storybook `Dialog / WithHeaderDescription` — X aligns with title's first line