### PR TITLE
fix(RatingSummary): equalize histogram track widths across rows

### DIFF
--- a/src/components/RatingSummary/RatingSummary.stories.tsx
+++ b/src/components/RatingSummary/RatingSummary.stories.tsx
@@ -73,6 +73,23 @@ export const LargeVolume: Story = {
   },
 };
 
+/**
+ * Rows mixing singular ("1 review") and plural ("6 reviews") labels: the
+ * differing label widths must not change the track lengths — every bar's
+ * right edge stays aligned.
+ */
+export const MixedPlurality: Story = {
+  args: {
+    distribution: [
+      { rating: 5, count: 6 },
+      { rating: 4, count: 1 },
+      { rating: 3, count: 3 },
+      { rating: 2, count: 0 },
+      { rating: 1, count: 0 },
+    ],
+  },
+};
+
 export const SingleReview: Story = {
   args: {
     distribution: [

--- a/src/components/RatingSummary/RatingSummary.tsx
+++ b/src/components/RatingSummary/RatingSummary.tsx
@@ -65,6 +65,11 @@ function getWeightedAverage(distribution: RatingCount[]): number {
  * followed by a per-rating histogram. Bar lengths are scaled relative to the
  * most-reviewed rating, so the busiest rating always fills the track.
  *
+ * The histogram is one shared grid (with subgrid rows) rather than per-row
+ * flex: the label column is sized by the widest label across all rows, so a
+ * width difference between labels (e.g. "1 review" vs "3 reviews") never
+ * changes a row's track length — every bar's right edge stays aligned.
+ *
  * The brand star is decorative; the header and each histogram row expose
  * `role="img"` with an accessible label (override via `formatAverageLabel` /
  * `formatRatingLabel`) so the single-star-plus-number reads clearly.
@@ -129,11 +134,14 @@ export const RatingSummary = React.forwardRef<HTMLDivElement, RatingSummaryProps
           </span>
         </div>
 
-        <ul className="m-0 flex list-none flex-col gap-4 p-0" aria-label="Rating breakdown">
+        <ul
+          className="m-0 grid list-none grid-cols-[1fr_auto] gap-4 p-0"
+          aria-label="Rating breakdown"
+        >
           {rows.map(({ rating, count }) => (
-            <li key={rating}>
+            <li key={rating} className="col-span-2 grid grid-cols-subgrid">
               <div
-                className="flex items-center gap-4"
+                className="col-span-2 grid grid-cols-subgrid items-center"
                 role="img"
                 aria-label={
                   formatRatingLabel
@@ -141,13 +149,13 @@ export const RatingSummary = React.forwardRef<HTMLDivElement, RatingSummaryProps
                     : `${rating} ${rating === 1 ? "star" : "stars"}, ${formatCount(count)}`
                 }
               >
-                <div className="relative h-4 flex-1 overflow-hidden rounded-full bg-neutral-alphas-50">
+                <div className="relative h-4 overflow-hidden rounded-full bg-neutral-alphas-50">
                   <div
                     className="absolute inset-y-0 left-0 rounded-full bg-brand-primary-default transition-[width] duration-300 ease-in-out"
                     style={{ width: maxCount === 0 ? "0%" : `${(count / maxCount) * 100}%` }}
                   />
                 </div>
-                <span className="flex shrink-0 items-center gap-1.5">
+                <span className="flex items-center gap-1.5">
                   <span className="typography-body-small-14px-semibold text-content-primary">
                     {rating}
                   </span>


### PR DESCRIPTION
## Summary

Fixes bar misalignment in the app store rating breakdown. Each histogram row was its own flex container: the track was `flex-1` and the trailing label `shrink-0`, so a row's track width depended on its own label width. A singular label ("1 review") is narrower than a plural one ("3 reviews"), so that row's track rendered longer and the bars' right edges misaligned.

The histogram is now one shared `grid grid-cols-[1fr_auto]` with subgrid rows (`col-span-2 grid grid-cols-subgrid` on each `li` and its `role="img"` row). The label column is sized once by the widest label across all rows, so every track gets an identical width and the rating digits align vertically. This holds for any label content (locales, `formatCount` overrides, large counts), not just singular/plural.

Note: `subgrid` needs Chrome/Edge 117+, Safari 16+, Firefox 71+.

## Changes

- `RatingSummary`: shared grid + subgrid rows replace per-row flex; dropped `flex-1`/`shrink-0`; JSDoc documents the layout constraint
- New `MixedPlurality` story reproducing the reported case (6/1/3/0/0) as a regression check

## Checklist

- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Linter passes (`pnpm lint`)
- [x] Tests pass (`pnpm test`) — 16 unit + 7 story tests for this component
- [x] New/updated components have stories
- [x] New/updated components have accessibility tests
- [x] New/updated components have forwardRef unit tests
- [x] New/updated components have className chaining unit tests
- [x] Exported in `src/index.ts` (if consumable by vendors) — unchanged export
- [ ] Figma link added to story `design` parameter (if applicable) — n/a, layout bug fix
- [x] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

See the new `Components/RatingSummary > MixedPlurality` story in the Chromatic build for this PR. Verified locally by measuring the DOM: all five tracks render at identical width (295.34px) with identical left/right edges; `LargeVolume` and `Empty` stories unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)