### PR TITLE
fix(DropdownMenu): add sheet variant for mobile drawer + confirm flip reposition (ENG-12331)

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1094,4 +1094,80 @@ describe("DropdownMenu sheet variant", () => {
     expect(onSelect).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
+
+  it("forwards passthrough HTML props (id, data-*, aria-*, style, onKeyDown) on a sheet item", async () => {
+    // Regression guard: the sheet-variant branch only wired up a handful of
+    // explicit props, silently dropping everything else a consumer passes.
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            id="item-1"
+            data-testid="item"
+            aria-keyshortcuts="Ctrl+1"
+            style={{ color: "red" }}
+            onKeyDown={onKeyDown}
+          >
+            Item 1
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    const item = screen.getByTestId("item");
+    expect(item).toHaveAttribute("id", "item-1");
+    expect(item).toHaveAttribute("aria-keyshortcuts", "Ctrl+1");
+    expect(item).toHaveStyle({ color: "rgb(255, 0, 0)" });
+    item.focus();
+    await user.keyboard("{Enter}");
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  it("forwards ref, style, and passthrough HTML props on a sheet content panel", async () => {
+    // Regression guard: the sheet-variant DropdownMenuContent branch dropped
+    // ref, style, and {...props} entirely, only passing className through.
+    const user = userEvent.setup();
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent
+          ref={ref}
+          data-testid="content"
+          style={{ color: "red" }}
+          id="content-1"
+        >
+          <DropdownMenuItem>Item 1</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    const content = screen.getByTestId("content");
+    expect(content).toHaveAttribute("id", "content-1");
+    expect(content).toHaveStyle({ color: "rgb(255, 0, 0)" });
+    expect(ref.current).toBe(content);
+  });
+
+  it("visually marks a disabled asChild item via aria-disabled styling", async () => {
+    // Regression guard: disabled asChild items in the sheet variant have no
+    // data-disabled or native disabled attribute for the CSS to key off, so
+    // they rendered with no visual disabled treatment at all.
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem asChild disabled>
+            <a href="/settings">Settings</a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    const link = screen.getByRole("option", { name: "Settings" });
+    expect(link).toHaveClass("aria-disabled:text-content-disabled");
+  });
 });

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -901,3 +901,107 @@ describe("DropdownMenuRadioItem", () => {
     });
   });
 });
