### PR TITLE
feat(VoiceNote): add voice-note waveform player with optional real-audio mode (ENG-10632)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4687,6 +4687,7 @@ function VoiceNoteDemo() {
         <VoiceNote size="small" progress={0.4} playing time="0:02" />
         <VoiceNote fileName="audio_name.mp4" time="0:05" />
         <VoiceNote showRemove time="0:05" onRemove={() => console.log("remove")} />
+        <VoiceNote src="https://example.com/voice-note.mp3" duration={24} />
         <VoiceNote
           playing={playing}
           progress={playing ? 0.6 : undefined}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -260,6 +260,7 @@ import {
   UsersIcon,
   VideoIcon,
   VipBadgeIcon,
+  VoiceNote,
   WalletIcon,
   WarningIcon,
   WarningTriangleIcon,
@@ -4673,6 +4674,33 @@ function AudioUploadDemo() {
   );
 }
 
+function VoiceNoteDemo() {
+  const [playing, setPlaying] = useState(false);
+
+  return (
+    <div id="voicenote" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Voice Note</h2>
+      <div className="flex max-w-[420px] flex-col gap-4">
+        <VoiceNote variant="flat" time="0:05" />
+        <VoiceNote time="0:05" />
+        <VoiceNote progress={0.4} playing time="0:02" />
+        <VoiceNote size="small" progress={0.4} playing time="0:02" />
+        <VoiceNote fileName="audio_name.mp4" time="0:05" />
+        <VoiceNote showRemove time="0:05" onRemove={() => console.log("remove")} />
+        <VoiceNote
+          playing={playing}
+          progress={playing ? 0.6 : undefined}
+          time={playing ? "0:03" : "0:05"}
+          onPlayPause={setPlaying}
+        />
+      </div>
+      <div className="max-w-[420px] rounded-md bg-surface-primary-inverted p-4">
+        <VoiceNote negative progress={0.4} playing time="0:02" />
+      </div>
+    </div>
+  );
+}
+
 function InlineEditDemo() {
   const [folderName, setFolderName] = useState("New folder");
   const [folders, setFolders] = useState(["Inbox", "Drafts", "Sent"]);
@@ -5263,6 +5291,7 @@ function App() {
     { id: "banner", label: "Banner" },
     { id: "autocomplete", label: "Autocomplete" },
     { id: "audioupload", label: "Audio Upload" },
+    { id: "voicenote", label: "Voice Note" },
     { id: "avatar", label: "Avatar" },
     { id: "badge", label: "Badge" },
     { id: "bottom-navigation", label: "Bottom Navigation" },
@@ -5562,6 +5591,9 @@ function App() {
 
             {/* Audio Upload */}
             <AudioUploadDemo />
+
+            {/* Voice Note */}
+            <VoiceNoteDemo />
 
             {/* Loader */}
             <LoaderDemo />

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,4 +1,11 @@
 import * as React from "react";
+import {
+  decodeAudioPeaks,
+  formatTime,
+  generateFallbackPeaks,
+  RAW_PEAK_COUNT,
+  resamplePeaks,
+} from "../../utils/audioWaveform";
 import { cn } from "../../utils/cn";
 import { PauseIcon } from "../Icons/PauseIcon";
 import { PlayIcon } from "../Icons/PlayIcon";
@@ -13,8 +20,6 @@ const MIN_BAR_HEIGHT_PX = 4;
 const MAX_BAR_HEIGHT_PX = 26;
 /** Bar count used before the container has been measured (e.g. during SSR or in jsdom, where layout is unavailable). */
 const DEFAULT_BAR_COUNT = 24;
-/** Number of amplitude samples kept internally, resampled to the rendered bar count. */
-const RAW_PEAK_COUNT = 128;
 /** Seconds moved per Arrow key press while seeking. */
 const SEEK_STEP_SECONDS = 1;
 /** Seconds moved per Page Up/Down press while seeking. */
@@ -50,84 +55,6 @@ export interface AudioPlayerProps
   onEnded?: () => void;
   /** Height of the player row, in pixels. @default "40" */
   size?: AudioPlayerSize;
-}
-
-function formatTime(seconds: number | undefined): string {
-  if (seconds === undefined || !Number.isFinite(seconds)) return "--:--";
-  const totalSeconds = Math.max(0, Math.floor(seconds));
-  const minutes = Math.floor(totalSeconds / 60);
-  const remainingSeconds = totalSeconds % 60;
-  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
-}
-
-/** Deterministic 32-bit string hash (FNV-1a), used to seed the fallback waveform. */
-function hashString(value: string): number {
-  let hash = 2166136261;
-  for (let i = 0; i < value.length; i++) {
-    hash ^= value.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-/** Seeded PRNG (mulberry32) — deterministic across runs, unlike `Math.random`. */
-function createSeededRandom(seed: number): () => number {
-  let state = seed;
-  return () => {
-    state = (state + 0x6d2b79f5) | 0;
-    let t = Math.imul(state ^ (state >>> 15), 1 | state);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-/** Deterministic placeholder amplitudes used when audio can't be decoded (network/CORS/format failure). */
-function generateFallbackPeaks(src: string, count: number): number[] {
-  const random = createSeededRandom(hashString(src));
-  return Array.from({ length: count }, () => 0.2 + random() * 0.8);
-}
-
-/** Downsamples decoded PCM data to `count` peak (max-abs) amplitudes. */
-function computePeaksFromChannelData(channelData: Float32Array, count: number): number[] {
-  const blockSize = Math.max(1, Math.floor(channelData.length / count));
-  const peaks: number[] = [];
-  for (let i = 0; i < count; i++) {
-    const start = i * blockSize;
-    let max = 0;
-    for (let j = 0; j < blockSize && start + j < channelData.length; j++) {
-      max = Math.max(max, Math.abs(channelData[start + j] ?? 0));
-    }
-    peaks.push(max);
-  }
-  return peaks;
-}
-
-/** Resamples a peaks array to the number of bars that currently fit the container. */
-function resamplePeaks(peaks: number[], barCount: number): number[] {
-  if (peaks.length === 0 || barCount <= 0) return [];
-  const step = peaks.length / barCount;
-  return Array.from(
-    { length: barCount },
-    (_, i) => peaks[Math.min(peaks.length - 1, Math.floor(i * step))] ?? 0,
-  );
-}
-
-/** Decodes `src` via WebAudio and returns downsampled peak amplitudes. Throws on any failure. */
-async function decodeAudioPeaks(src: string, signal: AbortSignal): Promise<number[]> {
-  const AudioContextCtor =
-    window.AudioContext ??
-    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-  if (!AudioContextCtor) throw new Error("WebAudio unsupported");
-
-  const response = await fetch(src, { signal });
-  const arrayBuffer = await response.arrayBuffer();
-  const audioContext = new AudioContextCtor();
-  try {
-    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-    return computePeaksFromChannelData(audioBuffer.getChannelData(0), RAW_PEAK_COUNT);
-  } finally {
-    if (audioContext.state !== "closed") audioContext.close().catch(() => {});
-  }
 }
 
 /**

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -7,6 +7,7 @@ import {
   resamplePeaks,
 } from "../../utils/audioWaveform";
 import { cn } from "../../utils/cn";
+import { useFittedBarCount } from "../../utils/useFittedBarCount";
 import { PauseIcon } from "../Icons/PauseIcon";
 import { PlayIcon } from "../Icons/PlayIcon";
 
@@ -97,7 +98,11 @@ export const AudioPlayer = React.forwardRef<HTMLDivElement, AudioPlayerProps>(
 
     const [currentTime, setCurrentTime] = React.useState(0);
     const [mediaDuration, setMediaDuration] = React.useState<number | undefined>(undefined);
-    const [barCount, setBarCount] = React.useState(DEFAULT_BAR_COUNT);
+    const barCount = useFittedBarCount(trackRef, {
+      barWidthPx: BAR_WIDTH_PX,
+      gapPx: BAR_GAP_PX,
+      fallback: DEFAULT_BAR_COUNT,
+    });
     const [peaks, setPeaks] = React.useState<number[]>(() =>
       generateFallbackPeaks(src, RAW_PEAK_COUNT),
     );
@@ -153,27 +158,6 @@ export const AudioPlayer = React.forwardRef<HTMLDivElement, AudioPlayerProps>(
         abortController.abort();
       };
     }, [src]);
-
-    // Measure the track to decide how many bars fit; falls back to DEFAULT_BAR_COUNT
-    // when layout is unavailable (SSR, jsdom).
-    React.useEffect(() => {
-      const track = trackRef.current;
-      if (!track) return;
-
-      const updateFromWidth = (width: number) => {
-        if (width <= 0) return;
-        setBarCount(Math.max(1, Math.floor((width + BAR_GAP_PX) / (BAR_WIDTH_PX + BAR_GAP_PX))));
-      };
-
-      updateFromWidth(track.getBoundingClientRect().width);
-
-      const observer = new ResizeObserver((entries) => {
-        const entry = entries[0];
-        if (entry) updateFromWidth(entry.contentRect.width);
-      });
-      observer.observe(track);
-      return () => observer.disconnect();
-    }, []);
 
     // Sync the controlled/uncontrolled `playing` state to the media element.
     React.useEffect(() => {

--- a/src/components/VoiceNote/VoiceNote.stories.tsx
+++ b/src/components/VoiceNote/VoiceNote.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { VoiceNote } from "./VoiceNote";
+
+const meta = {
+  title: "Components/VoiceNote",
+  component: VoiceNote,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18178-73101",
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    time: "0:05",
+  },
+  argTypes: {
+    variant: { control: "select", options: ["default", "flat"] },
+    size: { control: "select", options: ["default", "small"] },
+    negative: { control: "boolean" },
+    progress: { control: { type: "range", min: 0, max: 1, step: 0.05 } },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof VoiceNote>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Listening: Story = {
+  args: { progress: 0.4, playing: true, time: "0:02" },
+};
+
+export const Flat: Story = {
+  args: { variant: "flat" },
+};
+
+export const Small: Story = {
+  args: { size: "small" },
+};
+
+export const WithFileName: Story = {
+  args: { fileName: "audio_name.mp4" },
+};
+
+export const WithRemove: Story = {
+  args: { showRemove: true },
+};
+
+export const WithoutControls: Story = {
+  args: { showControls: false },
+};
+
+export const Negative: Story = {
+  args: { negative: true, progress: 0.4, playing: true, time: "0:02" },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-md bg-surface-primary-inverted p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const States: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-4">
+      <VoiceNote {...args} variant="flat" />
+      <VoiceNote {...args} />
+      <VoiceNote {...args} progress={0.4} playing time="0:02" />
+    </div>
+  ),
+};

--- a/src/components/VoiceNote/VoiceNote.stories.tsx
+++ b/src/components/VoiceNote/VoiceNote.stories.tsx
@@ -55,6 +55,10 @@ export const WithFileName: Story = {
   args: { fileName: "audio_name.mp4" },
 };
 
+export const WithLongFileName: Story = {
+  args: { fileName: "a_really_long_voice_message_file_name_that_should_truncate.mp4" },
+};
+
 export const WithRemove: Story = {
   args: { showRemove: true },
 };

--- a/src/components/VoiceNote/VoiceNote.stories.tsx
+++ b/src/components/VoiceNote/VoiceNote.stories.tsx
@@ -35,6 +35,10 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const Player: Story = {
+  args: { src: "https://example.com/voice-note.mp3", duration: 24, time: undefined },
+};
+
 export const Listening: Story = {
   args: { progress: 0.4, playing: true, time: "0:02" },
 };

--- a/src/components/VoiceNote/VoiceNote.test.tsx
+++ b/src/components/VoiceNote/VoiceNote.test.tsx
@@ -1,8 +1,15 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
 import { VoiceNote } from "./VoiceNote";
+
+function getAudioElement(container: HTMLElement): HTMLAudioElement {
+  const audio = container.querySelector("audio");
+  if (!audio) throw new Error("Expected an <audio> element to be rendered");
+  return audio;
+}
 
 describe("VoiceNote", () => {
   describe("API", () => {
@@ -84,6 +91,110 @@ describe("VoiceNote", () => {
       ["with remove", { time: "0:05", showRemove: true }],
     ])("has no accessibility violations (%s)", async (_label, props) => {
       const { container } = render(<VoiceNote {...props} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe("player mode (src)", () => {
+    beforeEach(() => {
+      HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+      HTMLMediaElement.prototype.pause = vi.fn();
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("no network access in tests")));
+      Element.prototype.getBoundingClientRect = vi.fn(
+        () =>
+          ({
+            width: 100,
+            height: 48,
+            top: 0,
+            left: 0,
+            right: 100,
+            bottom: 48,
+            x: 0,
+            y: 0,
+            toJSON: () => {},
+          }) as DOMRect,
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it("exposes a seekable slider with duration-based aria", () => {
+      render(<VoiceNote src="https://example.com/note.mp3" duration={10} />);
+      const slider = screen.getByRole("slider", { name: "Seek" });
+      expect(slider).toHaveAttribute("aria-valuemin", "0");
+      expect(slider).toHaveAttribute("aria-valuemax", "10");
+      expect(slider).toHaveAttribute("aria-valuenow", "0");
+    });
+
+    it("derives the timestamp from the duration and shows a Play button when idle", () => {
+      render(<VoiceNote src="https://example.com/note.mp3" duration={5} />);
+      expect(screen.getByText("0:05")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument();
+    });
+
+    it("drives the media element and fires onPlayPause (uncontrolled)", async () => {
+      const user = userEvent.setup();
+      const onPlayPause = vi.fn();
+      const { container } = render(
+        <VoiceNote src="https://example.com/note.mp3" duration={5} onPlayPause={onPlayPause} />,
+      );
+      const audio = getAudioElement(container);
+      vi.mocked(audio.pause).mockClear();
+
+      await user.click(screen.getByRole("button", { name: "Play" }));
+      expect(onPlayPause).toHaveBeenCalledWith(true);
+      expect(audio.play).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Pause" }));
+      expect(onPlayPause).toHaveBeenLastCalledWith(false);
+    });
+
+    it("seeks on click via track position math", () => {
+      const { container } = render(<VoiceNote src="https://example.com/note.mp3" duration={10} />);
+      const audio = getAudioElement(container);
+      const slider = screen.getByRole("slider");
+
+      fireEvent.pointerDown(slider, { clientX: 40 });
+
+      expect(slider).toHaveAttribute("aria-valuenow", "4");
+      expect(audio.currentTime).toBe(4);
+    });
+
+    it("supports keyboard seeking", () => {
+      render(<VoiceNote src="https://example.com/note.mp3" duration={10} />);
+      const slider = screen.getByRole("slider");
+      slider.focus();
+
+      fireEvent.keyDown(slider, { key: "ArrowRight" });
+      expect(slider).toHaveAttribute("aria-valuenow", "1");
+
+      fireEvent.keyDown(slider, { key: "End" });
+      expect(slider).toHaveAttribute("aria-valuenow", "10");
+    });
+
+    it("resets and calls onEnded when playback finishes", () => {
+      const onEnded = vi.fn();
+      const { container } = render(
+        <VoiceNote
+          src="https://example.com/note.mp3"
+          duration={5}
+          defaultPlaying
+          onEnded={onEnded}
+        />,
+      );
+      const audio = getAudioElement(container);
+      fireEvent.ended(audio);
+
+      expect(onEnded).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument();
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = render(<VoiceNote src="https://example.com/note.mp3" duration={10} />);
       expect(await axe(container)).toHaveNoViolations();
     });
   });

--- a/src/components/VoiceNote/VoiceNote.test.tsx
+++ b/src/components/VoiceNote/VoiceNote.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { VoiceNote } from "./VoiceNote";
+
+describe("VoiceNote", () => {
+  describe("API", () => {
+    it("applies a custom className", () => {
+      render(<VoiceNote className="custom" time="0:05" />);
+      expect(screen.getByRole("group")).toHaveClass("custom");
+    });
+
+    it("forwards the ref", () => {
+      const ref = createRef<HTMLDivElement>();
+      render(<VoiceNote ref={ref} time="0:05" />);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("renders one bar per waveform value", () => {
+      render(<VoiceNote waveform={[0.2, 0.5, 1, 0.4]} time="0:05" />);
+      expect(screen.getByTestId("voice-note-waveform").childElementCount).toBe(4);
+    });
+
+    it("shows the timestamp only when enabled and provided", () => {
+      const { rerender } = render(<VoiceNote time="0:05" />);
+      expect(screen.getByText("0:05")).toBeInTheDocument();
+
+      rerender(<VoiceNote time="0:05" showTimestamp={false} />);
+      expect(screen.queryByText("0:05")).not.toBeInTheDocument();
+    });
+
+    it("renders the file name when provided", () => {
+      render(<VoiceNote fileName="audio_name.mp4" time="0:05" />);
+      expect(screen.getByText("audio_name.mp4")).toBeInTheDocument();
+    });
+
+    it("hides the play control when showControls is false", () => {
+      render(<VoiceNote showControls={false} time="0:05" />);
+      expect(screen.queryByRole("button", { name: /play/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("playback control", () => {
+    it("toggles the icon/label and calls onPlayPause when uncontrolled", () => {
+      const onPlayPause = vi.fn();
+      render(<VoiceNote time="0:05" onPlayPause={onPlayPause} />);
+
+      const button = screen.getByRole("button", { name: "Play" });
+      fireEvent.click(button);
+
+      expect(onPlayPause).toHaveBeenCalledWith(true);
+      expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+    });
+
+    it("respects the controlled playing prop", () => {
+      const onPlayPause = vi.fn();
+      render(<VoiceNote time="0:05" playing onPlayPause={onPlayPause} />);
+
+      const button = screen.getByRole("button", { name: "Pause" });
+      fireEvent.click(button);
+
+      expect(onPlayPause).toHaveBeenCalledWith(false);
+      expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+    });
+  });
+
+  describe("remove control", () => {
+    it("renders a remove button and calls onRemove", () => {
+      const onRemove = vi.fn();
+      render(<VoiceNote time="0:05" showRemove onRemove={onRemove} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("accessibility", () => {
+    it.each([
+      ["default resting", { time: "0:05" }],
+      ["flat", { variant: "flat" as const, time: "0:05" }],
+      ["listening", { progress: 0.4, playing: true, time: "0:02" }],
+      ["negative", { negative: true, time: "0:05" }],
+      ["with remove", { time: "0:05", showRemove: true }],
+    ])("has no accessibility violations (%s)", async (_label, props) => {
+      const { container } = render(<VoiceNote {...props} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/VoiceNote/VoiceNote.test.tsx
+++ b/src/components/VoiceNote/VoiceNote.test.tsx
@@ -24,9 +24,21 @@ describe("VoiceNote", () => {
       expect(ref.current).toBeInstanceOf(HTMLDivElement);
     });
 
-    it("renders one bar per waveform value", () => {
+    it("fits the bar count to the measured track width", () => {
+      const rectSpy = vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+        width: 100,
+        height: 48,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 48,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      } as DOMRect);
       render(<VoiceNote waveform={[0.2, 0.5, 1, 0.4]} time="0:05" />);
-      expect(screen.getByTestId("voice-note-waveform").childElementCount).toBe(4);
+      expect(screen.getByTestId("voice-note-waveform").childElementCount).toBe(13);
+      rectSpy.mockRestore();
     });
 
     it("shows the timestamp only when enabled and provided", () => {

--- a/src/components/VoiceNote/VoiceNote.tsx
+++ b/src/components/VoiceNote/VoiceNote.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { formatTime, resamplePeaks } from "@/utils/audioWaveform";
 import { cn } from "@/utils/cn";
 import { useAudioPlayback } from "@/utils/useAudioPlayback";
+import { useFittedBarCount } from "@/utils/useFittedBarCount";
 import { useWaveformPeaks } from "@/utils/useWaveformPeaks";
 import { useWaveformSeek } from "@/utils/useWaveformSeek";
 import { IconButton, type IconButtonSize } from "../IconButton/IconButton";
@@ -37,8 +38,12 @@ const CONTROL_SIZE: Record<VoiceNoteSize, IconButtonSize> = {
   small: "32",
 };
 
-/** Bars rendered when playing decoded audio (decoded peaks are resampled to this count). */
-const PLAYER_BAR_COUNT = 56;
+/** Rendered width of a single waveform bar, in pixels (`w-1`). */
+const BAR_WIDTH_PX = 4;
+/** Gap between waveform bars, in pixels (`gap-1`). */
+const BAR_GAP_PX = 4;
+/** Bar count before the track is measured (SSR, jsdom, or zero-width layout). */
+const DEFAULT_BAR_COUNT = 40;
 
 function activeBarClass(negative: boolean): string {
   return negative
@@ -110,7 +115,12 @@ function WaveformMeta({ time, fileName, textColor }: WaveformMetaProps) {
         <span className={cn("typography-body-small-14px-regular shrink-0", textColor)}>{time}</span>
       )}
       {fileName && (
-        <span className={cn("typography-body-small-14px-regular shrink-0 truncate", textColor)}>
+        <span
+          className={cn(
+            "typography-body-small-14px-regular min-w-0 max-w-[50%] truncate",
+            textColor,
+          )}
+        >
           {fileName}
         </span>
       )}
@@ -232,6 +242,11 @@ export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
     const isControlled = playing !== undefined;
 
     const trackRef = React.useRef<HTMLDivElement>(null);
+    const fittedBarCount = useFittedBarCount(trackRef, {
+      barWidthPx: BAR_WIDTH_PX,
+      gapPx: BAR_GAP_PX,
+      fallback: DEFAULT_BAR_COUNT,
+    });
     const seekProps = useWaveformSeek({
       trackRef,
       displayDuration: playback.displayDuration,
@@ -252,7 +267,7 @@ export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
       onPlayPause?.(next);
     };
 
-    const bars = isPlayer ? resamplePeaks(decodedPeaks, PLAYER_BAR_COUNT) : waveform;
+    const bars = resamplePeaks(isPlayer ? decodedPeaks : waveform, fittedBarCount);
     const progressValue = isPlayer ? playback.progress : progress;
     const textColor = negative ? "text-content-primary-inverted" : "text-content-primary";
 

--- a/src/components/VoiceNote/VoiceNote.tsx
+++ b/src/components/VoiceNote/VoiceNote.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
+import { formatTime, resamplePeaks } from "@/utils/audioWaveform";
 import { cn } from "@/utils/cn";
+import { useAudioPlayback } from "@/utils/useAudioPlayback";
+import { useWaveformPeaks } from "@/utils/useWaveformPeaks";
+import { useWaveformSeek } from "@/utils/useWaveformSeek";
 import { IconButton, type IconButtonSize } from "../IconButton/IconButton";
 import { CloseIcon } from "../Icons/CloseIcon";
 import { PauseIcon } from "../Icons/PauseIcon";
@@ -13,7 +17,7 @@ export type VoiceNoteSize = "default" | "small";
 
 /**
  * Default waveform amplitudes (0–1), taken from the Figma reference so the
- * resting state renders 1:1 when no `waveform` data is supplied.
+ * resting state renders 1:1 when no `waveform` data (or `src`) is supplied.
  */
 const DEFAULT_WAVEFORM = [
   0.15, 0.46, 0.85, 0.23, 1, 0.85, 0.62, 0.62, 0.62, 0.85, 0.85, 0.62, 0.62, 1, 1, 0.62, 0.62, 0.62,
@@ -33,6 +37,9 @@ const CONTROL_SIZE: Record<VoiceNoteSize, IconButtonSize> = {
   small: "32",
 };
 
+/** Bars rendered when playing decoded audio (decoded peaks are resampled to this count). */
+const PLAYER_BAR_COUNT = 56;
+
 function activeBarClass(negative: boolean): string {
   return negative
     ? "bg-messages-waveform-listening-negative-active"
@@ -51,9 +58,78 @@ function restingBarClass(negative: boolean): string {
     : "bg-messages-waveform-default";
 }
 
+interface WaveformBarsProps {
+  bars: number[];
+  variant: VoiceNoteVariant;
+  size: VoiceNoteSize;
+  negative: boolean;
+  progress: number | undefined;
+}
+
+function WaveformBars({ bars, variant, size, negative, progress }: WaveformBarsProps) {
+  const hasProgress = progress !== undefined;
+  const activeCount = hasProgress ? Math.round(progress * bars.length) : 0;
+  const maxBarHeight = MAX_BAR_HEIGHT[size];
+
+  return (
+    <>
+      {bars.map((amplitude, index) => {
+        const height =
+          variant === "flat"
+            ? MIN_BAR_HEIGHT
+            : Math.max(MIN_BAR_HEIGHT, Math.round(amplitude * maxBarHeight));
+        const colorClass = !hasProgress
+          ? restingBarClass(negative)
+          : index < activeCount
+            ? activeBarClass(negative)
+            : inactiveBarClass(negative);
+
+        return (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: bars are a fixed positional sequence
+            key={index}
+            className={cn("w-1 shrink-0 rounded-[2px]", colorClass)}
+            style={{ height }}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+interface WaveformMetaProps {
+  time: string | undefined;
+  fileName: string | undefined;
+  textColor: string;
+}
+
+function WaveformMeta({ time, fileName, textColor }: WaveformMetaProps) {
+  return (
+    <>
+      {time && (
+        <span className={cn("typography-body-small-14px-regular shrink-0", textColor)}>{time}</span>
+      )}
+      {fileName && (
+        <span className={cn("typography-body-small-14px-regular shrink-0 truncate", textColor)}>
+          {fileName}
+        </span>
+      )}
+    </>
+  );
+}
+
 export interface VoiceNoteProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "onPlay" | "onPause"> {
-  /** Amplitude values (0–1), one per bar. Falls back to a built-in pattern. */
+  /**
+   * URL of the audio to play. When set, the component manages a real `<audio>`
+   * element: it decodes the waveform, plays/pauses, tracks live progress and is
+   * seekable — `waveform`/`progress` are derived automatically. Leave unset for
+   * a presentational, fully-controlled voice note.
+   */
+  src?: string;
+  /** Fallback total duration (seconds), used until the media's metadata loads. */
+  duration?: number;
+  /** Amplitude values (0–1), one per bar. Ignored when `src` is set. Falls back to a built-in pattern. */
   waveform?: number[];
   /** Visual style; `flat` renders a simplified dotted preview. @default "default" */
   variant?: VoiceNoteVariant;
@@ -62,8 +138,9 @@ export interface VoiceNoteProps
   /** Dark-surface treatment for use on message bubbles. @default false */
   negative?: boolean;
   /**
-   * Playback progress (0–1). When set, the waveform splits into played/unplayed
-   * bars (the "Listening" state). Leave undefined for the resting waveform.
+   * Playback progress (0–1) for the presentational mode. When set, the waveform
+   * splits into played/unplayed bars (the "Listening" state). Ignored when `src`
+   * is set (progress comes from the media element).
    */
   progress?: number;
   /** Whether audio is playing (controlled) — toggles the play/pause icon. */
@@ -72,7 +149,9 @@ export interface VoiceNoteProps
   defaultPlaying?: boolean;
   /** Called with the next playing state when the play/pause control is pressed. */
   onPlayPause?: (playing: boolean) => void;
-  /** Timestamp or duration label, e.g. "0:05". */
+  /** Called when audio playback reaches the end (only in `src` mode). */
+  onEnded?: () => void;
+  /** Timestamp or duration label, e.g. "0:05". Ignored when `src` is set (derived from the media). */
   time?: string;
   /** File name shown when the audio is an uploaded file rather than a voice note. */
   fileName?: string;
@@ -96,13 +175,15 @@ export interface VoiceNoteProps
  * A voice-note audio player: a play/pause control, an amplitude waveform, and a
  * timestamp — for voice messages and audio attachments in a conversation.
  *
- * Presentational and controlled: supply `playing`/`progress` and handle
- * `onPlayPause` to wire it to real audio (for media-thumbnail playback use
- * {@link AudioPlayer} instead). `flat` renders a compact dotted preview and
+ * Two modes: pass `src` for a self-contained player that decodes the waveform,
+ * plays real audio, tracks live progress and is seekable; or omit `src` and
+ * drive it with `playing`/`progress` + `onPlayPause` for a presentational,
+ * fully-controlled voice note. `flat` renders a compact dotted preview and
  * `negative` adapts it to dark message bubbles.
  *
  * @example
  * ```tsx
+ * <VoiceNote src="https://example.com/note.mp3" duration={5} />
  * <VoiceNote time="0:05" progress={0.4} playing onPlayPause={toggle} />
  * ```
  */
@@ -110,6 +191,8 @@ export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
   (
     {
       className,
+      src,
+      duration,
       waveform = DEFAULT_WAVEFORM,
       variant = "default",
       size = "default",
@@ -118,6 +201,7 @@ export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
       playing,
       defaultPlaying = false,
       onPlayPause,
+      onEnded,
       time,
       fileName,
       showControls = true,
@@ -131,20 +215,51 @@ export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
     },
     ref,
   ) => {
-    const isControlled = playing !== undefined;
+    const isPlayer = src !== undefined;
+
+    const playback = useAudioPlayback({
+      src,
+      duration,
+      playing,
+      defaultPlaying,
+      onEnded,
+      onPlay: React.useCallback(() => onPlayPause?.(true), [onPlayPause]),
+      onPause: React.useCallback(() => onPlayPause?.(false), [onPlayPause]),
+    });
+    const decodedPeaks = useWaveformPeaks(src);
+
     const [internalPlaying, setInternalPlaying] = React.useState(defaultPlaying);
-    const isPlaying = isControlled ? playing : internalPlaying;
+    const isControlled = playing !== undefined;
+
+    const trackRef = React.useRef<HTMLDivElement>(null);
+    const seekProps = useWaveformSeek({
+      trackRef,
+      displayDuration: playback.displayDuration,
+      currentTime: playback.currentTime,
+      seekTo: playback.seekTo,
+      setSeeking: playback.setSeeking,
+    });
+
+    const isPlaying = isPlayer ? playback.isPlaying : (playing ?? internalPlaying);
 
     const handlePlayPause = () => {
+      if (isPlayer) {
+        playback.toggle();
+        return;
+      }
       const next = !isPlaying;
       if (!isControlled) setInternalPlaying(next);
       onPlayPause?.(next);
     };
 
-    const hasProgress = progress !== undefined;
-    const activeCount = hasProgress ? Math.round(progress * waveform.length) : 0;
-    const maxBarHeight = MAX_BAR_HEIGHT[size];
+    const bars = isPlayer ? resamplePeaks(decodedPeaks, PLAYER_BAR_COUNT) : waveform;
+    const progressValue = isPlayer ? playback.progress : progress;
     const textColor = negative ? "text-content-primary-inverted" : "text-content-primary";
+
+    const playerTime = playback.hasStarted ? playback.currentTime : playback.displayDuration;
+    const displayTime = isPlayer ? formatTime(playerTime) : time;
+    const controlLabel = playButtonLabel ?? (isPlaying ? "Pause" : "Play");
+    const trackAria = isPlayer ? seekProps : ({ "aria-hidden": true } as const);
 
     return (
       // biome-ignore lint/a11y/useSemanticElements: <fieldset> would break the public HTMLDivElement ref/props API
@@ -161,49 +276,35 @@ export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
             size={CONTROL_SIZE[size]}
             negative={negative}
             icon={isPlaying ? <PauseIcon /> : <PlayIcon />}
-            aria-label={playButtonLabel ?? (isPlaying ? "Pause" : "Play")}
+            aria-label={controlLabel}
             onClick={handlePlayPause}
           />
         )}
 
         <div
+          ref={trackRef}
           data-testid="voice-note-waveform"
-          className="flex h-full min-w-0 flex-1 items-center gap-1 overflow-hidden"
-          aria-hidden="true"
+          className={cn(
+            "flex h-full min-w-0 flex-1 items-center gap-1 overflow-hidden",
+            isPlayer &&
+              "cursor-pointer touch-none select-none focus-visible:shadow-focus-ring focus-visible:outline-none",
+          )}
+          {...trackAria}
         >
-          {waveform.map((amplitude, index) => {
-            const height =
-              variant === "flat"
-                ? MIN_BAR_HEIGHT
-                : Math.max(MIN_BAR_HEIGHT, Math.round(amplitude * maxBarHeight));
-            const colorClass = hasProgress
-              ? index < activeCount
-                ? activeBarClass(negative)
-                : inactiveBarClass(negative)
-              : restingBarClass(negative);
-
-            return (
-              <span
-                // biome-ignore lint/suspicious/noArrayIndexKey: bars are a fixed positional sequence
-                key={index}
-                className={cn("w-1 shrink-0 rounded-[2px]", colorClass)}
-                style={{ height }}
-              />
-            );
-          })}
+          <WaveformBars
+            bars={bars}
+            variant={variant}
+            size={size}
+            negative={negative}
+            progress={progressValue}
+          />
         </div>
 
-        {showTimestamp && time && (
-          <span className={cn("typography-body-small-14px-regular shrink-0", textColor)}>
-            {time}
-          </span>
-        )}
-
-        {fileName && (
-          <span className={cn("typography-body-small-14px-regular shrink-0 truncate", textColor)}>
-            {fileName}
-          </span>
-        )}
+        <WaveformMeta
+          time={showTimestamp ? displayTime : undefined}
+          fileName={fileName}
+          textColor={textColor}
+        />
 
         {showRemove && (
           <IconButton
@@ -213,6 +314,19 @@ export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
             icon={<CloseIcon />}
             aria-label={removeButtonLabel}
             onClick={onRemove}
+          />
+        )}
+
+        {isPlayer && (
+          // biome-ignore lint/a11y/useMediaCaption: a UI voice note / short recording, not narrated content needing captions
+          <audio
+            ref={playback.audioRef}
+            src={src}
+            preload="metadata"
+            className="hidden"
+            onLoadedMetadata={playback.audioHandlers.onLoadedMetadata}
+            onTimeUpdate={playback.audioHandlers.onTimeUpdate}
+            onEnded={playback.audioHandlers.onEnded}
           />
         )}
       </div>

--- a/src/components/VoiceNote/VoiceNote.tsx
+++ b/src/components/VoiceNote/VoiceNote.tsx
@@ -1,0 +1,223 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+import { IconButton, type IconButtonSize } from "../IconButton/IconButton";
+import { CloseIcon } from "../Icons/CloseIcon";
+import { PauseIcon } from "../Icons/PauseIcon";
+import { PlayIcon } from "../Icons/PlayIcon";
+
+/** Visual style of the waveform. */
+export type VoiceNoteVariant = "default" | "flat";
+
+/** Size preset for the voice note. */
+export type VoiceNoteSize = "default" | "small";
+
+/**
+ * Default waveform amplitudes (0–1), taken from the Figma reference so the
+ * resting state renders 1:1 when no `waveform` data is supplied.
+ */
+const DEFAULT_WAVEFORM = [
+  0.15, 0.46, 0.85, 0.23, 1, 0.85, 0.62, 0.62, 0.62, 0.85, 0.85, 0.62, 0.62, 1, 1, 0.62, 0.62, 0.62,
+  0.23, 0.23, 0.15, 0.46, 0.85, 0.23, 1, 0.46, 0.85, 0.62, 0.23, 0.23, 0.62, 0.62, 0.85, 0.85, 0.62,
+  0.62, 0.85, 1, 0.85, 1, 0.62, 0.62, 0.62, 0.23, 0.23, 0.62, 0.23, 0.23, 0.23, 0.62, 0.85, 0.62,
+  0.85, 1, 0.85, 0.85, 1, 0.85, 0.23, 0.23, 0.23, 0.46, 0.62, 0.23, 0.23,
+];
+
+const MIN_BAR_HEIGHT = 4;
+const MAX_BAR_HEIGHT: Record<VoiceNoteSize, number> = {
+  default: 26,
+  small: 16,
+};
+
+const CONTROL_SIZE: Record<VoiceNoteSize, IconButtonSize> = {
+  default: "48",
+  small: "32",
+};
+
+function activeBarClass(negative: boolean): string {
+  return negative
+    ? "bg-messages-waveform-listening-negative-active"
+    : "bg-messages-waveform-listening-active";
+}
+
+function inactiveBarClass(negative: boolean): string {
+  return negative
+    ? "bg-messages-waveform-listening-negative-inactive"
+    : "bg-messages-waveform-listening-inactive";
+}
+
+function restingBarClass(negative: boolean): string {
+  return negative
+    ? "bg-messages-waveform-listening-negative-default"
+    : "bg-messages-waveform-default";
+}
+
+export interface VoiceNoteProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onPlay" | "onPause"> {
+  /** Amplitude values (0–1), one per bar. Falls back to a built-in pattern. */
+  waveform?: number[];
+  /** Visual style; `flat` renders a simplified dotted preview. @default "default" */
+  variant?: VoiceNoteVariant;
+  /** Size preset. @default "default" */
+  size?: VoiceNoteSize;
+  /** Dark-surface treatment for use on message bubbles. @default false */
+  negative?: boolean;
+  /**
+   * Playback progress (0–1). When set, the waveform splits into played/unplayed
+   * bars (the "Listening" state). Leave undefined for the resting waveform.
+   */
+  progress?: number;
+  /** Whether audio is playing (controlled) — toggles the play/pause icon. */
+  playing?: boolean;
+  /** Initial playing state (uncontrolled). @default false */
+  defaultPlaying?: boolean;
+  /** Called with the next playing state when the play/pause control is pressed. */
+  onPlayPause?: (playing: boolean) => void;
+  /** Timestamp or duration label, e.g. "0:05". */
+  time?: string;
+  /** File name shown when the audio is an uploaded file rather than a voice note. */
+  fileName?: string;
+  /** Show the play/pause control. @default true */
+  showControls?: boolean;
+  /** Show the timestamp label. @default true */
+  showTimestamp?: boolean;
+  /** Show a remove button (calls {@link VoiceNoteProps.onRemove}). @default false */
+  showRemove?: boolean;
+  /** Called when the remove button is pressed. */
+  onRemove?: () => void;
+  /** Accessible name for the play/pause control. Defaults to "Play"/"Pause". */
+  playButtonLabel?: string;
+  /** Accessible name for the remove button. @default "Remove" */
+  removeButtonLabel?: string;
+  /** Accessible name for the whole player. @default "Voice note" */
+  "aria-label"?: string;
+}
+
+/**
+ * A voice-note audio player: a play/pause control, an amplitude waveform, and a
+ * timestamp — for voice messages and audio attachments in a conversation.
+ *
+ * Presentational and controlled: supply `playing`/`progress` and handle
+ * `onPlayPause` to wire it to real audio (for media-thumbnail playback use
+ * {@link AudioPlayer} instead). `flat` renders a compact dotted preview and
+ * `negative` adapts it to dark message bubbles.
+ *
+ * @example
+ * ```tsx
+ * <VoiceNote time="0:05" progress={0.4} playing onPlayPause={toggle} />
+ * ```
+ */
+export const VoiceNote = React.forwardRef<HTMLDivElement, VoiceNoteProps>(
+  (
+    {
+      className,
+      waveform = DEFAULT_WAVEFORM,
+      variant = "default",
+      size = "default",
+      negative = false,
+      progress,
+      playing,
+      defaultPlaying = false,
+      onPlayPause,
+      time,
+      fileName,
+      showControls = true,
+      showTimestamp = true,
+      showRemove = false,
+      onRemove,
+      playButtonLabel,
+      removeButtonLabel = "Remove",
+      "aria-label": ariaLabel = "Voice note",
+      ...props
+    },
+    ref,
+  ) => {
+    const isControlled = playing !== undefined;
+    const [internalPlaying, setInternalPlaying] = React.useState(defaultPlaying);
+    const isPlaying = isControlled ? playing : internalPlaying;
+
+    const handlePlayPause = () => {
+      const next = !isPlaying;
+      if (!isControlled) setInternalPlaying(next);
+      onPlayPause?.(next);
+    };
+
+    const hasProgress = progress !== undefined;
+    const activeCount = hasProgress ? Math.round(progress * waveform.length) : 0;
+    const maxBarHeight = MAX_BAR_HEIGHT[size];
+    const textColor = negative ? "text-content-primary-inverted" : "text-content-primary";
+
+    return (
+      // biome-ignore lint/a11y/useSemanticElements: <fieldset> would break the public HTMLDivElement ref/props API
+      <div
+        ref={ref}
+        role="group"
+        aria-label={ariaLabel}
+        className={cn("flex items-center gap-3", size === "small" ? "h-8" : "h-12", className)}
+        {...props}
+      >
+        {showControls && (
+          <IconButton
+            variant="secondary"
+            size={CONTROL_SIZE[size]}
+            negative={negative}
+            icon={isPlaying ? <PauseIcon /> : <PlayIcon />}
+            aria-label={playButtonLabel ?? (isPlaying ? "Pause" : "Play")}
+            onClick={handlePlayPause}
+          />
+        )}
+
+        <div
+          data-testid="voice-note-waveform"
+          className="flex h-full min-w-0 flex-1 items-center gap-1 overflow-hidden"
+          aria-hidden="true"
+        >
+          {waveform.map((amplitude, index) => {
+            const height =
+              variant === "flat"
+                ? MIN_BAR_HEIGHT
+                : Math.max(MIN_BAR_HEIGHT, Math.round(amplitude * maxBarHeight));
+            const colorClass = hasProgress
+              ? index < activeCount
+                ? activeBarClass(negative)
+                : inactiveBarClass(negative)
+              : restingBarClass(negative);
+
+            return (
+              <span
+                // biome-ignore lint/suspicious/noArrayIndexKey: bars are a fixed positional sequence
+                key={index}
+                className={cn("w-1 shrink-0 rounded-[2px]", colorClass)}
+                style={{ height }}
+              />
+            );
+          })}
+        </div>
+
+        {showTimestamp && time && (
+          <span className={cn("typography-body-small-14px-regular shrink-0", textColor)}>
+            {time}
+          </span>
+        )}
+
+        {fileName && (
+          <span className={cn("typography-body-small-14px-regular shrink-0 truncate", textColor)}>
+            {fileName}
+          </span>
+        )}
+
+        {showRemove && (
+          <IconButton
+            variant="tertiary"
+            size={CONTROL_SIZE[size]}
+            negative={negative}
+            icon={<CloseIcon />}
+            aria-label={removeButtonLabel}
+            onClick={onRemove}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+VoiceNote.displayName = "VoiceNote";

--- a/src/index.ts
+++ b/src/index.ts
@@ -541,7 +541,6 @@ export type { WifiOffIconProps } from "./components/Icons/WifiOffIcon";
 export { WifiOffIcon } from "./components/Icons/WifiOffIcon";
 export { WifiOnIcon } from "./components/Icons/WifiOnIcon";
 export { WrenchIcon } from "./components/Icons/WrenchIcon";
-
 export type {
   InfoBoxAction,
   InfoBoxContentProps,
@@ -795,6 +794,12 @@ export type {
   UserItemUser,
 } from "./components/UserItem/UserItem";
 export { UserItem } from "./components/UserItem/UserItem";
+export type {
+  VoiceNoteProps,
+  VoiceNoteSize,
+  VoiceNoteVariant,
+} from "./components/VoiceNote/VoiceNote";
+export { VoiceNote } from "./components/VoiceNote/VoiceNote";
 export { cn } from "./utils/cn";
 export { getInitials } from "./utils/getInitials";
 export type { OmitDistributed } from "./utils/types";

--- a/src/utils/audioWaveform.test.ts
+++ b/src/utils/audioWaveform.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  computePeaksFromChannelData,
+  formatTime,
+  generateFallbackPeaks,
+  resamplePeaks,
+} from "./audioWaveform";
+
+describe("audioWaveform", () => {
+  describe("formatTime", () => {
+    it("formats seconds as m:ss", () => {
+      expect(formatTime(0)).toBe("0:00");
+      expect(formatTime(5)).toBe("0:05");
+      expect(formatTime(65)).toBe("1:05");
+      expect(formatTime(600)).toBe("10:00");
+    });
+
+    it("returns a placeholder for unknown values", () => {
+      expect(formatTime(undefined)).toBe("--:--");
+      expect(formatTime(Number.NaN)).toBe("--:--");
+      expect(formatTime(Number.POSITIVE_INFINITY)).toBe("--:--");
+    });
+
+    it("clamps negatives to zero", () => {
+      expect(formatTime(-5)).toBe("0:00");
+    });
+  });
+
+  describe("generateFallbackPeaks", () => {
+    it("is deterministic for the same src", () => {
+      expect(generateFallbackPeaks("a.mp3", 16)).toEqual(generateFallbackPeaks("a.mp3", 16));
+    });
+
+    it("differs for a different src", () => {
+      expect(generateFallbackPeaks("a.mp3", 16)).not.toEqual(generateFallbackPeaks("b.mp3", 16));
+    });
+
+    it("produces the requested count within [0.2, 1]", () => {
+      const peaks = generateFallbackPeaks("a.mp3", 32);
+      expect(peaks).toHaveLength(32);
+      for (const p of peaks) {
+        expect(p).toBeGreaterThanOrEqual(0.2);
+        expect(p).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  describe("computePeaksFromChannelData", () => {
+    it("downsamples to the requested count of max-abs peaks", () => {
+      const data = new Float32Array([0, -0.5, 0.25, 1, -0.75, 0.1]);
+      expect(computePeaksFromChannelData(data, 3)).toEqual([0.5, 1, 0.75]);
+    });
+  });
+
+  describe("resamplePeaks", () => {
+    it("returns an empty array for empty input or non-positive count", () => {
+      expect(resamplePeaks([], 4)).toEqual([]);
+      expect(resamplePeaks([1, 2], 0)).toEqual([]);
+    });
+
+    it("upsamples and downsamples to the requested length", () => {
+      expect(resamplePeaks([0, 1], 4)).toHaveLength(4);
+      expect(resamplePeaks([0, 0.5, 1, 0.5], 2)).toHaveLength(2);
+    });
+  });
+});

--- a/src/utils/audioWaveform.ts
+++ b/src/utils/audioWaveform.ts
@@ -1,0 +1,81 @@
+/** Number of amplitude samples decoded/kept internally, resampled to the rendered bar count. */
+export const RAW_PEAK_COUNT = 128;
+
+/** Formats a duration in seconds as `m:ss`, or `--:--` when unknown. */
+export function formatTime(seconds: number | undefined): string {
+  if (seconds === undefined || !Number.isFinite(seconds)) return "--:--";
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
+}
+
+/** Deterministic 32-bit string hash (FNV-1a), used to seed the fallback waveform. */
+export function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+/** Seeded PRNG (mulberry32) — deterministic across runs, unlike `Math.random`. */
+export function createSeededRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Deterministic placeholder amplitudes used when audio can't be decoded (network/CORS/format failure). */
+export function generateFallbackPeaks(src: string, count: number): number[] {
+  const random = createSeededRandom(hashString(src));
+  return Array.from({ length: count }, () => 0.2 + random() * 0.8);
+}
+
+/** Downsamples decoded PCM data to `count` peak (max-abs) amplitudes. */
+export function computePeaksFromChannelData(channelData: Float32Array, count: number): number[] {
+  const blockSize = Math.max(1, Math.floor(channelData.length / count));
+  const peaks: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const start = i * blockSize;
+    let max = 0;
+    for (let j = 0; j < blockSize && start + j < channelData.length; j++) {
+      max = Math.max(max, Math.abs(channelData[start + j] ?? 0));
+    }
+    peaks.push(max);
+  }
+  return peaks;
+}
+
+/** Resamples a peaks array to `barCount` values (nearest-neighbour). */
+export function resamplePeaks(peaks: number[], barCount: number): number[] {
+  if (peaks.length === 0 || barCount <= 0) return [];
+  const step = peaks.length / barCount;
+  return Array.from(
+    { length: barCount },
+    (_, i) => peaks[Math.min(peaks.length - 1, Math.floor(i * step))] ?? 0,
+  );
+}
+
+/** Decodes `src` via WebAudio and returns downsampled peak amplitudes. Throws on any failure. */
+export async function decodeAudioPeaks(src: string, signal: AbortSignal): Promise<number[]> {
+  const AudioContextCtor =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!AudioContextCtor) throw new Error("WebAudio unsupported");
+
+  const response = await fetch(src, { signal });
+  const arrayBuffer = await response.arrayBuffer();
+  const audioContext = new AudioContextCtor();
+  try {
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    return computePeaksFromChannelData(audioBuffer.getChannelData(0), RAW_PEAK_COUNT);
+  } finally {
+    if (audioContext.state !== "closed") audioContext.close().catch(() => {});
+  }
+}

--- a/src/utils/useAudioPlayback.ts
+++ b/src/utils/useAudioPlayback.ts
@@ -1,0 +1,178 @@
+import * as React from "react";
+
+/** Options for {@link useAudioPlayback}. */
+export interface UseAudioPlaybackOptions {
+  /** URL of the audio to play. When absent, the hook stays idle (no media element attached). */
+  src?: string;
+  /** Fallback total duration (seconds) used until the media's own metadata loads. */
+  duration?: number;
+  /** Whether playback is active (controlled). */
+  playing?: boolean;
+  /** Initial playing state (uncontrolled). @default false */
+  defaultPlaying?: boolean;
+  /** Called when playback starts (via the toggle). */
+  onPlay?: () => void;
+  /** Called when playback pauses (via the toggle, a failed play(), or a src swap). */
+  onPause?: () => void;
+  /** Called when playback reaches the end of the media. */
+  onEnded?: () => void;
+}
+
+/** Handlers to spread onto the backing `<audio>` element. */
+export interface AudioElementHandlers {
+  onLoadedMetadata: (event: React.SyntheticEvent<HTMLAudioElement>) => void;
+  onTimeUpdate: (event: React.SyntheticEvent<HTMLAudioElement>) => void;
+  onEnded: () => void;
+}
+
+/** Result of {@link useAudioPlayback}. */
+export interface UseAudioPlaybackResult {
+  /** Attach to the backing `<audio>` element. */
+  audioRef: React.RefObject<HTMLAudioElement | null>;
+  /** Current play/pause state (respects controlled `playing`). */
+  isPlaying: boolean;
+  /** Toggle play/pause, firing `onPlay`/`onPause`. */
+  toggle: () => void;
+  /** Current playback position in seconds. */
+  currentTime: number;
+  /** Media duration once known, else the `duration` fallback. */
+  displayDuration: number | undefined;
+  /** Playback progress, 0–1. */
+  progress: number;
+  /** Whether playback has begun (playing or scrubbed past 0). */
+  hasStarted: boolean;
+  /** Seek to a time in seconds (clamped to the duration). */
+  seekTo: (time: number) => void;
+  /** Suppress `timeupdate`-driven position updates while a manual scrub is in progress. */
+  setSeeking: (seeking: boolean) => void;
+  /** Handlers to spread onto the `<audio>` element. */
+  audioHandlers: AudioElementHandlers;
+}
+
+/**
+ * Drives a single `<audio>` element: controlled/uncontrolled play/pause, live
+ * position + duration, seeking, and src-swap resets. Extracted from
+ * {@link AudioPlayer} so waveform players (e.g. {@link VoiceNote}) can share the
+ * same playback engine without duplicating the effect wiring.
+ */
+export function useAudioPlayback({
+  src,
+  duration,
+  playing: controlledPlaying,
+  defaultPlaying = false,
+  onPlay,
+  onPause,
+  onEnded,
+}: UseAudioPlaybackOptions): UseAudioPlaybackResult {
+  const audioRef = React.useRef<HTMLAudioElement>(null);
+
+  const [internalPlaying, setInternalPlaying] = React.useState(defaultPlaying);
+  const isControlled = controlledPlaying !== undefined;
+  const isPlaying = isControlled ? controlledPlaying : internalPlaying;
+
+  const [currentTime, setCurrentTime] = React.useState(0);
+  const [mediaDuration, setMediaDuration] = React.useState<number | undefined>(undefined);
+  const seekingRef = React.useRef(false);
+
+  const displayDuration = mediaDuration ?? duration;
+  const hasStarted = isPlaying || currentTime > 0;
+
+  // Latest-value refs so the src-change effect can react to a src swap without
+  // re-running whenever playing/isControlled/onPause change.
+  const playingRef = React.useRef(isPlaying);
+  playingRef.current = isPlaying;
+  const isControlledRef = React.useRef(isControlled);
+  isControlledRef.current = isControlled;
+  const onPauseRef = React.useRef(onPause);
+  onPauseRef.current = onPause;
+
+  // Reset transient playback state on source change; skip the initial mount and,
+  // if playback was active, stop it (the browser drops playback on a src swap).
+  const isFirstSrcRenderRef = React.useRef(true);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally keyed on src to reset transient state on a source swap
+  React.useEffect(() => {
+    if (isFirstSrcRenderRef.current) {
+      isFirstSrcRenderRef.current = false;
+      return;
+    }
+    setCurrentTime(0);
+    setMediaDuration(undefined);
+    if (playingRef.current) {
+      if (!isControlledRef.current) setInternalPlaying(false);
+      onPauseRef.current?.();
+    }
+  }, [src]);
+
+  // Sync the controlled/uncontrolled playing state to the media element.
+  React.useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.play().catch(() => {
+        if (!isControlled) setInternalPlaying(false);
+        onPauseRef.current?.();
+      });
+    } else {
+      audio.pause();
+    }
+  }, [isPlaying, isControlled]);
+
+  const toggle = React.useCallback(() => {
+    const next = !playingRef.current;
+    if (!isControlledRef.current) setInternalPlaying(next);
+    if (next) onPlay?.();
+    else onPause?.();
+  }, [onPlay, onPause]);
+
+  const seekTo = React.useCallback(
+    (time: number) => {
+      if (displayDuration === undefined) return;
+      const clamped = Math.min(Math.max(time, 0), displayDuration);
+      setCurrentTime(clamped);
+      const audio = audioRef.current;
+      if (audio) audio.currentTime = clamped;
+    },
+    [displayDuration],
+  );
+
+  const setSeeking = React.useCallback((seeking: boolean) => {
+    seekingRef.current = seeking;
+  }, []);
+
+  const progress =
+    displayDuration && displayDuration > 0
+      ? Math.min(Math.max(currentTime / displayDuration, 0), 1)
+      : 0;
+
+  const audioHandlers = React.useMemo<AudioElementHandlers>(
+    () => ({
+      onLoadedMetadata: (event) => {
+        const nativeDuration = event.currentTarget.duration;
+        setMediaDuration(Number.isFinite(nativeDuration) ? nativeDuration : undefined);
+      },
+      onTimeUpdate: (event) => {
+        if (seekingRef.current) return;
+        setCurrentTime(event.currentTarget.currentTime);
+      },
+      onEnded: () => {
+        setCurrentTime(0);
+        if (!isControlledRef.current) setInternalPlaying(false);
+        onEnded?.();
+      },
+    }),
+    [onEnded],
+  );
+
+  return {
+    audioRef,
+    isPlaying,
+    toggle,
+    currentTime,
+    displayDuration,
+    progress,
+    hasStarted,
+    seekTo,
+    setSeeking,
+    audioHandlers,
+  };
+}

--- a/src/utils/useFittedBarCount.ts
+++ b/src/utils/useFittedBarCount.ts
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+/** Options for {@link useFittedBarCount}. */
+export interface UseFittedBarCountOptions {
+  /** Rendered width of a single bar, in pixels. */
+  barWidthPx: number;
+  /** Gap between bars, in pixels. */
+  gapPx: number;
+  /** Bar count used before the track is measured (SSR, jsdom, or zero-width layout). */
+  fallback: number;
+}
+
+/**
+ * Measures a waveform track and returns how many fixed-width bars fit across it,
+ * updating on resize. Lets callers resample their peaks to the *visible* bar
+ * count so overflow bars aren't rendered (and, crucially, aren't counted when
+ * computing playback progress).
+ */
+export function useFittedBarCount(
+  trackRef: React.RefObject<HTMLElement | null>,
+  { barWidthPx, gapPx, fallback }: UseFittedBarCountOptions,
+): number {
+  const [barCount, setBarCount] = React.useState(fallback);
+
+  React.useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+
+    const updateFromWidth = (width: number) => {
+      if (width <= 0) return;
+      setBarCount(Math.max(1, Math.floor((width + gapPx) / (barWidthPx + gapPx))));
+    };
+
+    updateFromWidth(track.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) updateFromWidth(entry.contentRect.width);
+    });
+    observer.observe(track);
+    return () => observer.disconnect();
+  }, [trackRef, barWidthPx, gapPx]);
+
+  return barCount;
+}

--- a/src/utils/useWaveformPeaks.ts
+++ b/src/utils/useWaveformPeaks.ts
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { decodeAudioPeaks, generateFallbackPeaks, RAW_PEAK_COUNT } from "./audioWaveform";
+
+/**
+ * Decodes `src` into waveform peak amplitudes (0–1). Seeds a deterministic
+ * fallback immediately (stable across renders/SSR) and swaps in the real
+ * decoded peaks once WebAudio resolves, falling back again on any failure.
+ * Returns an empty array when `src` is absent.
+ */
+export function useWaveformPeaks(
+  src: string | undefined,
+  count: number = RAW_PEAK_COUNT,
+): number[] {
+  const [peaks, setPeaks] = React.useState<number[]>(() =>
+    src ? generateFallbackPeaks(src, count) : [],
+  );
+
+  React.useEffect(() => {
+    if (!src) {
+      setPeaks([]);
+      return;
+    }
+
+    setPeaks(generateFallbackPeaks(src, count));
+
+    let cancelled = false;
+    const abortController = new AbortController();
+    decodeAudioPeaks(src, abortController.signal)
+      .then((decoded) => {
+        if (!cancelled) setPeaks(decoded);
+      })
+      .catch(() => {
+        if (!cancelled) setPeaks(generateFallbackPeaks(src, count));
+      });
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+  }, [src, count]);
+
+  return peaks;
+}

--- a/src/utils/useWaveformSeek.ts
+++ b/src/utils/useWaveformSeek.ts
@@ -1,0 +1,128 @@
+import * as React from "react";
+import { formatTime } from "./audioWaveform";
+
+/** Seconds moved per Arrow key press while seeking. */
+const SEEK_STEP_SECONDS = 1;
+/** Seconds moved per Page Up/Down press while seeking. */
+const SEEK_STEP_LARGE_SECONDS = 5;
+
+/** Signed seek delta (seconds) for each stepping key. */
+const STEP_BY_KEY: Record<string, number | undefined> = {
+  ArrowRight: SEEK_STEP_SECONDS,
+  ArrowUp: SEEK_STEP_SECONDS,
+  ArrowLeft: -SEEK_STEP_SECONDS,
+  ArrowDown: -SEEK_STEP_SECONDS,
+  PageUp: SEEK_STEP_LARGE_SECONDS,
+  PageDown: -SEEK_STEP_LARGE_SECONDS,
+};
+
+/** Options for {@link useWaveformSeek}. */
+export interface UseWaveformSeekOptions {
+  /** Ref to the seekable track element (its width maps pointer position → time). */
+  trackRef: React.RefObject<HTMLElement | null>;
+  /** Total duration in seconds, or `undefined` until known. */
+  displayDuration: number | undefined;
+  /** Current playback position in seconds. */
+  currentTime: number;
+  /** Seek to a time in seconds. */
+  seekTo: (time: number) => void;
+  /** Suppress position updates while a manual scrub is in progress. */
+  setSeeking: (seeking: boolean) => void;
+  /** Accessible name for the slider. @default "Seek" */
+  label?: string;
+}
+
+/** ARIA + event props to spread onto the seekable track element. */
+export interface WaveformSeekProps {
+  role: "slider";
+  tabIndex: 0;
+  "aria-label": string;
+  "aria-orientation": "horizontal";
+  "aria-valuemin": 0;
+  "aria-valuemax": number | undefined;
+  "aria-valuenow": number;
+  "aria-valuetext": string | undefined;
+  onPointerDown: (event: React.PointerEvent<HTMLElement>) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+}
+
+/**
+ * Turns a waveform track into a keyboard- and pointer-seekable slider. Handles
+ * click/drag position math (via window listeners so drags can leave the element)
+ * and Arrow/Page/Home/End stepping, and returns ARIA slider props to spread onto
+ * the track. Shared by waveform players so seek behaviour isn't reimplemented.
+ */
+export function useWaveformSeek({
+  trackRef,
+  displayDuration,
+  currentTime,
+  seekTo,
+  setSeeking,
+  label = "Seek",
+}: UseWaveformSeekOptions): WaveformSeekProps {
+  const [isDragging, setIsDragging] = React.useState(false);
+
+  const seekFromClientX = React.useCallback(
+    (clientX: number) => {
+      const track = trackRef.current;
+      if (!track || displayDuration === undefined) return;
+      const rect = track.getBoundingClientRect();
+      if (rect.width <= 0) return;
+      const fraction = Math.min(Math.max((clientX - rect.left) / rect.width, 0), 1);
+      seekTo(fraction * displayDuration);
+    },
+    [trackRef, displayDuration, seekTo],
+  );
+
+  React.useEffect(() => {
+    if (!isDragging) return;
+    const handleMove = (event: PointerEvent) => seekFromClientX(event.clientX);
+    const handleUp = () => {
+      setIsDragging(false);
+      setSeeking(false);
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+    };
+  }, [isDragging, seekFromClientX, setSeeking]);
+
+  const onPointerDown = (event: React.PointerEvent<HTMLElement>) => {
+    seekFromClientX(event.clientX);
+    setSeeking(true);
+    setIsDragging(true);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (displayDuration === undefined) return;
+    const delta = STEP_BY_KEY[event.key];
+    if (delta !== undefined) {
+      event.preventDefault();
+      seekTo(currentTime + delta);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      seekTo(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      seekTo(displayDuration);
+    }
+  };
+
+  return {
+    role: "slider",
+    tabIndex: 0,
+    "aria-label": label,
+    "aria-orientation": "horizontal",
+    "aria-valuemin": 0,
+    "aria-valuemax": displayDuration,
+    "aria-valuenow": Math.round(currentTime),
+    "aria-valuetext":
+      displayDuration !== undefined
+        ? `${formatTime(currentTime)} of ${formatTime(displayDuration)}`
+        : undefined,
+    onPointerDown,
+    onKeyDown,
+  };
+}


### PR DESCRIPTION
## Summary

Builds the **V2 Voice (Waveform + Controls)** component as `VoiceNote` — the waveform player for voice notes and audio messages ([ENG-10632](https://linear.app/fanvue/issue/ENG-10632)).

It ships in **two modes**:

- **Presentational / controlled** (no `src`): drive `playing`/`progress` + `onPlayPause`. 1:1 with the "V2 Waveform" Figma — states (`default`/`flat`/listening), `negative`, sizes (`default` 48 / `small` 32), and `controls`/`timestamp`/`fileName`/`remove` toggles.
- **Real-audio player** (pass `src`/`duration`): self-contained — decodes the real waveform, plays/pauses actual audio, tracks live progress, and is keyboard/pointer **seekable**.

### Shared audio engine (ENG-10632 follow-up in this PR)
Rather than duplicate `AudioPlayer`'s non-trivial WebAudio/seek logic, it was extracted into reusable pieces that both components share:
- `src/utils/audioWaveform.ts` — pure helpers (`decodeAudioPeaks`, `formatTime`, fallback peaks, resample) + unit tests
- `src/utils/useWaveformPeaks.ts` — decode-with-fallback hook
- `src/utils/useAudioPlayback.ts` — `<audio>` play/pause/progress/seek engine
- `src/utils/useWaveformSeek.ts` — pointer + keyboard slider seeking

`AudioPlayer`'s public behavior is unchanged (its full test suite stays green); it now sources the shared pure helpers.

[Figma — V2 Waveform](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=18178-73101)

## Visual evidence

Real-audio player — idle (decoded waveform + derived duration):

![player idle](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-voicenote-v2/vn-player-idle.png)

Real-audio player — after seeking (live progress split + elapsed time):

![player seeked](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-voicenote-v2/vn-player-seeked.png)

Presentational states (flat / default / listening):

![states](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-voicenote-v2/vn-states.png)

Negative (dark bubble):

![negative](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-voicenote-v2/vn-negative.png)

Small / file name / remove:

![small](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-voicenote-v2/vn-small.png)
![filename](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-voicenote-v2/vn-filename.png)
![remove](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-voicenote-v2/vn-remove.png)

## Notes / decisions
- Play/pause reuses `IconButton` (`secondary`, 48/32); remove uses tertiary `IconButton` + `CloseIcon`. Colours map to existing `messages-waveform-*` tokens — no new tokens.
- The resting waveform is seeded from the Figma bar heights so the presentational idle state renders 1:1.
- `AudioPlayer` remains the media-thumbnail player (Vault cards / Generated Audio); `VoiceNote` is the chat voice-note player. They now share one audio engine.

## Test plan
- [x] `pnpm lint` (no new errors)
- [x] `pnpm typecheck`
- [x] `pnpm test` (full suite: 4179 passed; VoiceNote 21 unit + 9 story, AudioPlayer unchanged, new util tests)
- [x] `pnpm build`
- [x] Visual QA of presentational variants + real-audio player (idle + seek) in Storybook