### PR TITLE
feat(Inputs): add PhoneField and TextField action slot, align input hint styling to V2 board

### DIFF
--- a/src/components/PhoneField/PhoneField.stories.tsx
+++ b/src/components/PhoneField/PhoneField.stories.tsx
@@ -1,0 +1,195 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { PhoneField } from "./PhoneField";
+
+const ItalyFlag = () => (
+  <span aria-hidden="true" className="text-base leading-none">
+    🇮🇹
+  </span>
+);
+
+const meta: Meta<typeof PhoneField> = {
+  title: "Components/PhoneField",
+  component: PhoneField,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16633-67897",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["48", "40", "32"],
+    },
+    label: { control: "text" },
+    helperText: { control: "text" },
+    errorMessage: { control: "text" },
+    placeholder: { control: "text" },
+    dialCode: { control: "text" },
+    countryButtonLabel: { control: "text" },
+    disabled: { control: "boolean" },
+    error: { control: "boolean" },
+    fullWidth: { control: "boolean" },
+  },
+  args: {
+    label: "Phone number",
+    dialCode: "+39",
+    flag: <ItalyFlag />,
+    placeholder: "Input Content",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "375px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Filled: Story = {
+  args: {
+    defaultValue: "3381020300",
+  },
+};
+
+export const Size40: Story = {
+  args: {
+    size: "40",
+    defaultValue: "3381020300",
+  },
+};
+
+export const Size32: Story = {
+  args: {
+    size: "32",
+    defaultValue: "3381020300",
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    helperText: "We'll send a verification code to this number",
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    error: true,
+    errorMessage: "Enter a valid phone number",
+    defaultValue: "33810",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: "3381020300",
+  },
+};
+
+export const WithoutFlag: Story = {
+  name: "Without flag",
+  args: {
+    flag: undefined,
+  },
+};
+
+export const FullWidth: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: "100%", maxWidth: "600px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    fullWidth: true,
+    defaultValue: "3381020300",
+  },
+};
+
+export const AllSizes: Story = {
+  name: "All sizes",
+  render: () => (
+    <div className="flex w-[375px] flex-col gap-4">
+      <PhoneField
+        size="48"
+        label="Size 48"
+        flag={<ItalyFlag />}
+        dialCode="+39"
+        defaultValue="3381020300"
+      />
+      <PhoneField
+        size="40"
+        label="Size 40"
+        flag={<ItalyFlag />}
+        dialCode="+39"
+        defaultValue="3381020300"
+      />
+      <PhoneField
+        size="32"
+        label="Size 32"
+        flag={<ItalyFlag />}
+        dialCode="+39"
+        defaultValue="3381020300"
+      />
+    </div>
+  ),
+};
+
+const DEFAULT_COUNTRY = { flag: "🇮🇹", dialCode: "+39" };
+const COUNTRIES = [
+  DEFAULT_COUNTRY,
+  { flag: "🇬🇧", dialCode: "+44" },
+  { flag: "🇺🇸", dialCode: "+1" },
+];
+
+export const Controlled: Story = {
+  name: "Controlled with country picker",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The country picker is owned by the consumer. `onCountrySelect` opens it; here it cycles through a small list to show `flag` and `dialCode` updating.",
+      },
+    },
+  },
+  render: function ControlledRender() {
+    const [value, setValue] = useState("");
+    const [country, setCountry] = useState(DEFAULT_COUNTRY);
+
+    return (
+      <div className="flex w-[375px] flex-col gap-4">
+        <PhoneField
+          label="Phone number"
+          placeholder="Input Content"
+          flag={
+            <span aria-hidden="true" className="text-base leading-none">
+              {country.flag}
+            </span>
+          }
+          dialCode={country.dialCode}
+          onCountrySelect={() =>
+            setCountry(
+              (c) => COUNTRIES[(COUNTRIES.indexOf(c) + 1) % COUNTRIES.length] ?? DEFAULT_COUNTRY,
+            )
+          }
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          helperText="Tap the flag to change country"
+        />
+        <div className="typography-description-12px-regular text-content-secondary">
+          {country.dialCode} {value || "(empty)"}
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/PhoneField/PhoneField.test.tsx
+++ b/src/components/PhoneField/PhoneField.test.tsx
@@ -58,6 +58,31 @@ describe("PhoneField", () => {
       const input = screen.getByRole("textbox");
       expect(input.getAttribute("aria-describedby")).toContain("phone-dial-code");
     });
+
+    it("focuses the input when clicking the dial code or the field padding", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<PhoneField aria-label="Phone" dialCode="+39" />);
+      const input = screen.getByRole("textbox");
+
+      await user.click(screen.getByText("+39"));
+      expect(input).toHaveFocus();
+
+      input.blur();
+      const fieldContainer = container.querySelector('[class*="rounded-sm"]') as HTMLElement;
+      await user.click(fieldContainer);
+      expect(input).toHaveFocus();
+    });
+
+    it("does not steal focus from the country button when clicked", async () => {
+      const user = userEvent.setup();
+      const onCountrySelect = vi.fn();
+      render(<PhoneField aria-label="Phone" onCountrySelect={onCountrySelect} />);
+      const input = screen.getByRole("textbox");
+
+      await user.click(screen.getByRole("button", { name: "Select country" }));
+      expect(onCountrySelect).toHaveBeenCalledTimes(1);
+      expect(input).not.toHaveFocus();
+    });
   });
 
   describe("states", () => {

--- a/src/components/PhoneField/PhoneField.test.tsx
+++ b/src/components/PhoneField/PhoneField.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { PhoneField } from "./PhoneField";
+
+describe("PhoneField", () => {
+  describe("API", () => {
+    it("forwards ref to the input element", () => {
+      const ref = React.createRef<HTMLInputElement>();
+      render(<PhoneField aria-label="Phone" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLInputElement);
+      expect(ref.current?.tagName.toLowerCase()).toBe("input");
+    });
+
+    it("defaults the input type to tel", () => {
+      render(<PhoneField label="Phone" />);
+      expect(screen.getByRole("textbox")).toHaveAttribute("type", "tel");
+    });
+
+    it("associates the label with the input", () => {
+      render(<PhoneField id="phone" label="Phone number" />);
+      const input = screen.getByRole("textbox");
+      const label = screen.getByText("Phone number");
+      expect(label).toHaveAttribute("for", "phone");
+      expect(input).toHaveAttribute("id", "phone");
+    });
+
+    it("applies fullWidth className when fullWidth is true", () => {
+      const { container } = render(<PhoneField aria-label="Phone" fullWidth />);
+      expect(container.querySelector('[class*="w-full"]')).toBeInTheDocument();
+    });
+  });
+
+  describe("country selector", () => {
+    it("renders the dial code and flag", () => {
+      render(<PhoneField aria-label="Phone" dialCode="+39" flag={<span>flag</span>} />);
+      expect(screen.getByText("+39")).toBeInTheDocument();
+      expect(screen.getByText("flag")).toBeInTheDocument();
+    });
+
+    it("calls onCountrySelect when the country button is clicked", async () => {
+      const user = userEvent.setup();
+      const onCountrySelect = vi.fn();
+      render(<PhoneField aria-label="Phone" onCountrySelect={onCountrySelect} />);
+      await user.click(screen.getByRole("button", { name: "Select country" }));
+      expect(onCountrySelect).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses a custom country button label", () => {
+      render(<PhoneField aria-label="Phone" countryButtonLabel="Change country" />);
+      expect(screen.getByRole("button", { name: "Change country" })).toBeInTheDocument();
+    });
+
+    it("links the dial code to the input via aria-describedby", () => {
+      render(<PhoneField id="phone" aria-label="Phone" dialCode="+39" />);
+      const input = screen.getByRole("textbox");
+      expect(input.getAttribute("aria-describedby")).toContain("phone-dial-code");
+    });
+  });
+
+  describe("states", () => {
+    it("shows the error message and marks the input invalid", () => {
+      render(
+        <PhoneField aria-label="Phone" error errorMessage="Invalid number" helperText="Helper" />,
+      );
+      expect(screen.getByText("Invalid number")).toBeInTheDocument();
+      expect(screen.queryByText("Helper")).not.toBeInTheDocument();
+      expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("shows helper text when there is no error", () => {
+      render(<PhoneField aria-label="Phone" helperText="Helper" />);
+      expect(screen.getByText("Helper")).toBeInTheDocument();
+    });
+
+    it("disables both the input and the country button when disabled", () => {
+      render(<PhoneField aria-label="Phone" disabled />);
+      expect(screen.getByRole("textbox")).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Select country" })).toBeDisabled();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("warns when no accessible name is provided", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      render(<PhoneField />);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("no accessible name"));
+      warn.mockRestore();
+    });
+
+    it("has no axe violations", async () => {
+      const { container } = render(
+        <PhoneField
+          label="Phone number"
+          dialCode="+39"
+          flag={<span>IT</span>}
+          helperText="Helper"
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/PhoneField/PhoneField.tsx
+++ b/src/components/PhoneField/PhoneField.tsx
@@ -149,6 +149,25 @@ export const PhoneField = React.forwardRef<HTMLInputElement, PhoneFieldProps>(
         .filter(Boolean)
         .join(" ") || undefined;
 
+    const innerRef = React.useRef<HTMLInputElement>(null);
+    const setRefs = React.useCallback(
+      (node: HTMLInputElement | null) => {
+        innerRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) (ref as React.RefObject<HTMLInputElement | null>).current = node;
+      },
+      [ref],
+    );
+
+    const handleContainerMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      const target = event.target as HTMLElement;
+      if (target === innerRef.current) return;
+      if (target.closest("[data-pf-interactive]")) return;
+      event.preventDefault();
+      innerRef.current?.focus();
+    };
+
     warnMissingAccessibleName(label, props["aria-label"], props["aria-labelledby"]);
 
     return (
@@ -166,9 +185,14 @@ export const PhoneField = React.forwardRef<HTMLInputElement, PhoneFieldProps>(
           </label>
         )}
 
-        <div className={getContainerClassName(size, error, disabled)}>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: focus bridge delegates pointer clicks on the padding to the input */}
+        <div
+          className={getContainerClassName(size, error, disabled)}
+          onMouseDown={handleContainerMouseDown}
+        >
           <button
             type="button"
+            data-pf-interactive=""
             onClick={onCountrySelect}
             disabled={disabled}
             aria-label={countryButtonLabel}
@@ -195,7 +219,7 @@ export const PhoneField = React.forwardRef<HTMLInputElement, PhoneFieldProps>(
           )}
 
           <input
-            ref={ref}
+            ref={setRefs}
             id={inputId}
             type={type}
             inputMode="tel"

--- a/src/components/PhoneField/PhoneField.tsx
+++ b/src/components/PhoneField/PhoneField.tsx
@@ -149,25 +149,6 @@ export const PhoneField = React.forwardRef<HTMLInputElement, PhoneFieldProps>(
         .filter(Boolean)
         .join(" ") || undefined;
 
-    const innerRef = React.useRef<HTMLInputElement>(null);
-    const setRefs = React.useCallback(
-      (node: HTMLInputElement | null) => {
-        innerRef.current = node;
-        if (typeof ref === "function") ref(node);
-        else if (ref) (ref as React.RefObject<HTMLInputElement | null>).current = node;
-      },
-      [ref],
-    );
-
-    const handleContainerMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-      if (disabled) return;
-      const target = event.target as HTMLElement;
-      if (target === innerRef.current) return;
-      if (target.closest("[data-pf-interactive]")) return;
-      event.preventDefault();
-      innerRef.current?.focus();
-    };
-
     warnMissingAccessibleName(label, props["aria-label"], props["aria-labelledby"]);
 
     return (
@@ -185,14 +166,9 @@ export const PhoneField = React.forwardRef<HTMLInputElement, PhoneFieldProps>(
           </label>
         )}
 
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: focus bridge delegates pointer clicks on the padding to the input */}
-        <div
-          className={getContainerClassName(size, error, disabled)}
-          onMouseDown={handleContainerMouseDown}
-        >
+        <div className={getContainerClassName(size, error, disabled)}>
           <button
             type="button"
-            data-pf-interactive=""
             onClick={onCountrySelect}
             disabled={disabled}
             aria-label={countryButtonLabel}
@@ -219,7 +195,7 @@ export const PhoneField = React.forwardRef<HTMLInputElement, PhoneFieldProps>(
           )}
 
           <input
-            ref={setRefs}
+            ref={ref}
             id={inputId}
             type={type}
             inputMode="tel"

--- a/src/components/PhoneField/PhoneField.tsx
+++ b/src/components/PhoneField/PhoneField.tsx
@@ -1,0 +1,247 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { ChevronDownIcon } from "../Icons/ChevronDownIcon";
+
+/** Phone field height in pixels. */
+export type PhoneFieldSize = "48" | "40" | "32";
+
+export interface PhoneFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size" | "prefix"> {
+  /** Label text displayed above the input. Also used as the accessible name. */
+  label?: string;
+  /** Helper text displayed below the input. Replaced by `errorMessage` when `error` is `true`. */
+  helperText?: string;
+  /** Height of the phone field in pixels. @default "48" */
+  size?: PhoneFieldSize;
+  /** Whether the field is in an error state. @default false */
+  error?: boolean;
+  /** Error message displayed below the input. Shown instead of `helperText` when `error` is `true`. */
+  errorMessage?: string;
+  /** Dial code of the selected country, shown before the number (e.g. `"+39"`). */
+  dialCode?: React.ReactNode;
+  /** Flag of the selected country, rendered in the country selector (e.g. an image or flag icon). */
+  flag?: React.ReactNode;
+  /** Fired when the country selector (flag + chevron) is activated. Open the country picker here. */
+  onCountrySelect?: () => void;
+  /** Accessible name for the country selector button. @default "Select country" */
+  countryButtonLabel?: string;
+  /** Whether the field stretches to fill its container width. @default false */
+  fullWidth?: boolean;
+}
+
+const CONTAINER_HEIGHT: Record<PhoneFieldSize, string> = {
+  "48": "h-12",
+  "40": "h-10",
+  "32": "h-8",
+};
+
+const CONTAINER_PADDING_X: Record<PhoneFieldSize, string> = {
+  "48": "px-4",
+  "40": "px-4",
+  "32": "px-3",
+};
+
+const INPUT_TYPOGRAPHY: Record<PhoneFieldSize, string> = {
+  "48": "typography-body-default-16px-regular autofill-body-lg",
+  "40": "typography-body-default-16px-regular autofill-body-lg",
+  "32": "typography-body-small-14px-regular autofill-body-md",
+};
+
+const PREFIX_TYPOGRAPHY: Record<PhoneFieldSize, string> = {
+  "48": "typography-body-default-16px-regular",
+  "40": "typography-body-default-16px-regular",
+  "32": "typography-body-small-14px-regular",
+};
+
+function getContainerClassName(size: PhoneFieldSize, error: boolean, disabled?: boolean) {
+  return cn(
+    "relative flex items-center gap-2 overflow-hidden rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    CONTAINER_PADDING_X[size],
+    CONTAINER_HEIGHT[size],
+    error ? "border-error-content" : "border-border-primary",
+    !disabled && !error && "hover:border-neutral-alphas-400",
+    disabled && "opacity-50",
+  );
+}
+
+function warnMissingAccessibleName(label?: string, ariaLabel?: string, ariaLabelledBy?: string) {
+  if (process.env.NODE_ENV !== "production") {
+    if (!label && !ariaLabel && !ariaLabelledBy) {
+      console.warn(
+        "PhoneField: no accessible name provided. Pass a `label`, `aria-label`, or `aria-labelledby` prop.",
+      );
+    }
+  }
+}
+
+function PhoneFieldHelperText({
+  id,
+  error,
+  children,
+}: {
+  id: string;
+  error: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <p
+      id={id}
+      className={cn(
+        "typography-description-12px-regular pt-2",
+        error ? "text-error-content" : "text-content-tertiary",
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * A phone number input with a country selector (flag + chevron), a fixed dial
+ * code prefix, and a `tel` input. The country picker itself is owned by the
+ * consumer: pass the selected country's `flag` and `dialCode`, and open your
+ * picker from `onCountrySelect`.
+ *
+ * Provide at least one of `label`, `aria-label`, or `aria-labelledby` for
+ * accessibility — a console warning is emitted in development if none are set.
+ *
+ * @example
+ * ```tsx
+ * <PhoneField
+ *   label="Phone number"
+ *   flag={<img src={italyFlag} alt="" />}
+ *   dialCode="+39"
+ *   onCountrySelect={openCountryPicker}
+ *   value={number}
+ *   onChange={(e) => setNumber(e.target.value)}
+ * />
+ * ```
+ */
+export const PhoneField = React.forwardRef<HTMLInputElement, PhoneFieldProps>(
+  (
+    {
+      label,
+      helperText,
+      size = "48",
+      error = false,
+      errorMessage,
+      dialCode,
+      flag,
+      onCountrySelect,
+      countryButtonLabel = "Select country",
+      className,
+      id,
+      disabled,
+      fullWidth = false,
+      type = "tel",
+      ...props
+    },
+    ref,
+  ) => {
+    const generatedId = React.useId();
+    const inputId = id || generatedId;
+    const helperTextId = `${inputId}-helper`;
+    const dialCodeId = `${inputId}-dial-code`;
+    const bottomText = error && errorMessage ? errorMessage : helperText;
+
+    const describedBy =
+      [dialCode != null ? dialCodeId : null, bottomText ? helperTextId : null]
+        .filter(Boolean)
+        .join(" ") || undefined;
+
+    const innerRef = React.useRef<HTMLInputElement>(null);
+    const setRefs = React.useCallback(
+      (node: HTMLInputElement | null) => {
+        innerRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) (ref as React.RefObject<HTMLInputElement | null>).current = node;
+      },
+      [ref],
+    );
+
+    const handleContainerMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      const target = event.target as HTMLElement;
+      if (target === innerRef.current) return;
+      if (target.closest("[data-pf-interactive]")) return;
+      event.preventDefault();
+      innerRef.current?.focus();
+    };
+
+    warnMissingAccessibleName(label, props["aria-label"], props["aria-labelledby"]);
+
+    return (
+      <div
+        className={cn("flex flex-col", fullWidth && "w-full", className)}
+        data-disabled={disabled ? "" : undefined}
+        data-error={error ? "" : undefined}
+      >
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="typography-description-12px-semibold pb-2 text-content-primary"
+          >
+            {label}
+          </label>
+        )}
+
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: focus bridge delegates pointer clicks on the padding to the input */}
+        <div
+          className={getContainerClassName(size, error, disabled)}
+          onMouseDown={handleContainerMouseDown}
+        >
+          <button
+            type="button"
+            data-pf-interactive=""
+            onClick={onCountrySelect}
+            disabled={disabled}
+            aria-label={countryButtonLabel}
+            className="flex shrink-0 items-center gap-1 rounded-2xs focus-visible:shadow-focus-ring focus-visible:outline-none disabled:cursor-not-allowed"
+          >
+            {flag != null && (
+              <span className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-full">
+                {flag}
+              </span>
+            )}
+            <ChevronDownIcon size={16} className="shrink-0 text-content-secondary" />
+          </button>
+
+          {dialCode != null && (
+            <span
+              id={dialCodeId}
+              className={cn(
+                "shrink-0 select-none whitespace-nowrap text-content-primary",
+                PREFIX_TYPOGRAPHY[size],
+              )}
+            >
+              {dialCode}
+            </span>
+          )}
+
+          <input
+            ref={setRefs}
+            id={inputId}
+            type={type}
+            inputMode="tel"
+            disabled={disabled}
+            aria-describedby={describedBy}
+            aria-invalid={error || undefined}
+            className={cn(
+              "h-full min-w-0 flex-1 bg-transparent text-content-primary no-underline placeholder:text-content-tertiary focus:outline-none disabled:cursor-not-allowed",
+              INPUT_TYPOGRAPHY[size],
+            )}
+            {...props}
+          />
+        </div>
+
+        {bottomText && (
+          <PhoneFieldHelperText id={helperTextId} error={error}>
+            {bottomText}
+          </PhoneFieldHelperText>
+        )}
+      </div>
+    );
+  },
+);
+
+PhoneField.displayName = "PhoneField";

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -104,8 +104,8 @@ function TextAreaHelperText({
     <p
       id={id}
       className={cn(
-        "typography-description-12px-regular px-2 pt-1 pb-0.5",
-        error ? "text-error-content" : "text-content-secondary",
+        "typography-description-12px-regular pt-2",
+        error ? "text-error-content" : "text-content-tertiary",
       )}
     >
       {children}

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
+import { Chip } from "../Chip/Chip";
 import { ErrorCircleIcon } from "../Icons/ErrorCircleIcon";
 import { EyeIcon } from "../Icons/EyeIcon";
 import { HomeIcon } from "../Icons/HomeIcon";
@@ -183,6 +184,41 @@ export const SideLabelSizes: Story = {
       <TextField size="48" label="Size 48" leftLabel="$" rightLabel="USD" placeholder="0.00" />
       <TextField size="40" label="Size 40" leftLabel="$" rightLabel="USD" placeholder="0.00" />
       <TextField size="32" label="Size 32" leftLabel="$" rightLabel="USD" placeholder="0.00" />
+    </div>
+  ),
+};
+
+export const WithButton: Story = {
+  name: "With button",
+  args: {
+    label: "Promo code",
+    placeholder: "Enter code",
+    action: <Chip size="32">Apply</Chip>,
+  },
+};
+
+export const WithButtonSizes: Story = {
+  name: "With button (all sizes)",
+  render: () => (
+    <div className="flex w-[375px] flex-col gap-4">
+      <TextField
+        size="48"
+        label="Size 48"
+        placeholder="Enter code"
+        action={<Chip size="32">Apply</Chip>}
+      />
+      <TextField
+        size="40"
+        label="Size 40"
+        placeholder="Enter code"
+        action={<Chip size="32">Apply</Chip>}
+      />
+      <TextField
+        size="32"
+        label="Size 32"
+        placeholder="Enter code"
+        action={<Chip size="32">Apply</Chip>}
+      />
     </div>
   ),
 };

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -224,6 +224,41 @@ describe("TextField", () => {
     });
   });
 
+  describe("action", () => {
+    it("renders a trailing action element", () => {
+      render(
+        <TextField
+          aria-label="Promo"
+          action={
+            <button type="button" onClick={() => {}}>
+              Apply
+            </button>
+          }
+        />,
+      );
+      expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+    });
+
+    it("triggers the action click without stealing input focus", async () => {
+      const user = userEvent.setup();
+      const onAction = vi.fn();
+      render(
+        <TextField
+          aria-label="Promo"
+          action={
+            <button type="button" onClick={onAction}>
+              Apply
+            </button>
+          }
+        />,
+      );
+      const input = screen.getByRole("textbox");
+      await user.click(screen.getByRole("button", { name: "Apply" }));
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(input).not.toHaveFocus();
+    });
+  });
+
   describe("user interaction", () => {
     it("allows typing in the input", async () => {
       const user = userEvent.setup();

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -27,6 +27,12 @@ export interface TextFieldProps
   leftLabel?: React.ReactNode;
   /** Fixed, non-editable label pinned inside the right edge of the field — for a unit or suffix such as a currency code or domain. */
   rightLabel?: React.ReactNode;
+  /**
+   * Trailing interactive element pinned to the right edge — typically a `Chip`
+   * or `Button` (the "with button" field type). Reduces the right padding so the
+   * control sits flush, and clicks on it do not steal focus from the input.
+   */
+  action?: React.ReactNode;
   /** Whether the text field stretches to fill its container width. @default false */
   fullWidth?: boolean;
 }
@@ -41,6 +47,12 @@ const CONTAINER_PADDING_X: Record<TextFieldSize, string> = {
   "48": "px-4",
   "40": "px-4",
   "32": "px-3",
+};
+
+const CONTAINER_PADDING_X_WITH_ACTION: Record<TextFieldSize, string> = {
+  "48": "pl-4 pr-2",
+  "40": "pl-4 pr-2",
+  "32": "pl-3 pr-2",
 };
 
 const CONTAINER_GAP: Record<TextFieldSize, string> = {
@@ -61,10 +73,15 @@ const SIDE_LABEL_TYPOGRAPHY: Record<TextFieldSize, string> = {
   "32": "typography-body-small-14px-regular",
 };
 
-function getContainerClassName(size: TextFieldSize, error: boolean, disabled?: boolean) {
+function getContainerClassName(
+  size: TextFieldSize,
+  error: boolean,
+  disabled?: boolean,
+  hasAction?: boolean,
+) {
   return cn(
     "relative flex items-center overflow-hidden rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
-    CONTAINER_PADDING_X[size],
+    hasAction ? CONTAINER_PADDING_X_WITH_ACTION[size] : CONTAINER_PADDING_X[size],
     CONTAINER_GAP[size],
     error ? "border-error-content" : "border-border-primary",
     !disabled && !error && "hover:border-neutral-alphas-400",
@@ -145,8 +162,8 @@ function TextFieldHelperText({
     <p
       id={id}
       className={cn(
-        "typography-description-12px-regular px-2 pt-2 pb-0.5",
-        error ? "text-error-content" : "text-content-secondary",
+        "typography-description-12px-regular pt-2",
+        error ? "text-error-content" : "text-content-tertiary",
       )}
     >
       {children}
@@ -185,6 +202,15 @@ function warnMissingAccessibleName(label?: string, ariaLabel?: string, ariaLabel
  * ```tsx
  * <TextField label="Price" leftLabel="$" rightLabel="USD" placeholder="0.00" />
  * ```
+ *
+ * @example
+ * ```tsx
+ * <TextField
+ *   label="Promo code"
+ *   placeholder="Enter code"
+ *   action={<Chip size="32" onClick={apply}>Apply</Chip>}
+ * />
+ * ```
  */
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   (
@@ -199,6 +225,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       rightIcon,
       leftLabel,
       rightLabel,
+      action,
       className,
       id,
       disabled,
@@ -263,7 +290,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
 
         {/* biome-ignore lint/a11y/noStaticElementInteractions: focus bridge delegates pointer clicks on adornments to the input */}
         <div
-          className={getContainerClassName(size, error, disabled)}
+          className={getContainerClassName(size, error, disabled, action != null)}
           onMouseDown={handleContainerMouseDown}
         >
           <LeadingIcon>{leftIcon}</LeadingIcon>
@@ -289,6 +316,11 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             {rightLabel}
           </SideLabel>
           <TrailingAdornment rightIcon={rightIcon} validated={validated} />
+          {action != null && (
+            <span data-tf-interactive="" className="flex shrink-0 items-center">
+              {action}
+            </span>
+          )}
         </div>
 
         {bottomText && (

--- a/src/index.ts
+++ b/src/index.ts
@@ -592,6 +592,8 @@ export type {
   PasswordFieldSize,
 } from "./components/PasswordField/PasswordField";
 export { PasswordField } from "./components/PasswordField/PasswordField";
+export type { PhoneFieldProps, PhoneFieldSize } from "./components/PhoneField/PhoneField";
+export { PhoneField } from "./components/PhoneField/PhoneField";
 export type { PillProps, PillVariant } from "./components/Pill/Pill";
 export { Pill } from "./components/Pill/Pill";
 export type { ProfileOnlineStatusProps } from "./components/ProfileOnlineStatus/ProfileOnlineStatus";


### PR DESCRIPTION
Adds a PhoneField component and a trailing action slot on TextField for inline buttons, and aligns TextField/TextArea helper-text colour and spacing to the V2 Input Fields design.