### PR TITLE
feat(CriticalBanner): build V2 critical banner (ENG-10622)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,7 @@ import {
   CreatorCard,
   CreatorCover,
   CreatorTile,
+  CriticalBanner,
   CrossIcon,
   CrownIcon,
   CyclingText,
@@ -1842,6 +1843,35 @@ function BannerDemo() {
             </Button>
           }
         />
+      </div>
+    </div>
+  );
+}
+
+function CriticalBannerDemo() {
+  return (
+    <div id="critical-banner" className="flex scroll-mt-20 flex-col gap-4">
+      <h2 className="typography-header-heading-sm mb-4">Critical Banner</h2>
+      <div className="flex max-w-4xl flex-col gap-6">
+        <CriticalBanner
+          layout="trailing"
+          title="Your account has been suspended"
+          ctaLabel="Contact support"
+        >
+          We detected activity that violates our terms of service. Contact support to resolve this
+          before you can continue.
+        </CriticalBanner>
+        <CriticalBanner
+          layout="under"
+          title="We couldn't process your payment"
+          ctaLabel="Update payment method"
+        >
+          Your subscription payment was declined. Update your payment method now to avoid losing
+          access to your account and its content.
+        </CriticalBanner>
+        <CriticalBanner layout="trailing">
+          This is the body text for a critical in-app alert, shown without a title.
+        </CriticalBanner>
       </div>
     </div>
   );
@@ -5408,6 +5438,7 @@ function App() {
     { id: "accordion", label: "Accordion" },
     { id: "alert", label: "Alert" },
     { id: "banner", label: "Banner" },
+    { id: "critical-banner", label: "Critical Banner" },
     { id: "autocomplete", label: "Autocomplete" },
     { id: "audioupload", label: "Audio Upload" },
     { id: "voicenote", label: "Voice Note" },
@@ -5585,6 +5616,9 @@ function App() {
 
             {/* Banner */}
             <BannerDemo />
+
+            {/* Critical Banner */}
+            <CriticalBannerDemo />
 
             {/* Empty State */}
             <EmptyStateDemo />

--- a/src/components/CriticalBanner/CriticalBanner.stories.tsx
+++ b/src/components/CriticalBanner/CriticalBanner.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CriticalBanner } from "./CriticalBanner";
+
+const meta = {
+  title: "Components/CriticalBanner",
+  component: CriticalBanner,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17880-90686",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    layout: {
+      control: "inline-radio",
+      options: ["trailing", "under"],
+    },
+    title: { control: "text" },
+    ctaLabel: { control: "text" },
+  },
+  args: {
+    title: "Alert title",
+    children: "This is the body text for info in-app alert, longer text for the reference",
+    ctaLabel: "CTA",
+  },
+} satisfies Meta<typeof CriticalBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TrailingCta: Story = {
+  args: {
+    layout: "trailing",
+  },
+};
+
+export const UnderCta: Story = {
+  args: {
+    layout: "under",
+  },
+};
+
+export const WithoutTitle: Story = {
+  args: {
+    layout: "trailing",
+    title: undefined,
+  },
+};
+
+export const WithoutCta: Story = {
+  args: {
+    layout: "trailing",
+    ctaLabel: undefined,
+  },
+};
+
+export const AccountSuspended: Story = {
+  args: {
+    layout: "trailing",
+    title: "Your account has been suspended",
+    children:
+      "We detected activity that violates our terms of service. Contact support to resolve this before you can continue.",
+    ctaLabel: "Contact support",
+  },
+};
+
+export const PaymentFailedUnder: Story = {
+  args: {
+    layout: "under",
+    title: "We couldn't process your payment",
+    children:
+      "Your subscription payment was declined. Update your payment method now to avoid losing access to your account and its content.",
+    ctaLabel: "Update payment method",
+  },
+};

