### PR TITLE
feat(ButtonStack): build V2 button stack (ENG-11787)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import {
   BreadcrumbPage,
   BulbIcon,
   Button,
+  ButtonStack,
   CalendarIcon,
   CameraIcon,
   Card,
@@ -2150,6 +2151,34 @@ function ButtonDemo() {
         <Button variant="brand" asChild>
           <a href="#link">Link as Brand</a>
         </Button>
+      </div>
+    </div>
+  );
+}
+
+function ButtonStackDemo() {
+  return (
+    <div id="buttonstack" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Button Stack</h2>
+      <div className="flex flex-col gap-6">
+        <div className="w-80 max-w-full">
+          <p className="typography-body-small-14px-regular mb-2 text-content-secondary">
+            Horizontal (equal width)
+          </p>
+          <ButtonStack direction="horizontal">
+            <Button variant="outline">Cancel</Button>
+            <Button variant="primary">Confirm</Button>
+          </ButtonStack>
+        </div>
+        <div className="w-80 max-w-full">
+          <p className="typography-body-small-14px-regular mb-2 text-content-secondary">
+            Vertical (full width)
+          </p>
+          <ButtonStack direction="vertical">
+            <Button variant="primary">Confirm</Button>
+            <Button variant="outline">Cancel</Button>
+          </ButtonStack>
+        </div>
       </div>
     </div>
   );
@@ -5415,6 +5444,7 @@ function App() {
     { id: "badge", label: "Badge" },
     { id: "bottom-navigation", label: "Bottom Navigation" },
     { id: "button", label: "Button" },
+    { id: "buttonstack", label: "Button Stack" },
     { id: "subscribebutton", label: "Subscribe Button" },
     { id: "card", label: "Card" },
     { id: "charts", label: "Charts" },
@@ -5600,6 +5630,9 @@ function App() {
 
             {/* Button */}
             <ButtonDemo />
+
+            {/* Button Stack */}
+            <ButtonStackDemo />
 
             {/* Subscribe Button */}
             <SubscribeButtonDemo />

--- a/src/components/ButtonStack/ButtonStack.stories.tsx
+++ b/src/components/ButtonStack/ButtonStack.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../Button/Button";
+import { ButtonStack } from "./ButtonStack";
+
+const meta = {
+  title: "Components/ButtonStack",
+  component: ButtonStack,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17522-10501",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    direction: {
+      control: "inline-radio",
+      options: ["horizontal", "vertical"],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ButtonStack>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  args: {
+    direction: "horizontal",
+    children: (
+      <>
+        <Button variant="outline">Cancel</Button>
+        <Button variant="primary">Confirm</Button>
+      </>
+    ),
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    direction: "vertical",
+    children: (
+      <>
+        <Button variant="primary">Confirm</Button>
+        <Button variant="outline">Cancel</Button>
+      </>
+    ),
+  },
+};

--- a/src/components/ButtonStack/ButtonStack.test.tsx
+++ b/src/components/ButtonStack/ButtonStack.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Button } from "../Button/Button";
+import { ButtonStack } from "./ButtonStack";
+
+describe("ButtonStack", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      render(
+        <ButtonStack className="custom" data-testid="stack">
+          <Button>Cancel</Button>
+          <Button>Confirm</Button>
+        </ButtonStack>,
+      );
+      expect(screen.getByTestId("stack")).toHaveClass("custom");
+    });
+
+    it("renders horizontal layout by default", () => {
+      render(
+        <ButtonStack data-testid="stack">
+          <Button>Cancel</Button>
+          <Button>Confirm</Button>
+        </ButtonStack>,
+      );
+      expect(screen.getByTestId("stack")).toHaveClass("flex-row");
+    });
+
+    it("renders vertical layout when direction is vertical", () => {
+      render(
+        <ButtonStack direction="vertical" data-testid="stack">
+          <Button>Cancel</Button>
+          <Button>Confirm</Button>
+        </ButtonStack>,
+      );
+      expect(screen.getByTestId("stack")).toHaveClass("flex-col");
+    });
+
+    it("forwards its ref to the underlying element", () => {
+      const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+      render(
+        <ButtonStack ref={ref}>
+          <Button>Cancel</Button>
+          <Button>Confirm</Button>
+        </ButtonStack>,
+      );
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(
+        <ButtonStack>
+          <Button>Cancel</Button>
+          <Button>Confirm</Button>
+        </ButtonStack>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/ButtonStack/ButtonStack.tsx
+++ b/src/components/ButtonStack/ButtonStack.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Layout orientation of the buttons within a {@link ButtonStack}. */
+export type ButtonStackDirection = "horizontal" | "vertical";
+
+export interface ButtonStackProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Layout orientation. `horizontal` places buttons side by side with equal
+   * widths for primary + secondary action pairs; `vertical` stacks them
+   * full-width for mobile screens and narrow panels.
+   * @default "horizontal"
+   */
+  direction?: ButtonStackDirection;
+  /** Buttons to arrange — typically two {@link Button} elements. */
+  children: React.ReactNode;
+}
+
+/**
+ * A layout helper that arranges action buttons either side by side
+ * (`horizontal`) or stacked (`vertical`). Compose it with {@link Button}
+ * children rather than reimplementing button styles.
+ *
+ * In `horizontal` mode each child stretches to an equal width; in `vertical`
+ * mode each child spans the full width of the container. Buttons keep their
+ * own sizing, so pass a matching `size` to each child for consistent heights.
+ *
+ * @example
+ * ```tsx
+ * <ButtonStack direction="horizontal">
+ *   <Button variant="outline">Cancel</Button>
+ *   <Button variant="primary">Confirm</Button>
+ * </ButtonStack>
+ * ```
+ */
+export const ButtonStack = React.forwardRef<HTMLDivElement, ButtonStackProps>(
+  ({ direction = "horizontal", className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex gap-2",
+          direction === "horizontal" && "flex-row [&>*]:min-w-0 [&>*]:flex-1",
+          direction === "vertical" && "flex-col [&>*]:w-full",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+ButtonStack.displayName = "ButtonStack";

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,11 @@ export type {
 } from "./components/Button/Button";
 export { Button } from "./components/Button/Button";
 export type {
+  ButtonStackDirection,
+  ButtonStackProps,
+} from "./components/ButtonStack/ButtonStack";
+export { ButtonStack } from "./components/ButtonStack/ButtonStack";
+export type {
   CardContentProps,
   CardDescriptionProps,
   CardFooterProps,


### PR DESCRIPTION
## Summary

Adds `ButtonStack`, a layout helper that arranges two action buttons either **horizontal** (equal-width primary + secondary pairs for dialogs/footers) or **vertical** (full-width, for mobile screens and narrow panels). It composes the existing `Button` component rather than reimplementing button styles.

- `direction="horizontal"` (default): `flex` row, each child stretches to equal width (`flex-1`)
- `direction="vertical"`: `flex-col`, each child spans full width (`w-full`)
- Gap maps to the Figma 8px `button-button` spacing token → `gap-2`
- Forwards `ref`, spreads `HTMLAttributes`, supports `className` passthrough, fully JSDoc'd

## Figma

[V2 Button Stack — node 17522-10501](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17522-10501)

### Token mapping

| Figma token | Value | Applied as |
| --- | --- | --- |
| `Spacing/Horizontal/Group/button-button` | 8px | `gap-2` |
| `Spacing/Vertical/Group/button-button` | 8px | `gap-2` |
| Horizontal child `flex-[1_0_0]` | equal width | `[&>*]:flex-1 [&>*]:min-w-0` |
| Vertical child `w-full` | full width | `[&>*]:w-full` |

The individual button fills/borders/radius/typography all come from the existing `Button` component, so no button styling is duplicated here.

## Screenshots

**Horizontal**

![Horizontal](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-button-stack-v2/bs-horizontal.png)

**Vertical**

![Vertical](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-button-stack-v2/bs-vertical.png)

## Notes / deviations

- Prop named `direction` with lowercase `"horizontal" | "vertical"` values (Figma variant is `Stack: Horizontal | Vertical`) — chosen for idiomatic React ergonomics.
- Kept the root as a neutral `<div>` (no forced `role`) so it stays an unopinionated layout primitive and passes axe without requiring a label; consumers can pass `role`/`aria-*` if they need grouping semantics.
- Button heights are not normalised by the stack — pass a matching `size` to each child (documented in JSDoc).

## Test plan

- [x] `pnpm biome check .`
- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/components/ButtonStack` (7 passed: 5 unit + 2 story)
- [x] `pnpm build`
- [x] Visual verification via Storybook + Playwright (screenshots above)
- [ ] Reviewer: confirm Design tab renders and link component in Figma via Storybook Connect after Chromatic publishes

Closes ENG-11787

Made with [Cursor](https://cursor.com)