### PR TITLE
feat(Count): align Chip + Count with V2 Notification Count (DES-789)

### DIFF
--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=87-4102&m=dev",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16965-92740&m=dev",
     },
   },
   tags: ["autodocs"],
@@ -40,7 +40,7 @@ const meta = {
     dotted: { control: "boolean" },
     notificationVariant: {
       control: "select",
-      options: ["default", "alert", "brand", "pink", "info", "success", "warning"],
+      options: ["default", "contrast", "brand", "alert", "pink", "info", "success", "warning"],
     },
   },
 } satisfies Meta<typeof Chip>;

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -38,6 +38,10 @@ const meta = {
     disabled: { control: "boolean" },
     leftDot: { control: "boolean" },
     dotted: { control: "boolean" },
+    notificationVariant: {
+      control: "select",
+      options: ["default", "alert", "brand", "pink", "info", "success", "warning"],
+    },
   },
 } satisfies Meta<typeof Chip>;
 
@@ -288,6 +292,37 @@ export const WithBothIcons: Story = {
 
 export const WithNotification: Story = {
   args: {
+    notificationCount: 3,
+    children: "Chip",
+  },
+};
+
+export const WithNotificationOverflow: Story = {
+  args: {
+    notificationCount: 12,
+    notificationMax: 9,
+    children: "Chip",
+  },
+};
+
+export const WithNotificationDefault: Story = {
+  args: {
+    notificationCount: 5,
+    notificationVariant: "default",
+    children: "Chip",
+  },
+};
+
+export const WithNotificationAlert: Story = {
+  args: {
+    notificationCount: 2,
+    notificationVariant: "alert",
+    children: "Chip",
+  },
+};
+
+export const WithNotificationLabel: Story = {
+  args: {
     notificationLabel: "99+",
     children: "Chip",
   },
@@ -297,7 +332,7 @@ export const FullExample: Story = {
   args: {
     leftDot: true,
     rightIcon: <CrossIcon className="size-5" />,
-    notificationLabel: "3",
+    notificationCount: 3,
     selected: true,
     children: "Filter",
     onClick: () => {},
@@ -378,7 +413,9 @@ export const Truncated: Story = {
         Long chip with icons
       </Chip>
       <Chip leftDot>Truncated chip with dot indicator</Chip>
-      <Chip notificationLabel="99+">Truncated with notification</Chip>
+      <Chip notificationCount={99} notificationMax={9}>
+        Truncated with notification
+      </Chip>
     </div>
   ),
 };

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -187,13 +187,14 @@ describe("Chip", () => {
       expect(badge).toHaveClass("py-0.5");
     });
 
-    it("adds end padding so the label clears the badge", () => {
+    it("does not change chip padding when a badge is present", () => {
       const { container } = render(<Chip notificationCount={99}>Chip</Chip>);
       const inner = container.querySelector('[data-testid="chip"] > span');
-      expect(inner).toHaveClass("pr-6");
+      expect(inner).toHaveClass("px-3");
+      expect(inner).not.toHaveClass("pr-6");
     });
 
-    it("offsets the badge for size 32 chips", () => {
+    it("anchors the badge leading edge for size 32 chips", () => {
       render(
         <Chip size="32" notificationCount={3}>
           Test
@@ -201,10 +202,10 @@ describe("Chip", () => {
       );
       const badge = screen.getByText("3");
       expect(badge).toHaveClass("top-[-4px]");
-      expect(badge).toHaveClass("right-[-9px]");
+      expect(badge).toHaveClass("left-[calc(100%_-_11px)]");
     });
 
-    it("offsets the badge for size 40 chips", () => {
+    it("anchors the badge leading edge for size 40 chips", () => {
       render(
         <Chip size="40" notificationCount={3}>
           Test
@@ -212,7 +213,7 @@ describe("Chip", () => {
       );
       const badge = screen.getByText("3");
       expect(badge).toHaveClass("top-[-4px]");
-      expect(badge).toHaveClass("right-[-4px]");
+      expect(badge).toHaveClass("left-[calc(100%_-_16px)]");
     });
 
     it("applies custom notificationVariant", () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -177,16 +177,20 @@ describe("Chip", () => {
       expect(badge).toHaveClass("text-content-always-black");
     });
 
-    it("uses Count size 24 (16px badge)", () => {
+    it("uses Figma V2 notification geometry without changing shared Count sizes", () => {
       render(<Chip notificationCount={3}>Test</Chip>);
       const badge = screen.getByText("3");
-      expect(badge).toHaveClass("h-4");
+      expect(badge).toHaveClass("h-5");
+      expect(badge).toHaveClass("min-w-5");
+      expect(badge).toHaveClass("rounded-md");
+      expect(badge).toHaveClass("px-1");
+      expect(badge).toHaveClass("py-0.5");
     });
 
     it("adds end padding so the label clears the badge", () => {
       const { container } = render(<Chip notificationCount={99}>Chip</Chip>);
       const inner = container.querySelector('[data-testid="chip"] > span');
-      expect(inner).toHaveClass("pr-5");
+      expect(inner).toHaveClass("pr-6");
     });
 
     it("offsets the badge for size 32 chips", () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -177,10 +177,33 @@ describe("Chip", () => {
       expect(badge).toHaveClass("text-content-always-black");
     });
 
-    it("uses Count size 24 (16px height)", () => {
+    it("uses Count size 24 (V2 notification geometry)", () => {
       render(<Chip notificationCount={3}>Test</Chip>);
       const badge = screen.getByText("3");
-      expect(badge).toHaveClass("h-4");
+      expect(badge).toHaveClass("min-h-5");
+      expect(badge).toHaveClass("rounded-md");
+    });
+
+    it("offsets the badge for size 32 chips", () => {
+      render(
+        <Chip size="32" notificationCount={3}>
+          Test
+        </Chip>,
+      );
+      const badge = screen.getByText("3");
+      expect(badge).toHaveClass("top-[-4px]");
+      expect(badge).toHaveClass("right-[-9px]");
+    });
+
+    it("offsets the badge for size 40 chips", () => {
+      render(
+        <Chip size="40" notificationCount={3}>
+          Test
+        </Chip>,
+      );
+      const badge = screen.getByText("3");
+      expect(badge).toHaveClass("top-[-4px]");
+      expect(badge).toHaveClass("right-[-4px]");
     });
 
     it("applies custom notificationVariant", () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -177,11 +177,16 @@ describe("Chip", () => {
       expect(badge).toHaveClass("text-content-always-black");
     });
 
-    it("uses Count size 24 (V2 notification geometry)", () => {
+    it("uses Count size 24 (16px badge)", () => {
       render(<Chip notificationCount={3}>Test</Chip>);
       const badge = screen.getByText("3");
-      expect(badge).toHaveClass("min-h-5");
-      expect(badge).toHaveClass("rounded-md");
+      expect(badge).toHaveClass("h-4");
+    });
+
+    it("adds end padding so the label clears the badge", () => {
+      const { container } = render(<Chip notificationCount={99}>Chip</Chip>);
+      const inner = container.querySelector('[data-testid="chip"] > span');
+      expect(inner).toHaveClass("pr-5");
     });
 
     it("offsets the badge for size 32 chips", () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -174,6 +174,13 @@ describe("Chip", () => {
       render(<Chip notificationCount={3}>Test</Chip>);
       const badge = screen.getByText("3");
       expect(badge).toHaveClass("bg-brand-primary-default");
+      expect(badge).toHaveClass("text-content-always-black");
+    });
+
+    it("uses Count size 24 (16px height)", () => {
+      render(<Chip notificationCount={3}>Test</Chip>);
+      const badge = screen.getByText("3");
+      expect(badge).toHaveClass("h-4");
     });
 
     it("applies custom notificationVariant", () => {

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -145,15 +145,45 @@ describe("Chip", () => {
     });
   });
 
-  describe("notificationLabel", () => {
+  describe("notification badge", () => {
     it("renders notification badge with label", () => {
       render(<Chip notificationLabel="99+">Test</Chip>);
       expect(screen.getByText("99+")).toBeInTheDocument();
     });
 
-    it("does not render badge when notificationLabel is not provided", () => {
+    it("renders notification badge with notificationCount", () => {
+      render(<Chip notificationCount={5}>Test</Chip>);
+      expect(screen.getByText("5")).toBeInTheDocument();
+    });
+
+    it("renders overflow format when notificationCount exceeds notificationMax", () => {
+      render(
+        <Chip notificationCount={12} notificationMax={9}>
+          Test
+        </Chip>,
+      );
+      expect(screen.getByText("9+")).toBeInTheDocument();
+    });
+
+    it("does not render badge when no notification props are provided", () => {
       render(<Chip>Test</Chip>);
       expect(screen.getByTestId("chip")).toHaveTextContent("Test");
+    });
+
+    it("uses brand variant by default", () => {
+      render(<Chip notificationCount={3}>Test</Chip>);
+      const badge = screen.getByText("3");
+      expect(badge).toHaveClass("bg-brand-primary-default");
+    });
+
+    it("applies custom notificationVariant", () => {
+      render(
+        <Chip notificationCount={3} notificationVariant="alert">
+          Test
+        </Chip>,
+      );
+      const badge = screen.getByText("3");
+      expect(badge).toHaveClass("bg-error-content");
     });
   });
 

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -183,7 +183,13 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
         ) : (
           <>
             {dottedBorder}
-            <span className="flex min-w-0 items-center gap-0.5 overflow-hidden px-3">
+            <span
+              className={cn(
+                "flex min-w-0 items-center gap-0.5 overflow-hidden px-3",
+                // Keep label clear of the corner badge (esp. wide values like "99+").
+                (notificationCount != null || notificationLabel) && "pr-5",
+              )}
+            >
               {leftDot && (
                 <span className="size-2 shrink-0 rounded-full bg-current" aria-hidden="true" />
               )}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -183,14 +183,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
         ) : (
           <>
             {dottedBorder}
-            <span
-              className={cn(
-                "flex min-w-0 items-center gap-0.5 overflow-hidden px-3",
-                // Figma overlays the badge, but reserving its width prevents wide
-                // values such as "99+" from covering short labels.
-                (notificationCount != null || notificationLabel) && "pr-6",
-              )}
-            >
+            <span className="flex min-w-0 items-center gap-0.5 overflow-hidden px-3">
               {leftDot && (
                 <span className="size-2 shrink-0 rounded-full bg-current" aria-hidden="true" />
               )}
@@ -217,7 +210,8 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
                   // V2 Notification Count: 20px high/min-width, caption 12,
                   // 4px horizontal and 2px vertical padding, rounded-md.
                   "absolute top-[-4px] rounded-md px-1 py-0.5",
-                  size === "40" ? "right-[-4px]" : "right-[-9px]",
+                  // Anchor the leading edge so wider values grow away from the label.
+                  size === "40" ? "left-[calc(100%_-_16px)]" : "left-[calc(100%_-_11px)]",
                 )}
                 value={notificationCount ?? 0}
                 max={notificationMax}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -186,8 +186,9 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             <span
               className={cn(
                 "flex min-w-0 items-center gap-0.5 overflow-hidden px-3",
-                // Keep label clear of the corner badge (esp. wide values like "99+").
-                (notificationCount != null || notificationLabel) && "pr-5",
+                // Figma overlays the badge, but reserving its width prevents wide
+                // values such as "99+" from covering short labels.
+                (notificationCount != null || notificationLabel) && "pr-6",
               )}
             >
               {leftDot && (
@@ -211,9 +212,11 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             {(notificationCount != null || notificationLabel) && (
               <Count
                 variant={notificationVariant}
-                size="24"
+                size="32"
                 className={cn(
-                  "absolute top-[-4px]",
+                  // V2 Notification Count: 20px high/min-width, caption 12,
+                  // 4px horizontal and 2px vertical padding, rounded-md.
+                  "absolute top-[-4px] rounded-md px-1 py-0.5",
                   size === "40" ? "right-[-4px]" : "right-[-9px]",
                 )}
                 value={notificationCount ?? 0}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -204,7 +204,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             </span>
             <Count
               variant={notificationVariant}
-              size="16"
+              size="24"
               className="absolute -top-1 -right-1"
               value={notificationCount ?? 0}
               max={notificationMax}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,6 +1,7 @@
 import { Slot, Slottable } from "@radix-ui/react-slot";
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { Count, type CountVariant } from "../Count/Count";
 
 /** Visual variant of the chip. */
 export type ChipVariant = "rounded" | "square" | "dark";
@@ -31,6 +32,12 @@ export interface ChipProps extends React.HTMLAttributes<HTMLElement> {
   rightIcon?: React.ReactNode;
   /** Notification badge content (e.g. `"99+"`). Passed as a string for i18n support. */
   notificationLabel?: string;
+  /** Numeric value for the notification badge. Uses the `Count` component for overflow formatting. Takes precedence over `notificationLabel` when both are provided. */
+  notificationCount?: number;
+  /** Maximum value before the badge shows overflow (e.g. `"9+"`). Only applies when `notificationCount` is set. @default 99 */
+  notificationMax?: number;
+  /** Colour variant of the notification badge. @default "brand" */
+  notificationVariant?: CountVariant;
   /** Click handler — when provided, the chip renders as a `<button>` for accessibility. */
   onClick?: React.MouseEventHandler<HTMLElement>;
   /** Merge props onto a child element instead of rendering a wrapper. @default false */
@@ -60,6 +67,9 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
       leftIcon,
       rightIcon,
       notificationLabel,
+      notificationCount,
+      notificationMax,
+      notificationVariant = "brand",
       onClick,
       asChild = false,
       children,
@@ -192,11 +202,15 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
                 </span>
               )}
             </span>
-            {notificationLabel && (
-              <span className="typography-description-12px-semibold absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-content-primary px-1 text-content-primary-inverted">
-                {notificationLabel}
-              </span>
-            )}
+            <Count
+              variant={notificationVariant}
+              size="16"
+              className="absolute -top-1 -right-1"
+              value={notificationCount ?? 0}
+              max={notificationMax}
+            >
+              {notificationCount == null ? notificationLabel : undefined}
+            </Count>
           </>
         )}
       </Comp>

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -202,15 +202,20 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
                 </span>
               )}
             </span>
-            <Count
-              variant={notificationVariant}
-              size="24"
-              className="absolute -top-1 -right-1"
-              value={notificationCount ?? 0}
-              max={notificationMax}
-            >
-              {notificationCount == null ? notificationLabel : undefined}
-            </Count>
+            {(notificationCount != null || notificationLabel) && (
+              <Count
+                variant={notificationVariant}
+                size="24"
+                className={cn(
+                  "absolute top-[-4px]",
+                  size === "40" ? "right-[-4px]" : "right-[-9px]",
+                )}
+                value={notificationCount ?? 0}
+                max={notificationMax}
+              >
+                {notificationCount == null ? notificationLabel : undefined}
+              </Count>
+            )}
           </>
         )}
       </Comp>

--- a/src/components/Count/Count.stories.tsx
+++ b/src/components/Count/Count.stories.tsx
@@ -46,7 +46,6 @@ export const Brand: Story = {
   args: {
     variant: "brand",
     value: 12,
-    size: "24",
   },
 };
 
@@ -54,7 +53,6 @@ export const Contrast: Story = {
   args: {
     variant: "contrast",
     value: 3,
-    size: "24",
   },
   decorators: [
     (Story) => (
@@ -113,7 +111,6 @@ export const MaxValue: Story = {
   args: {
     value: 150,
     max: 99,
-    size: "24",
   },
 };
 
@@ -126,7 +123,6 @@ export const ZeroValue: Story = {
 export const CustomContent: Story = {
   args: {
     children: "NEW",
-    size: "24",
   },
 };
 
@@ -134,7 +130,7 @@ export const OnButton: Story = {
   render: () => (
     <Button variant="tertiary" size="40" className="relative">
       Messages
-      <Count value={24} variant="alert" size="24" className="absolute -top-2 -right-2" />
+      <Count value={24} variant="alert" className="absolute -top-2 -right-2" />
     </Button>
   ),
 };
@@ -144,10 +140,10 @@ export const V2Types: Story = {
   render: () => (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-4">
-        <Count value={5} variant="default" size="24" />
-        <Count value={12} variant="brand" size="24" />
+        <Count value={5} variant="default" />
+        <Count value={12} variant="brand" />
         <div className="rounded-md bg-neutral-alphas-600 p-3">
-          <Count value={3} variant="contrast" size="24" />
+          <Count value={3} variant="contrast" />
         </div>
       </div>
       <div className="flex items-center gap-4">
@@ -163,15 +159,14 @@ export const V2Types: Story = {
 
 export const MultipleVariants: Story = {
   render: () => (
-    <div className="flex flex-wrap items-center gap-4">
-      <Count value={5} variant="default" size="24" />
-      <Count value={3} variant="contrast" size="24" />
-      <Count value={12} variant="brand" size="24" />
-      <Count value={3} variant="alert" size="24" />
-      <Count value={8} variant="pink" size="24" />
-      <Count value={3} variant="info" size="24" />
-      <Count value={7} variant="success" size="24" />
-      <Count value={99} variant="warning" size="24" />
+    <div className="flex items-center gap-4">
+      <Count value={5} variant="default" />
+      <Count value={3} variant="alert" />
+      <Count value={12} variant="brand" />
+      <Count value={8} variant="pink" />
+      <Count value={3} variant="info" />
+      <Count value={7} variant="success" />
+      <Count value={99} variant="warning" />
     </div>
   ),
 };

--- a/src/components/Count/Count.stories.tsx
+++ b/src/components/Count/Count.stories.tsx
@@ -39,7 +39,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     value: 5,
-    size: "24",
   },
 };
 

--- a/src/components/Count/Count.stories.tsx
+++ b/src/components/Count/Count.stories.tsx
@@ -9,20 +9,26 @@ const meta = {
     layout: "centered",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=1810-5202&m=dev",
+      // V2 Notification Count — Fanvue Library (instance node used by V2 Chips)
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17898-11698&m=dev",
     },
   },
   tags: ["autodocs"],
   argTypes: {
     variant: {
       control: "select",
-      options: ["default", "alert", "brand", "pink", "info", "success", "warning"],
+      options: ["default", "contrast", "brand", "alert", "pink", "info", "success", "warning"],
     },
+    showAmount: { control: "boolean" },
     value: {
       control: { type: "number", min: 0, max: 999 },
     },
     max: {
       control: { type: "number", min: 1, max: 999 },
+    },
+    size: {
+      control: "select",
+      options: ["16", "24", "32"],
     },
   },
 } satisfies Meta<typeof Count>;
@@ -33,13 +39,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     value: 5,
-  },
-};
-
-export const Alert: Story = {
-  args: {
-    variant: "alert",
-    value: 5,
+    size: "24",
   },
 };
 
@@ -47,6 +47,38 @@ export const Brand: Story = {
   args: {
     variant: "brand",
     value: 12,
+    size: "24",
+  },
+};
+
+export const Contrast: Story = {
+  args: {
+    variant: "contrast",
+    value: 3,
+    size: "24",
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-md bg-neutral-alphas-600 p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const DotBrand: Story = {
+  name: "Show Amount False (Dot)",
+  args: {
+    variant: "brand",
+    value: 1,
+    showAmount: false,
+  },
+};
+
+export const Alert: Story = {
+  args: {
+    variant: "alert",
+    value: 5,
   },
 };
 
@@ -82,6 +114,7 @@ export const MaxValue: Story = {
   args: {
     value: 150,
     max: 99,
+    size: "24",
   },
 };
 
@@ -94,6 +127,7 @@ export const ZeroValue: Story = {
 export const CustomContent: Story = {
   args: {
     children: "NEW",
+    size: "24",
   },
 };
 
@@ -101,21 +135,44 @@ export const OnButton: Story = {
   render: () => (
     <Button variant="tertiary" size="40" className="relative">
       Messages
-      <Count value={24} variant="alert" className="absolute -top-2 -right-2" />
+      <Count value={24} variant="alert" size="24" className="absolute -top-2 -right-2" />
     </Button>
+  ),
+};
+
+export const V2Types: Story = {
+  name: "V2 Types × Show Amount",
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-4">
+        <Count value={5} variant="default" size="24" />
+        <Count value={12} variant="brand" size="24" />
+        <div className="rounded-md bg-neutral-alphas-600 p-3">
+          <Count value={3} variant="contrast" size="24" />
+        </div>
+      </div>
+      <div className="flex items-center gap-4">
+        <Count value={1} variant="default" showAmount={false} />
+        <Count value={1} variant="brand" showAmount={false} />
+        <div className="rounded-md bg-neutral-alphas-600 p-3">
+          <Count value={1} variant="contrast" showAmount={false} />
+        </div>
+      </div>
+    </div>
   ),
 };
 
 export const MultipleVariants: Story = {
   render: () => (
-    <div className="flex items-center gap-4">
-      <Count value={5} variant="default" />
-      <Count value={3} variant="alert" />
-      <Count value={12} variant="brand" />
-      <Count value={8} variant="pink" />
-      <Count value={3} variant="info" />
-      <Count value={7} variant="success" />
-      <Count value={99} variant="warning" />
+    <div className="flex flex-wrap items-center gap-4">
+      <Count value={5} variant="default" size="24" />
+      <Count value={3} variant="contrast" size="24" />
+      <Count value={12} variant="brand" size="24" />
+      <Count value={3} variant="alert" size="24" />
+      <Count value={8} variant="pink" size="24" />
+      <Count value={3} variant="info" size="24" />
+      <Count value={7} variant="success" size="24" />
+      <Count value={99} variant="warning" size="24" />
     </div>
   ),
 };

--- a/src/components/Count/Count.test.tsx
+++ b/src/components/Count/Count.test.tsx
@@ -103,12 +103,11 @@ describe("Count", () => {
       expect(badge).toHaveClass("text-content-always-black");
     });
 
-    it("uses V2 notification geometry for size 24", () => {
+    it("keeps size 24 at 16px height", () => {
       render(<Count value={5} size="24" />);
       const badge = screen.getByText("5");
-      expect(badge).toHaveClass("min-h-5");
-      expect(badge).toHaveClass("min-w-5");
-      expect(badge).toHaveClass("rounded-md");
+      expect(badge).toHaveClass("h-4");
+      expect(badge).toHaveClass("min-w-4");
     });
   });
 

--- a/src/components/Count/Count.test.tsx
+++ b/src/components/Count/Count.test.tsx
@@ -87,4 +87,44 @@ describe("Count", () => {
       expect(screen.getByText("999+")).toBeInTheDocument();
     });
   });
+
+  describe("V2 variants", () => {
+    it("applies brand styles", () => {
+      render(<Count value={5} variant="brand" size="24" />);
+      const badge = screen.getByText("5");
+      expect(badge).toHaveClass("bg-brand-primary-default");
+      expect(badge).toHaveClass("text-content-always-black");
+    });
+
+    it("applies contrast styles", () => {
+      render(<Count value={5} variant="contrast" size="24" />);
+      const badge = screen.getByText("5");
+      expect(badge).toHaveClass("bg-content-always-white");
+      expect(badge).toHaveClass("text-content-always-black");
+    });
+
+    it("uses V2 notification geometry for size 24", () => {
+      render(<Count value={5} size="24" />);
+      const badge = screen.getByText("5");
+      expect(badge).toHaveClass("min-h-5");
+      expect(badge).toHaveClass("min-w-5");
+      expect(badge).toHaveClass("rounded-md");
+    });
+  });
+
+  describe("showAmount", () => {
+    it("renders an unread dot when showAmount is false", () => {
+      render(<Count value={3} variant="brand" showAmount={false} />);
+      const dot = screen.getByTestId("count");
+      expect(dot).toHaveClass("size-2");
+      expect(dot).toHaveClass("rounded-full");
+      expect(dot).toHaveClass("bg-brand-primary-default");
+      expect(dot).toBeEmptyDOMElement();
+    });
+
+    it("still hides when value is 0 and showAmount is false", () => {
+      const { container } = render(<Count value={0} showAmount={false} />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
 });

--- a/src/components/Count/Count.tsx
+++ b/src/components/Count/Count.tsx
@@ -2,23 +2,66 @@ import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 import { cn } from "../../utils/cn";
 
-/** Colour variant for the count badge. */
-export type CountVariant = "default" | "alert" | "brand" | "pink" | "info" | "success" | "warning";
+/**
+ * Colour variant for the count badge.
+ *
+ * V2 Notification Count (Fanvue Library) types: `default`, `brand`, `contrast`.
+ * Remaining values are retained extensions for existing consumers.
+ */
+export type CountVariant =
+  | "default"
+  | "contrast"
+  | "brand"
+  | "alert"
+  | "pink"
+  | "info"
+  | "success"
+  | "warning";
 
-/** Size of the count badge, aligned with button and icon-button sizes. */
+/** Size of the count badge. `"24"` matches V2 Notification Count geometry (~20px / caption 12). */
 export type CountSize = "16" | "24" | "32";
 
 function getDisplayValue(value: number, max: number): string {
   return value > max ? `${max}+` : value.toString();
 }
 
+function variantClasses(variant: CountVariant): string {
+  switch (variant) {
+    case "default":
+      return "bg-content-primary text-content-primary-inverted";
+    case "contrast":
+      // V2: on dark or coloured hosts (filled buttons, images)
+      return "bg-content-always-white text-content-always-black";
+    case "brand":
+      return "bg-brand-primary-default text-content-always-black";
+    case "alert":
+      return "bg-error-content text-content-always-white";
+    case "pink":
+      return "bg-brand-secondary-default text-content-always-black";
+    case "info":
+      return "bg-info-content text-content-always-white";
+    case "success":
+      return "bg-success-content text-content-always-white";
+    case "warning":
+      return "bg-warning-content text-content-always-black";
+  }
+}
+
 export interface CountProps extends React.HTMLAttributes<HTMLSpanElement> {
-  /** Colour variant of the count badge. @default "default" */
+  /**
+   * Colour variant of the count badge.
+   * Figma V2 types: `default` | `brand` | `contrast`. @default "default"
+   */
   variant?: CountVariant;
   /** Numeric value to display. Renders nothing when `0` and no `children` are provided. @default 0 */
   value?: number;
   /** Maximum value before showing overflow (e.g. `"99+"`). @default 99 */
   max?: number;
+  /**
+   * When `false`, renders an 8px unread dot instead of a numeric amount
+   * (Figma Show Amount=False). @default true
+   */
+  showAmount?: boolean;
   /** Size of the count badge. @default "32" */
   size?: CountSize;
   /** Merge props onto a child element instead of rendering a `<span>`. @default false */
@@ -26,13 +69,14 @@ export interface CountProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 /**
- * A numeric badge typically used for notification counts. Automatically
- * truncates values above `max` (e.g. `"99+"`). Renders nothing when the
- * value is `0` and no children are provided.
+ * V2 Notification Count — a small badge for unread activity on nav items,
+ * icons, buttons, or chips. Truncates values above `max` (e.g. `"99+"`).
+ * Renders nothing when the value is `0` and no children are provided.
  *
  * @example
  * ```tsx
  * <Count value={5} variant="brand" />
+ * <Count value={1} variant="brand" showAmount={false} />
  * ```
  */
 export const Count = React.forwardRef<HTMLSpanElement, CountProps>(
@@ -42,6 +86,7 @@ export const Count = React.forwardRef<HTMLSpanElement, CountProps>(
       variant = "default",
       value = 0,
       max = 99,
+      showAmount = true,
       size = "32",
       asChild = false,
       children,
@@ -54,22 +99,30 @@ export const Count = React.forwardRef<HTMLSpanElement, CountProps>(
     }
 
     const Comp = asChild ? Slot : "span";
+    const colors = variantClasses(variant);
+
+    if (!showAmount) {
+      return (
+        <Comp
+          ref={ref}
+          data-testid="count"
+          className={cn("inline-flex size-2 shrink-0 rounded-full", colors, className)}
+          {...props}
+        />
+      );
+    }
 
     return (
       <Comp
         ref={ref}
+        data-testid="count"
         className={cn(
-          "typography-description-12px-semibold inline-flex shrink-0 items-center justify-center rounded-full tabular-nums leading-none",
-          size === "16" && "h-3 min-w-3 px-0.5 text-[8px]",
-          size === "24" && "h-4 min-w-4 px-1 text-[10px]",
-          size === "32" && "h-5 min-w-5 px-1.5 text-[12px]",
-          variant === "default" && "bg-content-primary text-content-primary-inverted",
-          variant === "alert" && "bg-error-content text-content-always-white",
-          variant === "brand" && "bg-brand-primary-default text-content-always-black",
-          variant === "pink" && "bg-brand-secondary-default text-content-always-black",
-          variant === "info" && "bg-info-content text-content-always-white",
-          variant === "success" && "bg-success-content text-content-always-white",
-          variant === "warning" && "bg-warning-content text-content-always-black",
+          "typography-description-12px-semibold inline-flex shrink-0 items-center justify-center tabular-nums leading-none",
+          size === "16" && "h-3 min-w-3 rounded-full px-0.5 text-[8px]",
+          // V2 Notification Count: caption 12, min-w 20, px 4 / py 2, rounded-md
+          size === "24" && "min-h-5 min-w-5 rounded-md px-1 py-0.5",
+          size === "32" && "h-5 min-w-5 rounded-full px-1.5",
+          colors,
           className,
         )}
         {...props}

--- a/src/components/Count/Count.tsx
+++ b/src/components/Count/Count.tsx
@@ -18,7 +18,7 @@ export type CountVariant =
   | "success"
   | "warning";
 
-/** Size of the count badge. `"24"` matches V2 Notification Count geometry (~20px / caption 12). */
+/** Size of the count badge, aligned with button and icon-button sizes. */
 export type CountSize = "16" | "24" | "32";
 
 function getDisplayValue(value: number, max: number): string {
@@ -117,11 +117,11 @@ export const Count = React.forwardRef<HTMLSpanElement, CountProps>(
         ref={ref}
         data-testid="count"
         className={cn(
-          "typography-description-12px-semibold inline-flex shrink-0 items-center justify-center tabular-nums leading-none",
-          size === "16" && "h-3 min-w-3 rounded-full px-0.5 text-[8px]",
-          // V2 Notification Count: caption 12, min-w 20, px 4 / py 2, rounded-md
-          size === "24" && "min-h-5 min-w-5 rounded-md px-1 py-0.5",
-          size === "32" && "h-5 min-w-5 rounded-full px-1.5",
+          "typography-description-12px-semibold inline-flex shrink-0 items-center justify-center rounded-full tabular-nums leading-none",
+          size === "16" && "h-3 min-w-3 px-0.5 text-[8px]",
+          // Kept at 16px so nav / IconButton badges don't grow; Chip nests this size.
+          size === "24" && "h-4 min-w-4 px-1 text-[10px]",
+          size === "32" && "h-5 min-w-5 px-1.5 text-[12px]",
           colors,
           className,
         )}


### PR DESCRIPTION
## Summary

Upgrade `Count` and `Chip` against Fanvue Library V2 — not a colour-only Chip patch.

**V2 Notification Count** ([Library instance](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17898-11698)):
- First-class types `default` | `brand` | `contrast` (extended variants kept for BC)
- `showAmount={false}` → 8px unread dot
- Existing shared Count sizes remain unchanged for backwards compatibility

**V2 Chips** ([16965:92740](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=16965-92740)):
- Composes `Count` via `notificationCount` / `notificationMax` / `notificationLabel`
- Default `notificationVariant="brand"` (green + always-black)
- Exact nested badge geometry: 20px high/min-width, caption 12, `rounded-md`
- Figma offsets: `top: -4px`, `right: -9px` (32) / `right: -4px` (40)
- Anchors the badge by its leading edge so wider counts grow outward without changing chip width or covering labels

## Breaking visual change

Existing `Chip` + `notificationLabel` consumers switch from white to **brand** green. Pass `notificationVariant="default"` to keep the old look.

## Related

- Closes DES-789
- Refs DES-782 (Notifications page can drop hand-rolled chip badges after this ships)