### PR TITLE
ci(release): format release notes as Slack mrkdwn in publish notification (ENG-12252)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,10 +169,6 @@ jobs:
           if [ -z "$RELEASE_BODY" ]; then
             RELEASE_BODY=$(gh release view "$TAG_NAME" --repo "$REPO" --json body --jq .body 2>/dev/null || echo "Republished ${VERSION}")
           fi
-          # Truncate to 2500 chars to stay within Slack limits
-          if [ ${#RELEASE_BODY} -gt 2500 ]; then
-            RELEASE_BODY="${RELEASE_BODY:0:2500}..."
-          fi
 
           if [ "$IS_RECOVERY" = "true" ]; then
             HEADER_TEXT="@fanvue/ui v${VERSION} republished"
@@ -186,8 +182,8 @@ jobs:
             *_success)       PUBLISHED_TO="GitHub Packages" ;;
           esac
 
-          # Escape special JSON characters
-          RELEASE_BODY=$(echo "$RELEASE_BODY" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+          # Convert GitHub markdown to Slack mrkdwn, truncate, and JSON-encode for the payload
+          RELEASE_BODY=$(RELEASE_BODY="$RELEASE_BODY" node scripts/gfm-to-slack-mrkdwn.mjs)
           curl -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             --fail-with-body \

--- a/scripts/gfm-to-slack-mrkdwn.mjs
+++ b/scripts/gfm-to-slack-mrkdwn.mjs
@@ -19,10 +19,7 @@ export function gfmToSlackMrkdwn(markdown) {
 
   const converted = lines.map((rawLine) => {
     // [text](url) -> <url|text>
-    let line = rawLine.replace(
-      /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
-      "<$2|$1>",
-    );
+    let line = rawLine.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, "<$2|$1>");
     // **bold** -> *bold*
     line = line.replace(/\*\*([^*]+)\*\*/g, "*$1*");
 
@@ -60,8 +57,7 @@ export function truncate(text, limit = SLACK_TEXT_LIMIT) {
 }
 
 // Run as a CLI only when invoked directly, so tests can import the functions.
-const invokedDirectly =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (invokedDirectly) {
   const mrkdwn = truncate(gfmToSlackMrkdwn(process.env.RELEASE_BODY ?? ""));

--- a/scripts/gfm-to-slack-mrkdwn.mjs
+++ b/scripts/gfm-to-slack-mrkdwn.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Converts GitHub-flavored markdown (the release notes produced by
+ * release-please) into Slack mrkdwn, so the release notification renders
+ * cleanly instead of showing raw "##", "**" and "[text](url)" markers.
+ *
+ * Used by .github/workflows/release.yml: reads the raw markdown from the
+ * RELEASE_BODY environment variable and writes the converted text, JSON
+ * encoded, to stdout so it can be dropped straight into the Slack payload.
+ */
+
+import { pathToFileURL } from "node:url";
+
+// Slack section text objects are capped at 3000 characters; leave headroom.
+const SLACK_TEXT_LIMIT = 2900;
+
+export function gfmToSlackMrkdwn(markdown) {
+  const lines = (markdown ?? "").split("\n");
+
+  const converted = lines.map((rawLine) => {
+    // [text](url) -> <url|text>
+    let line = rawLine.replace(
+      /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+      "<$2|$1>",
+    );
+    // **bold** -> *bold*
+    line = line.replace(/\*\*([^*]+)\*\*/g, "*$1*");
+
+    // Headings (#..######) become a bold line. Skip bolding when the heading
+    // contains a link, because Slack does not reliably render *<url|text>*.
+    const heading = line.match(/^\s*#{1,6}\s+(.*\S)\s*$/);
+    if (heading) {
+      const content = heading[1];
+      return content.includes("<") ? content : `*${content}*`;
+    }
+
+    // "* item" / "- item" -> "• item", preserving indentation.
+    const bullet = line.match(/^(\s*)[*-]\s+(.*)$/);
+    if (bullet) {
+      return `${bullet[1]}• ${bullet[2]}`;
+    }
+
+    return line;
+  });
+
+  return converted
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export function truncate(text, limit = SLACK_TEXT_LIMIT) {
+  if (text.length <= limit) {
+    return text;
+  }
+  const clipped = text.slice(0, limit);
+  const lastBreak = clipped.lastIndexOf("\n");
+  const safe = lastBreak > 0 ? clipped.slice(0, lastBreak) : clipped;
+  return `${safe.trimEnd()}\n…`;
+}
+
+// Run as a CLI only when invoked directly, so tests can import the functions.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  const mrkdwn = truncate(gfmToSlackMrkdwn(process.env.RELEASE_BODY ?? ""));
+  process.stdout.write(JSON.stringify(mrkdwn));
+}


### PR DESCRIPTION
Converts the release-please GitHub markdown into Slack mrkdwn before posting the release notification, so section titles, bullets, and links render correctly instead of showing raw markup.