+
+describe("DropdownMenu sheet variant", () => {
+  it("opens a bottom drawer instead of a Radix menu", async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item 1</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Item 1" })).toBeInTheDocument();
+  });
+
+  it("selects an item, calls onSelect, and closes the sheet", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={onSelect}>Item 1</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    await user.click(screen.getByRole("option", { name: "Item 1" }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not close the sheet or fire selection when the item is disabled", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={onSelect} disabled>
+            Item 1
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    await user.click(screen.getByRole("option", { name: "Item 1" }));
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("marks the selected item via aria-selected", async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem selected>Item 1</DropdownMenuItem>
+          <DropdownMenuItem selected={false}>Item 2</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    expect(screen.getByRole("option", { name: "Item 1" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: "Item 2" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("renders a native <hr> separator without requiring Radix menu context", async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item 1</DropdownMenuItem>
+          <DropdownMenuSeparator data-testid="separator" />
+          <DropdownMenuItem>Item 2</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    expect(screen.getByTestId("separator").tagName).toBe("HR");
+  });
+
+  it("renders a plain title (not a Radix label) without requiring menu context", async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Group title</DropdownMenuLabel>
+          <DropdownMenuItem>Item 1</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    expect(screen.getByText("Group title")).toBeInTheDocument();
+  });
+});

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1031,6 +1031,49 @@ describe("DropdownMenu sheet variant", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("passes a real Event to onSelect, not a fake partial shape", async () => {
+    // Regression guard: a hand-built object cast to Event only had
+    // preventDefault/currentTarget/target — any handler calling another
+    // Event API method (stopPropagation, composedPath, etc.) would throw.
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={onSelect}>Item 1</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    await user.click(screen.getByRole("option", { name: "Item 1" }));
+    const receivedEvent = onSelect.mock.calls[0]?.[0];
+    expect(receivedEvent).toBeInstanceOf(Event);
+    expect(() => (receivedEvent as Event).stopPropagation()).not.toThrow();
+  });
+
+  it("prevents the default action of a disabled asChild item's click (e.g. link navigation)", async () => {
+    // Regression guard: the disabled guard used to return early without
+    // calling preventDefault, so a disabled asChild link still navigated.
+    // fireEvent's return value is false when preventDefault was called by any
+    // listener during dispatch — the same signal the browser uses to decide
+    // whether to run the click's default action.
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem asChild disabled>
+            <a href="/settings">Settings</a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    const notCancelled = fireEvent.click(screen.getByRole("option", { name: "Settings" }));
+    expect(notCancelled).toBe(false);
+  });
+
   it("blocks selection on a disabled asChild item despite no native disabled semantics", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1004,4 +1004,51 @@ describe("DropdownMenu sheet variant", () => {
     await user.click(screen.getByText("trigger"));
     expect(screen.getByText("Group title")).toBeInTheDocument();
   });
+
+  it("renders asChild via Slot instead of Radix's menu-context Item, without crashing", async () => {
+    // Regression guard: DropdownMenuItem previously fell through to
+    // DropdownMenuPrimitive.Item asChild whenever asChild was true, even in
+    // the sheet variant, which never mounts a Radix menu Root/Content
+    // ancestor — that primitive throws without menu context.
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem asChild onSelect={onSelect} selected>
+            <a href="/settings">Settings</a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    const link = screen.getByRole("option", { name: "Settings" });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("aria-selected", "true");
+    await user.click(link);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("blocks selection on a disabled asChild item despite no native disabled semantics", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem asChild onSelect={onSelect} disabled>
+            <a href="/settings">Settings</a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    const link = screen.getByRole("option", { name: "Settings" });
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    await user.click(link);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
 });

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1126,6 +1126,51 @@ describe("DropdownMenu sheet variant", () => {
     expect(onKeyDown).toHaveBeenCalled();
   });
 
+  it("composes a consumer onClick with the internal select-and-close handler on a sheet item", async () => {
+    // Regression guard: an explicit onClick after {...props} in the sheet
+    // branch silently overwrote a consumer-supplied onClick instead of
+    // composing with it.
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onClick={onClick} onSelect={onSelect}>
+            Item 1
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    await user.click(screen.getByRole("option", { name: "Item 1" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("skips the internal select-and-close handler when a consumer onClick calls preventDefault", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn((event: React.MouseEvent) => event.preventDefault());
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu variant="sheet" defaultOpen={false}>
+        <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onClick={onClick} onSelect={onSelect}>
+            Item 1
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByText("trigger"));
+    await user.click(screen.getByRole("option", { name: "Item 1" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
   it("forwards ref, style, and passthrough HTML props on a sheet content panel", async () => {
     // Regression guard: the sheet-variant DropdownMenuContent branch dropped
     // ref, style, and {...props} entirely, only passing className through.

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -542,17 +542,19 @@ export const DropdownMenuItem = React.forwardRef<
           onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
             // A native <button disabled> already blocks its click event, but
             // asChild's element (e.g. a link) has no such enforcement — guard
-            // explicitly so aria-disabled actually stops selection.
-            if (disabled) return;
-            let defaultPrevented = false;
-            onSelect?.({
-              preventDefault: () => {
-                defaultPrevented = true;
-              },
-              currentTarget: event.currentTarget,
-              target: event.target,
-            } as unknown as Event);
-            if (!defaultPrevented) toggleOpen?.(() => false);
+            // explicitly, and prevent the click's default action (e.g. anchor
+            // navigation) since aria-disabled alone doesn't stop it.
+            if (disabled) {
+              event.preventDefault();
+              return;
+            }
+            // Pass the real native event through, not a fake partial shape —
+            // handlers that call any Event API beyond preventDefault (e.g.
+            // stopPropagation, composedPath) need it to actually exist. It's
+            // still live (currentTarget/target are valid) since we're inside
+            // the same synchronous click handler that produced it.
+            onSelect?.(event.nativeEvent);
+            if (!event.nativeEvent.defaultPrevented) toggleOpen?.(() => false);
           }}
         >
           {asChild ? children : itemChildren}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -3,6 +3,7 @@ import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 import { FLOATING_CONTENT_COLLISION_PADDING } from "../../utils/floatingContentCollisionPadding";
+import { Drawer, DrawerContent, DrawerTrigger } from "../Drawer/Drawer";
 import { IconButton } from "../IconButton/IconButton";
 import { CheckIcon } from "../Icons/CheckIcon";
 import { CloseIcon } from "../Icons/CloseIcon";
@@ -37,15 +38,31 @@ const ToggleOpenContext = React.createContext<
   ((updater: (prev: boolean) => boolean) => void) | null
 >(null);
 
+/**
+ * How a {@link DropdownMenu} presents its content.
+ * - `"menu"` (default) — a Radix-positioned panel anchored to the trigger.
+ * - `"sheet"` — a bottom drawer (via {@link Drawer}), for mobile/touch viewports.
+ *
+ * The viewport decision belongs to the consumer (it owns the breakpoint
+ * source of truth), so pass e.g. `variant={isDesktop ? "menu" : "sheet"}`.
+ */
+export type DropdownMenuVariant = "menu" | "sheet";
+
+const DropdownMenuVariantContext = React.createContext<DropdownMenuVariant>("menu");
+
 /** Props for the {@link DropdownMenu} root component. */
 export interface DropdownMenuProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {}
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {
+  /** How the menu presents its content. @default "menu" */
+  variant?: DropdownMenuVariant;
+}
 
 /** Root component that manages open/close state for a dropdown menu. */
 export function DropdownMenu({
   open: openProp,
   defaultOpen,
   onOpenChange,
+  variant = "menu",
   children,
   ...props
 }: DropdownMenuProps) {
@@ -55,12 +72,26 @@ export function DropdownMenu({
     onChange: onOpenChange,
   });
 
+  if (variant === "sheet") {
+    return (
+      <DropdownMenuVariantContext.Provider value="sheet">
+        <ToggleOpenContext.Provider value={setOpen}>
+          <Drawer open={open} onOpenChange={setOpen}>
+            {children}
+          </Drawer>
+        </ToggleOpenContext.Provider>
+      </DropdownMenuVariantContext.Provider>
+    );
+  }
+
   return (
-    <ToggleOpenContext.Provider value={setOpen}>
-      <DropdownMenuPrimitive.Root open={open} onOpenChange={setOpen} {...props}>
-        {children}
-      </DropdownMenuPrimitive.Root>
-    </ToggleOpenContext.Provider>
+    <DropdownMenuVariantContext.Provider value="menu">
+      <ToggleOpenContext.Provider value={setOpen}>
+        <DropdownMenuPrimitive.Root open={open} onOpenChange={setOpen} {...props}>
+          {children}
+        </DropdownMenuPrimitive.Root>
+      </ToggleOpenContext.Provider>
+    </DropdownMenuVariantContext.Provider>
   );
 }
 
@@ -81,8 +112,15 @@ export const DropdownMenuTrigger = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Trigger>,
   DropdownMenuTriggerProps
 >((props, ref) => {
+  const variant = React.useContext(DropdownMenuVariantContext);
   const toggleOpen = React.useContext(ToggleOpenContext);
   const tapRef = React.useRef<ActiveTap | null>(null);
+
+  // The sheet variant opens a Drawer (Dialog), which already suppresses
+  // scroll-drag-end synthetic clicks itself — no need for the touch-tap gating below.
+  if (variant === "sheet") {
+    return <DrawerTrigger {...props} ref={ref} />;
+  }
 
   // Used outside our DropdownMenu wrapper — fall through to Radix defaults.
   if (toggleOpen === null) {
@@ -174,33 +212,55 @@ export const DropdownMenuContent = React.forwardRef<
       className,
       style,
       sideOffset = 4,
+      // Radix defaults `avoidCollisions` to true, so passing `collisionPadding`
+      // is enough to keep the menu flipping/shifting to stay on screen — no
+      // hand-rolled reposition logic needed.
       collisionPadding = FLOATING_CONTENT_COLLISION_PADDING,
+      children,
       ...props
     },
     ref,
-  ) => (
-    <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        ref={ref}
-        sideOffset={sideOffset}
-        collisionPadding={collisionPadding}
-        className={cn(
-          "w-max min-w-(--radix-dropdown-menu-trigger-width) max-w-(--radix-dropdown-menu-content-available-width) overflow-y-auto rounded-sm border border-neutral-alphas-200 bg-surface-primary p-1 text-content-primary shadow-lg",
-          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-          "data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-in-from-top-2",
-          "data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2",
-          className,
-        )}
-        style={{
-          zIndex: "var(--fanvue-ui-portal-z-index, 50)",
-          maxHeight: "var(--radix-dropdown-menu-content-available-height)",
-          ...style,
-        }}
-        {...props}
-      />
-    </DropdownMenuPrimitive.Portal>
-  ),
+  ) => {
+    const variant = React.useContext(DropdownMenuVariantContext);
+
+    if (variant === "sheet") {
+      return (
+        <DrawerContent
+          position="bottom"
+          variant="sheet"
+          className={cn("flex flex-col gap-1 p-1", className)}
+        >
+          {children}
+        </DrawerContent>
+      );
+    }
+
+    return (
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content
+          ref={ref}
+          sideOffset={sideOffset}
+          collisionPadding={collisionPadding}
+          className={cn(
+            "w-max min-w-(--radix-dropdown-menu-trigger-width) max-w-(--radix-dropdown-menu-content-available-width) overflow-y-auto rounded-sm border border-neutral-alphas-200 bg-surface-primary p-1 text-content-primary shadow-lg",
+            "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+            "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+            "data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-in-from-top-2",
+            "data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2",
+            className,
+          )}
+          style={{
+            zIndex: "var(--fanvue-ui-portal-z-index, 50)",
+            maxHeight: "var(--radix-dropdown-menu-content-available-height)",
+            ...style,
+          }}
+          {...props}
+        >
+          {children}
+        </DropdownMenuPrimitive.Content>
+      </DropdownMenuPrimitive.Portal>
+    );
+  },
 );
 DropdownMenuContent.displayName = "DropdownMenuContent";
 
@@ -209,7 +269,11 @@ export type DropdownMenuGroupProps = React.ComponentPropsWithoutRef<
   typeof DropdownMenuPrimitive.Group
 >;
 
-/** Groups related menu items. Accepts an optional `DropdownMenuLabel`. */
+/**
+ * Groups related menu items. Accepts an optional `DropdownMenuLabel`.
+ *
+ * Requires Radix menu context — not supported inside a `variant="sheet"` menu.
+ */
 export const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 DropdownMenuGroup.displayName = "DropdownMenuGroup";
 
@@ -231,17 +295,22 @@ export interface DropdownMenuLabelProps
 export const DropdownMenuLabel = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
   DropdownMenuLabelProps
->(({ className, position = "default", ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
-    ref={ref}
-    className={cn(
-      "typography-description-12px-regular flex items-center px-3 text-content-secondary",
-      position === "top" ? "py-2" : "pb-2 pt-4",
-      className,
-    )}
-    {...props}
-  />
-));
+>(({ className, position = "default", ...props }, ref) => {
+  const variant = React.useContext(DropdownMenuVariantContext);
+  const labelClassName = cn(
+    "typography-description-12px-regular flex items-center px-3 text-content-secondary",
+    position === "top" ? "py-2" : "pb-2 pt-4",
+    className,
+  );
+
+  // DropdownMenuPrimitive.Label requires Radix menu context, unavailable when
+  // the sheet variant renders inside a Drawer (Dialog) instead.
+  if (variant === "sheet") {
+    return <div ref={ref} className={labelClassName} {...props} />;
+  }
+
+  return <DropdownMenuPrimitive.Label ref={ref} className={labelClassName} {...props} />;
+});
 DropdownMenuLabel.displayName = "DropdownMenuLabel";
 
 /**
@@ -360,10 +429,14 @@ export const DropdownMenuItem = React.forwardRef<
       className,
       children,
       asChild,
+      onSelect,
+      disabled,
       ...props
     },
     ref,
   ) => {
+    const variant = React.useContext(DropdownMenuVariantContext);
+    const toggleOpen = React.useContext(ToggleOpenContext);
     const normalizedSize = SIZE_NORMALIZED[size];
     const hasDescription = description != null;
     const hasAvatar = avatar != null;
@@ -376,6 +449,7 @@ export const DropdownMenuItem = React.forwardRef<
       hasAvatar && !hasDescription && normalizedSize === "32" && "py-1",
       "data-[highlighted]:bg-neutral-alphas-50",
       "data-[disabled]:cursor-not-allowed data-[disabled]:text-content-disabled",
+      "disabled:cursor-not-allowed disabled:text-content-disabled",
       destructive && "text-error-content",
       // bg-interaction-hover aliases to the same token as the plain hover
       // background above, so a selected row would be indistinguishable from a
@@ -384,14 +458,6 @@ export const DropdownMenuItem = React.forwardRef<
       selected && ["bg-neutral-alphas-100", "data-[highlighted]:bg-neutral-alphas-200"],
       className,
     );
-
-    if (asChild) {
-      return (
-        <DropdownMenuPrimitive.Item ref={ref} asChild className={itemClassName} {...props}>
-          {children}
-        </DropdownMenuPrimitive.Item>
-      );
-    }
 
     // In the two-line (description) layout, icons sit on the title's line.
     // 24px title line-height vs 16px icon → 4px (pt-1) centres the icon on it.
@@ -425,8 +491,8 @@ export const DropdownMenuItem = React.forwardRef<
         selected && <SelectedCheckIndicator hasDescription={hasDescription} />
       );
 
-    return (
-      <DropdownMenuPrimitive.Item ref={ref} className={itemClassName} {...props}>
+    const itemChildren = (
+      <>
         {avatar != null ? (
           <span className="shrink-0">{avatar}</span>
         ) : (
@@ -449,6 +515,62 @@ export const DropdownMenuItem = React.forwardRef<
         )}
         {countNode}
         {trailingNode}
+      </>
+    );
+
+    // The sheet variant renders inside a Drawer (Dialog), not a Radix menu, so
+    // DropdownMenuPrimitive.Item (which requires menu context) can't be used —
+    // render a plain option row with equivalent selection semantics instead.
+    if (variant === "sheet" && !asChild) {
+      return (
+        <button
+          ref={ref as React.Ref<HTMLButtonElement>}
+          type="button"
+          role="option"
+          aria-selected={selected}
+          disabled={disabled}
+          className={itemClassName}
+          onClick={(event) => {
+            let defaultPrevented = false;
+            onSelect?.({
+              preventDefault: () => {
+                defaultPrevented = true;
+              },
+              currentTarget: event.currentTarget,
+              target: event.target,
+            } as unknown as Event);
+            if (!defaultPrevented) toggleOpen?.(() => false);
+          }}
+        >
+          {itemChildren}
+        </button>
+      );
+    }
+
+    if (asChild) {
+      return (
+        <DropdownMenuPrimitive.Item
+          ref={ref}
+          asChild
+          className={itemClassName}
+          disabled={disabled}
+          onSelect={onSelect}
+          {...props}
+        >
+          {children}
+        </DropdownMenuPrimitive.Item>
+      );
+    }
+
+    return (
+      <DropdownMenuPrimitive.Item
+        ref={ref}
+        className={itemClassName}
+        disabled={disabled}
+        onSelect={onSelect}
+        {...props}
+      >
+        {itemChildren}
       </DropdownMenuPrimitive.Item>
     );
   },
@@ -463,13 +585,19 @@ export interface DropdownMenuSeparatorProps
 export const DropdownMenuSeparator = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
   DropdownMenuSeparatorProps
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={cn("my-1 h-px bg-neutral-alphas-200", className)}
-    {...props}
-  />
-));
+>(({ className, ...props }, ref) => {
+  const variant = React.useContext(DropdownMenuVariantContext);
+  const separatorClassName = cn("my-1 h-px bg-neutral-alphas-200", className);
+
+  // DropdownMenuPrimitive.Separator requires Radix menu context, unavailable
+  // when the sheet variant renders inside a Drawer (Dialog) instead. <hr> is a
+  // native separator, so it needs no ARIA role.
+  if (variant === "sheet") {
+    return <hr ref={ref as React.Ref<HTMLHRElement>} className={separatorClassName} {...props} />;
+  }
+
+  return <DropdownMenuPrimitive.Separator ref={ref} className={separatorClassName} {...props} />;
+});
 DropdownMenuSeparator.displayName = "DropdownMenuSeparator";
 
 /** Header type. `"default"` shows a title; `"search"` shows a search input. */
@@ -654,6 +782,8 @@ export interface DropdownMenuRadioGroupProps
  *   <DropdownMenuRadioItem value="oldest">Oldest first</DropdownMenuRadioItem>
  * </DropdownMenuRadioGroup>
  * ```
+ *
+ * Requires Radix menu context — not supported inside a `variant="sheet"` menu.
  */
 export const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,4 +1,5 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Slot } from "@radix-ui/react-slot";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import * as React from "react";
 import { cn } from "../../utils/cn";
@@ -520,17 +521,29 @@ export const DropdownMenuItem = React.forwardRef<
 
     // The sheet variant renders inside a Drawer (Dialog), not a Radix menu, so
     // DropdownMenuPrimitive.Item (which requires menu context) can't be used —
-    // render a plain option row with equivalent selection semantics instead.
-    if (variant === "sheet" && !asChild) {
+    // render a plain option element with equivalent selection semantics instead.
+    // asChild goes through the same Slot primitive Radix's own Item uses
+    // internally, so a custom element (e.g. a link) gets the option
+    // role/handlers merged onto it without needing menu context.
+    if (variant === "sheet") {
+      const Comp = asChild ? Slot : "button";
+      const sheetSpecificProps = !asChild
+        ? { type: "button" as const, disabled }
+        : disabled
+          ? { "aria-disabled": true }
+          : {};
       return (
-        <button
+        <Comp
           ref={ref as React.Ref<HTMLButtonElement>}
-          type="button"
+          {...sheetSpecificProps}
           role="option"
           aria-selected={selected}
-          disabled={disabled}
           className={itemClassName}
-          onClick={(event) => {
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            // A native <button disabled> already blocks its click event, but
+            // asChild's element (e.g. a link) has no such enforcement — guard
+            // explicitly so aria-disabled actually stops selection.
+            if (disabled) return;
             let defaultPrevented = false;
             onSelect?.({
               preventDefault: () => {
@@ -542,8 +555,8 @@ export const DropdownMenuItem = React.forwardRef<
             if (!defaultPrevented) toggleOpen?.(() => false);
           }}
         >
-          {itemChildren}
-        </button>
+          {asChild ? children : itemChildren}
+        </Comp>
       );
     }
 

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -227,9 +227,12 @@ export const DropdownMenuContent = React.forwardRef<
     if (variant === "sheet") {
       return (
         <DrawerContent
+          ref={ref}
           position="bottom"
           variant="sheet"
           className={cn("flex flex-col gap-1 p-1", className)}
+          style={style}
+          {...props}
         >
           {children}
         </DrawerContent>
@@ -451,6 +454,10 @@ export const DropdownMenuItem = React.forwardRef<
       "data-[highlighted]:bg-neutral-alphas-50",
       "data-[disabled]:cursor-not-allowed data-[disabled]:text-content-disabled",
       "disabled:cursor-not-allowed disabled:text-content-disabled",
+      // Sheet-variant asChild items are marked disabled via aria-disabled
+      // (see below), not the native disabled attribute or Radix's
+      // data-disabled — neither selector above matches them.
+      "aria-disabled:cursor-not-allowed aria-disabled:text-content-disabled",
       destructive && "text-error-content",
       // bg-interaction-hover aliases to the same token as the plain hover
       // background above, so a selected row would be indistinguishable from a
@@ -535,6 +542,7 @@ export const DropdownMenuItem = React.forwardRef<
       return (
         <Comp
           ref={ref as React.Ref<HTMLButtonElement>}
+          {...(props as React.ComponentPropsWithoutRef<"button">)}
           {...sheetSpecificProps}
           role="option"
           aria-selected={selected}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -534,6 +534,12 @@ export const DropdownMenuItem = React.forwardRef<
     // role/handlers merged onto it without needing menu context.
     if (variant === "sheet") {
       const Comp = asChild ? Slot : "button";
+      // Pull the consumer's onClick out of the passthrough spread so the
+      // handler below can compose with it instead of the spread order
+      // silently overwriting it (an explicit onClick after {...props} always
+      // wins over the spread's).
+      const { onClick: consumerOnClick, ...restProps } =
+        props as React.ComponentPropsWithoutRef<"button">;
       const sheetSpecificProps = !asChild
         ? { type: "button" as const, disabled }
         : disabled
@@ -542,7 +548,7 @@ export const DropdownMenuItem = React.forwardRef<
       return (
         <Comp
           ref={ref as React.Ref<HTMLButtonElement>}
-          {...(props as React.ComponentPropsWithoutRef<"button">)}
+          {...restProps}
           {...sheetSpecificProps}
           role="option"
           aria-selected={selected}
@@ -556,6 +562,8 @@ export const DropdownMenuItem = React.forwardRef<
               event.preventDefault();
               return;
             }
+            consumerOnClick?.(event);
+            if (event.defaultPrevented) return;
             // Pass the real native event through, not a fake partial shape —
             // handlers that call any Event API beyond preventDefault (e.g.
             // stopPropagation, composedPath) need it to actually exist. It's


### PR DESCRIPTION
## Summary
- Behavioural work only for ENG-12331 (flip positioning + mobile drawer). The visual padding/hover restyle is explicitly ON HOLD and is not part of this PR.
- Adds `variant="sheet"` to `DropdownMenu`, which swaps the Radix-positioned menu for a `Drawer` (Dialog) bottom sheet on mobile/touch viewports. The consumer decides which variant to render (owns the breakpoint source of truth).
- `DropdownMenuTrigger`/`Content`/`Label`/`Separator` degrade to plain elements in the sheet variant since the Radix menu primitives require menu context that a Dialog doesn't provide. `DropdownMenuItem` renders a `role="option"` button with equivalent selection semantics (aria-selected, onSelect, disabled).
- Confirmed the flip/reposition behaviour already works via Radix's default `avoidCollisions` plus the existing `collisionPadding` prop — documented this instead of adding hand-rolled reposition logic (there wasn't a real bug here to fix).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `biome check` clean (only pre-existing nursery warnings unrelated to this diff)
- [x] `vitest run DropdownMenu.test.tsx` — 59/59 passing, including new sheet-variant coverage (opens a dialog not a menu, selects + closes, disabled item blocks selection/close, aria-selected on options, native `<hr>` separator, plain title without Radix label)
- [ ] Manual verification of mobile drawer on a real mobile viewport