--- a/src/components/CriticalBanner/CriticalBanner.test.tsx
+++ b/src/components/CriticalBanner/CriticalBanner.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { CriticalBanner } from "./CriticalBanner";
+
+describe("CriticalBanner", () => {
+  describe("API", () => {
+    it("applies custom className to the root", () => {
+      render(
+        <CriticalBanner className="custom" title="Blocked">
+          Body copy
+        </CriticalBanner>,
+      );
+      expect(screen.getByRole("alert")).toHaveClass("custom");
+    });
+
+    it("renders a built-in CTA from ctaLabel and forwards onClick", async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+      render(
+        <CriticalBanner title="Blocked" ctaLabel="Fix it" ctaProps={{ onClick }}>
+          Body copy
+        </CriticalBanner>,
+      );
+      await user.click(screen.getByRole("button", { name: "Fix it" }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders a custom action instead of the built-in CTA", () => {
+      render(
+        <CriticalBanner title="Blocked" ctaLabel="Ignored" action={<a href="/help">Get help</a>}>
+          Body copy
+        </CriticalBanner>,
+      );
+      expect(screen.getByRole("link", { name: "Get help" })).toHaveAttribute("href", "/help");
+      expect(screen.queryByRole("button", { name: "Ignored" })).not.toBeInTheDocument();
+    });
+
+    it("allows overriding the default alert role", () => {
+      render(
+        <CriticalBanner role="region" aria-label="Account status" title="Blocked">
+          Body copy
+        </CriticalBanner>,
+      );
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.getByRole("region", { name: "Account status" })).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations in the trailing layout", async () => {
+      const { container } = render(
+        <CriticalBanner title="Account suspended" ctaLabel="Contact support">
+          Your account has been suspended pending review.
+        </CriticalBanner>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations in the under layout", async () => {
+      const { container } = render(
+        <CriticalBanner layout="under" title="Verify your identity" ctaLabel="Start verification">
+          You must verify your identity before you can continue.
+        </CriticalBanner>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/CriticalBanner/CriticalBanner.test.tsx
+++ b/src/components/CriticalBanner/CriticalBanner.test.tsx
@@ -27,6 +27,17 @@ describe("CriticalBanner", () => {
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
+    it("keeps the Button disabled treatment when the CTA is disabled", () => {
+      render(
+        <CriticalBanner title="Blocked" ctaLabel="Fix it" ctaProps={{ disabled: true }}>
+          Body copy
+        </CriticalBanner>,
+      );
+      const cta = screen.getByRole("button", { name: "Fix it" });
+      expect(cta).toBeDisabled();
+      expect(cta).not.toHaveClass("text-alerts-critical-banner-background");
+    });
+
     it("renders a custom action instead of the built-in CTA", () => {
       render(
         <CriticalBanner title="Blocked" ctaLabel="Ignored" action={<a href="/help">Get help</a>}>

--- a/src/components/CriticalBanner/CriticalBanner.tsx
+++ b/src/components/CriticalBanner/CriticalBanner.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { Button, type ButtonProps } from "../Button/Button";
+import { WarningIcon } from "../Icons/WarningIcon";
+
+/**
+ * Placement of the call-to-action relative to the message.
+ *
+ * - `"trailing"` keeps the action inline, aligned to the end of the banner.
+ * - `"under"` stacks the action beneath the message (use when the CTA label is
+ *   too long to sit comfortably on the same line).
+ */
+export type CriticalBannerLayout = "trailing" | "under";
+
+export interface CriticalBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Body copy describing the blocking situation. */
+  children: React.ReactNode;
+  /** Placement of the call-to-action relative to the message. @default "trailing" */
+  layout?: CriticalBannerLayout;
+  /** Optional bold heading shown above the body copy. */
+  title?: React.ReactNode;
+  /** Leading icon. Overrides the default filled warning icon. */
+  icon?: React.ReactNode;
+  /** Label for the built-in white call-to-action button. Ignored when `action` is set. */
+  ctaLabel?: React.ReactNode;
+  /** Props forwarded to the built-in call-to-action button (e.g. `onClick`, `asChild`). */
+  ctaProps?: Omit<ButtonProps, "variant" | "size" | "children">;
+  /** Custom action node rendered in place of the built-in call-to-action button. */
+  action?: React.ReactNode;
+}
+
+function CriticalBannerCta({
+  ctaLabel,
+  ctaProps,
+}: {
+  ctaLabel: React.ReactNode;
+  ctaProps?: CriticalBannerProps["ctaProps"];
+}) {
+  return (
+    <Button
+      variant="white"
+      size="40"
+      {...ctaProps}
+      className={cn(
+        "text-alerts-critical-banner-background hover:text-alerts-critical-banner-background active:text-alerts-critical-banner-background",
+        ctaProps?.className,
+      )}
+    >
+      {ctaLabel}
+    </Button>
+  );
+}
+
+/**
+ * A full-width, high-priority banner reserved for situations that block or
+ * significantly impact a user's ability to use the platform — account
+ * suspensions, blocking payment failures, identity verification requirements,
+ * or critical security notices. It sits at the very top of a page and is
+ * intentionally disruptive, so use it sparingly; for non-blocking messaging use
+ * {@link Alert} or {@link Banner} instead.
+ *
+ * Renders with `role="alert"` so assistive technology conveys its urgency;
+ * override `role` for a less assertive treatment when appropriate.
+ *
+ * @example
+ * ```tsx
+ * <CriticalBanner
+ *   title="Payment failed"
+ *   layout="trailing"
+ *   ctaLabel="Update payment"
+ *   ctaProps={{ onClick: handleUpdate }}
+ * >
+ *   We couldn't process your last payment. Update your details to keep your account active.
+ * </CriticalBanner>
+ * ```
+ */
+export const CriticalBanner = React.forwardRef<HTMLDivElement, CriticalBannerProps>(
+  (
+    {
+      className,
+      children,
+      layout = "trailing",
+      title,
+      icon,
+      ctaLabel,
+      ctaProps,
+      action,
+      role = "alert",
+      ...props
+    },
+    ref,
+  ) => {
+    const hasTitle = title !== undefined && title !== null && title !== false;
+    const isUnder = layout === "under";
+
+    const cta =
+      action ??
+      (ctaLabel !== undefined && ctaLabel !== null && ctaLabel !== false ? (
+        <CriticalBannerCta ctaLabel={ctaLabel} ctaProps={ctaProps} />
+      ) : null);
+
+    const iconNode = (
+      <span className="shrink-0 text-alerts-critical-banner-icons" aria-hidden="true">
+        {icon ?? <WarningIcon filled size={32} />}
+      </span>
+    );
+
+    const textColumn = (
+      <div className="flex min-w-0 flex-col gap-1 break-words pt-1 text-alerts-critical-banner-content">
+        {hasTitle && <div className="typography-header-heading-xs">{title}</div>}
+        <div className="typography-body-default-16px-regular">{children}</div>
+      </div>
+    );
+
+    if (isUnder) {
+      return (
+        <div
+          ref={ref}
+          role={role}
+          className={cn(
+            "flex w-full min-w-[260px] items-start gap-4 rounded-md bg-alerts-critical-banner-background p-6",
+            className,
+          )}
+          {...props}
+        >
+          {iconNode}
+          <div className="flex min-w-0 flex-1 flex-col items-start gap-6">
+            {textColumn}
+            {cta !== null && <div className="shrink-0">{cta}</div>}
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        ref={ref}
+        role={role}
+        className={cn(
+          "flex w-full min-w-[260px] items-center gap-6 rounded-md bg-alerts-critical-banner-background p-6",
+          className,
+        )}
+        {...props}
+      >
+        <div className="flex min-w-0 flex-1 items-start gap-4">
+          {iconNode}
+          {textColumn}
+        </div>
+        {cta !== null && <div className="shrink-0">{cta}</div>}
+      </div>
+    );
+  },
+);
+
+CriticalBanner.displayName = "CriticalBanner";

--- a/src/components/CriticalBanner/CriticalBanner.tsx
+++ b/src/components/CriticalBanner/CriticalBanner.tsx
@@ -23,8 +23,12 @@ export interface CriticalBannerProps extends Omit<React.HTMLAttributes<HTMLDivEl
   icon?: React.ReactNode;
   /** Label for the built-in white call-to-action button. Ignored when `action` is set. */
   ctaLabel?: React.ReactNode;
-  /** Props forwarded to the built-in call-to-action button (e.g. `onClick`, `asChild`). */
-  ctaProps?: Omit<ButtonProps, "variant" | "size" | "children">;
+  /**
+   * Props forwarded to the built-in call-to-action button (e.g. `onClick`).
+   * `asChild` is intentionally excluded — the built-in CTA renders `ctaLabel`
+   * as text; for a link or fully custom element use the `action` prop instead.
+   */
+  ctaProps?: Omit<ButtonProps, "variant" | "size" | "children" | "asChild">;
   /** Custom action node rendered in place of the built-in call-to-action button. */
   action?: React.ReactNode;
 }
@@ -36,13 +40,17 @@ function CriticalBannerCta({
   ctaLabel: React.ReactNode;
   ctaProps?: CriticalBannerProps["ctaProps"];
 }) {
+  // Only tint the label red for enabled states; when disabled, let Button keep
+  // its own `text-content-disabled` treatment instead of overriding it.
+  const isDisabled = ctaProps?.disabled ?? false;
   return (
     <Button
       variant="white"
       size="40"
       {...ctaProps}
       className={cn(
-        "text-alerts-critical-banner-background hover:text-alerts-critical-banner-background active:text-alerts-critical-banner-background",
+        !isDisabled &&
+          "text-alerts-critical-banner-background hover:text-alerts-critical-banner-background active:text-alerts-critical-banner-background",
         ctaProps?.className,
       )}
     >
@@ -90,7 +98,6 @@ export const CriticalBanner = React.forwardRef<HTMLDivElement, CriticalBannerPro
     },
     ref,
   ) => {
-    const hasTitle = title !== undefined && title !== null && title !== false;
     const isUnder = layout === "under";
 
     const cta =
@@ -107,7 +114,7 @@ export const CriticalBanner = React.forwardRef<HTMLDivElement, CriticalBannerPro
 
     const textColumn = (
       <div className="flex min-w-0 flex-col gap-1 break-words pt-1 text-alerts-critical-banner-content">
-        {hasTitle && <div className="typography-header-heading-xs">{title}</div>}
+        {title && <div className="typography-header-heading-xs">{title}</div>}
         <div className="typography-body-default-16px-regular">{children}</div>
       </div>
     );

--- a/src/components/CriticalBanner/CriticalBanner.tsx
+++ b/src/components/CriticalBanner/CriticalBanner.tsx
@@ -12,7 +12,7 @@ import { WarningIcon } from "../Icons/WarningIcon";
  */
 export type CriticalBannerLayout = "trailing" | "under";
 
-export interface CriticalBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CriticalBannerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   /** Body copy describing the blocking situation. */
   children: React.ReactNode;
   /** Placement of the call-to-action relative to the message. @default "trailing" */

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,11 @@ export type {
 } from "./components/CreatorTile/CreatorTile";
 export { CreatorTile } from "./components/CreatorTile/CreatorTile";
 export type {
+  CriticalBannerLayout,
+  CriticalBannerProps,
+} from "./components/CriticalBanner/CriticalBanner";
+export { CriticalBanner } from "./components/CriticalBanner/CriticalBanner";
+export type {
   CyclingTextProps,
   CyclingTextSizing,
 } from "./components/CyclingText/CyclingText";


### PR DESCRIPTION
## Summary

Adds a new `CriticalBanner` component — a full-width, high-priority, top-of-page banner for blocking situations (account suspension, blocking payment failures, KYC/identity verification, critical security notices). It is intentionally disruptive and should be used sparingly; non-blocking messaging should use `Alert` or the existing `Banner`.

- New component under `src/components/CriticalBanner/` (implementation, tests, stories). The existing V1 `Banner` is untouched.
- Supports both Figma CTA layouts via `layout`: `"trailing"` (action inline, vertically centred) and `"under"` (action stacked beneath the message).
- Reuses library primitives: `Button` (`variant="white"`) for the CTA and the filled `WarningIcon` (32px) for the leading icon.
- Ergonomic API: `title`, body via `children`, built-in CTA via `ctaLabel` + `ctaProps`, plus an `action` escape hatch for a fully custom CTA and an `icon` override. Renders with `role="alert"` by default (overridable).
- Exported (component + `CriticalBannerProps`, `CriticalBannerLayout`) from `src/index.ts`; demo section added to `src/App.tsx`.

## Design

- Figma node: [V2 Critical Banner](https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=17880-90686)

### Token mapping (Figma → repo theme tokens)

| Figma variable | Repo token / utility |
| --- | --- |
| `Color/Alerts/Critical Banner/Background` | `--color-alerts-critical-banner-background` → `bg-alerts-critical-banner-background` |
| `Color/Alerts/Critical Banner/Content` | `--color-alerts-critical-banner-content` → `text-alerts-critical-banner-content` |
| `Color/Alerts/Critical Banner/Icons` | `--color-alerts-critical-banner-icons` → `text-alerts-critical-banner-icons` |
| `Color/Buttons/Always White/Default` (CTA fill) | `Button variant="white"` (`bg-buttons-always-white-default`) |
| CTA label colour (`#f01932`) | `text-alerts-critical-banner-background` override on the CTA |
| `Radius/rounded-md` (16px) | `rounded-md` |
| `Spacing/Global/lg` (24px) | `p-6`, `gap-6` |
| `Spacing/Global/md` (16px) | `gap-4` |
| `Spacing/Global/2xs` (4px) | `gap-1`, `pt-1` |
| Title (`Header/Heading xs`) | `typography-header-heading-xs` |
| Body (`Body Default 16px/Regular`) | `typography-body-default-16px-regular` |

## Screenshots

**Trailing CTA**

![Trailing CTA](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-critical-banner-v2/cb-trailing-cta.png)

**Under CTA**

![Under CTA](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-critical-banner-v2/cb-under-cta.png)

**Without title**

![Without title](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-critical-banner-v2/cb-without-title.png)

**Without CTA**

![Without CTA](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-critical-banner-v2/cb-without-cta.png)

**Example — account suspended (trailing)**

![Account suspended](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-critical-banner-v2/cb-account-suspended.png)

**Example — payment failed (under, multi-line)**

![Payment failed](https://raw.githubusercontent.com/fanvue/fanv-ui/screenshots-critical-banner-v2/cb-payment-failed-under.png)

## Notes / deviations

- The Figma frame shows a fixed `741px` width; since this is a full-width top-of-page banner the root is `w-full` with `min-w-[260px]` (Figma `min-w` preserved).
- Figma's `V2 Button` is a static rectangle. This PR uses the real `Button` component (`variant="white"`, `size="40"`) with the CTA label colour overridden to the critical-banner background token, so it inherits focus rings, hover/active states, and `asChild` support.
- Default accessibility role is `role="alert"` to convey urgency; it can be overridden (e.g. `role="region"` + `aria-label`) — covered by a test.

## Test plan

- [x] `pnpm biome check --write .` then `pnpm biome check .`
- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/components/CriticalBanner` (12 passed — 6 unit incl. axe, 6 story)
- [x] `pnpm build`
- [x] Visual verification via Storybook + Playwright (screenshots above)

Closes ENG-10622

Made with [Cursor](https://cursor.com)