### PR TITLE
fix(forms): keep focus ring visible on autofilled inputs

### DIFF
--- a/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/Autocomplete.test.tsx
@@ -88,6 +88,21 @@ describe("Autocomplete", () => {
     });
   });
 
+  describe("focus ring", () => {
+    it("renders the focus ring via the after overlay so autofill cannot paint over it", () => {
+      const { container } = renderAutocomplete();
+      const fieldContainer = container.querySelector('[class*="has-focus-visible"]') as HTMLElement;
+      expect(fieldContainer).toHaveClass(
+        "after:pointer-events-none",
+        "after:absolute",
+        "after:inset-0",
+        "after:rounded-[inherit]",
+        "has-focus-visible:after:shadow-focus-ring",
+      );
+      expect(fieldContainer).not.toHaveClass("has-focus-visible:shadow-focus-ring");
+    });
+  });
+
   describe("error state", () => {
     it("applies error border on container", () => {
       const { container } = renderAutocomplete({ error: true });

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -234,7 +234,7 @@ export const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard interaction is handled by the inner combobox input */}
           <div
             className={cn(
-              "flex flex-wrap items-center overflow-hidden rounded-sm border bg-neutral-alphas-100 has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+              "relative flex flex-wrap items-center overflow-hidden rounded-sm border bg-neutral-alphas-100 after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] has-focus-visible:outline-none has-focus-visible:after:shadow-focus-ring motion-safe:transition-colors",
               error ? "border-error-content" : "border-transparent",
               !disabled && !error && "hover:border-neutral-alphas-400",
               ac.isOpen && !error && !disabled && "border-neutral-alphas-400",

--- a/src/components/PhoneField/PhoneField.test.tsx
+++ b/src/components/PhoneField/PhoneField.test.tsx
@@ -107,6 +107,21 @@ describe("PhoneField", () => {
     });
   });
 
+  describe("focus ring", () => {
+    it("renders the focus ring via the after overlay so autofill cannot paint over it", () => {
+      const { container } = render(<PhoneField aria-label="Phone" />);
+      const fieldContainer = container.querySelector('[class*="has-focus-visible"]') as HTMLElement;
+      expect(fieldContainer).toHaveClass(
+        "after:pointer-events-none",
+        "after:absolute",
+        "after:inset-0",
+        "after:rounded-[inherit]",
+        "has-focus-visible:after:shadow-focus-ring",
+      );
+      expect(fieldContainer).not.toHaveClass("has-focus-visible:shadow-focus-ring");
+    });
+  });
+
   describe("accessibility", () => {
     it("warns when no accessible name is provided", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/components/PhoneField/PhoneField.tsx
+++ b/src/components/PhoneField/PhoneField.tsx
@@ -55,7 +55,7 @@ const PREFIX_TYPOGRAPHY: Record<PhoneFieldSize, string> = {
 
 function getContainerClassName(size: PhoneFieldSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative flex items-center gap-2 overflow-hidden rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    "relative flex items-center gap-2 overflow-hidden rounded-sm border bg-inputs-inputs-primary after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] has-focus-visible:outline-none has-focus-visible:after:shadow-focus-ring motion-safe:transition-colors",
     CONTAINER_PADDING_X[size],
     CONTAINER_HEIGHT[size],
     error ? "border-error-content" : "border-border-primary",

--- a/src/components/TextArea/TextArea.test.tsx
+++ b/src/components/TextArea/TextArea.test.tsx
@@ -254,6 +254,21 @@ describe("TextArea", () => {
     });
   });
 
+  describe("focus ring", () => {
+    it("renders the focus ring via the after overlay so autofill cannot paint over it", () => {
+      const { container } = render(<TextArea label="Test" />);
+      const fieldContainer = container.querySelector('[class*="has-focus-visible"]') as HTMLElement;
+      expect(fieldContainer).toHaveClass(
+        "after:pointer-events-none",
+        "after:absolute",
+        "after:inset-0",
+        "after:rounded-[inherit]",
+        "has-focus-visible:after:shadow-focus-ring",
+      );
+      expect(fieldContainer).not.toHaveClass("has-focus-visible:shadow-focus-ring");
+    });
+  });
+
   describe("accessibility", () => {
     it("has no accessibility violations", async () => {
       const { container } = render(<TextArea label="Description" />);

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -67,7 +67,7 @@ const CLEAR_BUTTON_RIGHT: Record<TextAreaSize, string> = {
 
 function getContainerClassName(size: TextAreaSize, error: boolean, disabled?: boolean) {
   return cn(
-    "relative rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    "relative rounded-sm border bg-inputs-inputs-primary after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] has-focus-visible:outline-none has-focus-visible:after:shadow-focus-ring motion-safe:transition-colors",
     error ? "border-error-content" : "border-border-primary",
     !disabled && !error && "hover:border-neutral-alphas-400",
     CONTAINER_MIN_HEIGHT[size],

--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -348,6 +348,21 @@ describe("TextField", () => {
     });
   });
 
+  describe("focus ring", () => {
+    it("renders the focus ring via the after overlay so autofill cannot paint over it", () => {
+      const { container } = render(<TextField aria-label="Test" />);
+      const inputContainer = container.querySelector('[class*="has-focus-visible"]') as HTMLElement;
+      expect(inputContainer).toHaveClass(
+        "after:pointer-events-none",
+        "after:absolute",
+        "after:inset-0",
+        "after:rounded-[inherit]",
+        "has-focus-visible:after:shadow-focus-ring",
+      );
+      expect(inputContainer).not.toHaveClass("has-focus-visible:shadow-focus-ring");
+    });
+  });
+
   describe("accessibility", () => {
     let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -80,7 +80,7 @@ function getContainerClassName(
   hasAction?: boolean,
 ) {
   return cn(
-    "relative flex items-center overflow-hidden rounded-sm border bg-inputs-inputs-primary has-focus-visible:shadow-focus-ring has-focus-visible:outline-none motion-safe:transition-colors",
+    "relative flex items-center overflow-hidden rounded-sm border bg-inputs-inputs-primary after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] has-focus-visible:outline-none has-focus-visible:after:shadow-focus-ring motion-safe:transition-colors",
     hasAction ? CONTAINER_PADDING_X_WITH_ACTION[size] : CONTAINER_PADDING_X[size],
     CONTAINER_GAP[size],
     error ? "border-error-content" : "border-border-primary",

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -21,6 +21,13 @@
    * visibly lighter band inside the field in dark mode. Note this rule
    * cannot be overridden by unlayered !important declarations downstream:
    * for !important the cascade reverses, so @layer base wins.
+   *
+   * Side effect: this opaque shadow paints ABOVE any inset box-shadow on an
+   * ancestor (a child's background/shadow always paints over the parent's
+   * inset shadow), so field containers must not draw their focus ring as a
+   * plain inset shadow on themselves — it gets erased behind the autofilled
+   * input. TextField/TextArea/PhoneField/Autocomplete render the ring in an
+   * ::after overlay instead.
    */
   input:-webkit-autofill,
   input:-webkit-autofill:hover,


### PR DESCRIPTION
## Summary

- On Chrome autofill, focused TextFields showed a broken focus ring — only the corner arcs remained, looking like a radius mismatch between the input and its outline.
- Root cause: the focus ring is an inset box-shadow on the field container, and inset shadows paint *below* child content. The autofill neutralisation hack in `base.css` puts an opaque `inset 0 0 0 1000px` shadow on the full-height `<input>`, which painted over the ring's top and bottom edges.
- Fix: render the ring in an `::after` overlay (`after:inset-0 after:rounded-[inherit]` + `has-focus-visible:after:shadow-focus-ring`) so nothing the input paints can erase it. Same token, same geometry. Applied to TextField, TextArea, PhoneField and Autocomplete; the paint-order gotcha is documented in `base.css`.

Autofilled inputs now look identical to manually-typed ones, with the focus ring intact.

## Test plan

- [x] Unit tests for TextField, TextArea, PhoneField, Autocomplete (271 passing)
- [x] `pnpm typecheck` and `pnpm lint`
- [x] Visual check in Storybook with simulated autofill shadow + forced `:focus-visible` (light + dark verified on local.fanvue.com signin)