### PR TITLE
docs: point Storybook badge at latest Chromatic main build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ React component library built with Tailwind CSS for the Fanvue ecosystem.
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@fanvue/ui)](https://bundlephobia.com/package/@fanvue/ui)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
-[![Storybook](https://img.shields.io/badge/Storybook-ff4785.svg?logo=storybook&logoColor=white)](https://697a1b6dd4dad73ee9c0e5f5-qhmsdilfrq.chromatic.com/)
+[![Storybook](https://img.shields.io/badge/Storybook-ff4785.svg?logo=storybook&logoColor=white)](https://main--697a1b6dd4dad73ee9c0e5f5.chromatic.com/)
 [![Showcase](https://img.shields.io/badge/Showcase-GitHub%20Pages-brightgreen.svg?logo=github)](https://fanvue.github.io/fanv-ui/)
 [![GitHub](https://img.shields.io/github/stars/fanvue/fanv-ui?style=social)](https://github.com/fanvue/fanv-ui)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Storybook badge in `README.md` linked to a frozen, build-specific Chromatic URL (`https://697a1b6dd4dad73ee9c0e5f5-qhmsdilfrq.chromatic.com/`), which permanently pointed at a months-old snapshot of the library.

Chromatic provides [branch permalinks](https://www.chromatic.com/docs/permalinks/) in the form `https://<branch>--<appid>.chromatic.com`, which always resolve to the **latest accepted build** on that branch. Since the Chromatic workflow runs on every push to `main`, `https://main--697a1b6dd4dad73ee9c0e5f5.chromatic.com/` automatically stays current with no further README updates needed.

Verified the permalink resolves (HTTP 200) and serves the published Storybook (1001 stories in the index).

## Changes

- Replace the build-specific Chromatic URL in the README Storybook badge with the `main` branch permalink

## Checklist

- [x] TypeScript compiles (`pnpm typecheck`) — n/a, docs-only change
- [x] Linter passes (`pnpm lint`) — Biome ran via lint-staged pre-commit hook
- [x] Tests pass (`pnpm test`) — n/a, docs-only change
- [ ] New/updated components have stories — n/a
- [ ] New/updated components have accessibility tests — n/a
- [ ] New/updated components have forwardRef unit tests — n/a
- [ ] New/updated components have className chaining unit tests — n/a
- [ ] Exported in `src/index.ts` (if consumable by vendors) — n/a
- [ ] Figma link added to story `design` parameter (if applicable) — n/a
- [ ] Does not have barrel file `src/YourComponent/index.ts` — n/a

## Screenshots / Storybook

Latest Storybook (auto-updating permalink): https://main--697a1b6dd4dad73ee9c0e5f5.chromatic.com/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ba49fa0-85c6-4be1-b249-ae0ca6ff7985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ba49fa0-85c6-4be1-b249-ae0ca6ff7985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

