### PR TITLE
fix: paint autofilled inputs with the input container background

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -13,6 +13,15 @@
     scrollbar-gutter: stable;
   }
 
+  /*
+   * Neutralise the browser's autofill highlight with the inset box-shadow
+   * hack. The shadow colour must match the input container background
+   * (TextField/TextArea render a transparent <input> inside a
+   * bg-inputs-inputs-primary wrapper) — a translucent tint here paints a
+   * visibly lighter band inside the field in dark mode. Note this rule
+   * cannot be overridden by unlayered !important declarations downstream:
+   * for !important the cascade reverses, so @layer base wins.
+   */
   input:-webkit-autofill,
   input:-webkit-autofill:hover,
   input:-webkit-autofill:focus,
@@ -26,8 +35,8 @@
   textarea:autofill:hover,
   textarea:autofill:focus {
     -webkit-text-fill-color: var(--color-content-primary);
-    -webkit-box-shadow: inset 0 0 0 1000px var(--color-neutral-alphas-50) !important;
-    box-shadow: inset 0 0 0 1000px var(--color-neutral-alphas-50) !important;
+    -webkit-box-shadow: inset 0 0 0 1000px var(--color-inputs-inputs-primary) !important;
+    box-shadow: inset 0 0 0 1000px var(--color-inputs-inputs-primary) !important;
     background-clip: padding-box !important;
     transition: background-color 9999s ease-in-out 0s;
   }


### PR DESCRIPTION
## Summary

- Fixes the lighter grey band inside autofilled inputs (most visible on the dark login form): the global autofill override painted an inset box-shadow of `--color-neutral-alphas-50` (10% white in dark mode) inside the `<input>`, while `TextField`/`TextArea` render a transparent input inside a `bg-inputs-inputs-primary` container. The fill now uses `--color-inputs-inputs-primary` so it always matches the container in both themes.
- The existing `AuthLayout.css` override in `@fanvue/ui-internal` (which repaints autofill with `--color-inputs-inputs-primary`) never took effect: both rules are `!important`, and for important declarations the cascade reverses — the `@layer base` rule here beats the unlayered override. That override can be removed as a follow-up once this ships.

## Before / after (dark mode token values)

- Before: input fill is `#262626` + `#ffffff1a` shadow → ~`#3b3b3b`, visibly lighter than the `#262626` container padding and icon gutter.
- After: shadow colour equals the container token, so the field renders as one uniform surface.

## Test plan

- [ ] `pnpm lint` / `pnpm build` pass (verified locally)
- [ ] Autofill an email/password on the dark login form in Chrome and Safari — input fill matches the container background
- [ ] Verify light mode: autofilled inputs match the `gray-75` container