### PR TITLE
fix(CyclingText): Apply label classes to sizing input as well

### DIFF
--- a/src/components/CyclingText/CyclingText.test.tsx
+++ b/src/components/CyclingText/CyclingText.test.tsx
@@ -56,6 +56,11 @@ describe("CyclingText", () => {
       expect(getVisibleLabel()).toHaveClass("shimmer");
     });
 
+    it("applies labelClassName to the sizing layer so measured width matches the labels", () => {
+      render(<CyclingText items={ITEMS} labelClassName="font-bold pr-4" />);
+      expect(getSizingLabel()).toHaveClass("font-bold", "pr-4");
+    });
+
     it("uses the longest item to size the wrapper by default", () => {
       render(<CyclingText items={["Hi", "Hello there", "Yo"]} />);
       expect(getSizingLabel().textContent).toBe("Hello there");

--- a/src/components/CyclingText/CyclingText.tsx
+++ b/src/components/CyclingText/CyclingText.tsx
@@ -161,7 +161,10 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
         <span
           ref={sizingLabelRef}
           aria-hidden="true"
-          className="pointer-events-none invisible inline-block select-none whitespace-nowrap leading-[inherit]"
+          className={cn(
+            "pointer-events-none invisible inline-block select-none whitespace-nowrap leading-[inherit]",
+            labelClassName,
+          )}
         >
           {sizingLabel}
         </span>


### PR DESCRIPTION
## Summary

The sizing input used to determine the width of the component wasn't receiving the same classes as the rendered text leading to a mismatch when the rendered text was bold.

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<!-- Paste screenshots or a link to the Chromatic/Storybook build. -->
