### PR TITLE
feat(Chart): move ChartCard and ChartSeriesToggle to V2 (DES-802)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5899,6 +5899,31 @@ function ChartsDemo() {
         </ChartLoadingOverlay>
       </ChartCard>
 
+      <h3 className="typography-body-default-16px-semibold">
+        ChartCard Metric Tiles (no children)
+      </h3>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <ChartCard
+          title="Total Earnings"
+          subtitle="$4,523"
+          tooltip="Total earnings for the selected period."
+          trendChip={{ label: "12.5%", trend: "positive" }}
+          dateInfo="Mar 1 – Mar 14"
+        />
+        <ChartCard
+          title="Subscribers"
+          subtitle="1,284"
+          trendChip={{ label: "3.1%", trend: "negative" }}
+          dateInfo="Mar 1 – Mar 14"
+        />
+        <ChartCard
+          hierarchy="secondary"
+          title="Avg. Spend"
+          subtitle="$18.40"
+          dateInfo="Mar 1 – Mar 14"
+        />
+      </div>
+
       <h3 className="typography-body-default-16px-semibold">Toggleable Multi-Series</h3>
       <ChartSeriesToggle
         items={[

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,3 +1,4 @@
+export type { CardHierarchy } from "./components/Card/Card";
 export type { ChartCardProps } from "./components/Chart/ChartCard";
 export { ChartCard } from "./components/Chart/ChartCard";
 export type { ChartCenterLabelProps } from "./components/Chart/ChartCenterLabel";

--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { Bar, BarChart } from "recharts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
 import { ChartCard } from "./ChartCard";
 import { ChartCenterLabel } from "./ChartCenterLabel";
@@ -251,6 +252,44 @@ describe("Chart", () => {
   });
 
   describe("ChartCard", () => {
+    it("renders the V2 primary card surface by default", () => {
+      const { container } = render(<ChartCard title="Revenue" />);
+      const card = container.firstElementChild;
+      expect(card).toHaveClass("rounded-lg", "border-border-primary", "bg-surface-primary");
+      expect(card).not.toHaveClass("shadow-sm");
+    });
+
+    it("applies the secondary surface when hierarchy is secondary", () => {
+      const { container } = render(<ChartCard title="Revenue" hierarchy="secondary" />);
+      expect(container.firstElementChild).toHaveClass(
+        "border-border-strong",
+        "bg-surface-secondary",
+      );
+    });
+
+    it("omits the children wrapper when no children are provided", () => {
+      const { container } = render(<ChartCard title="Revenue" subtitle="$1,234" />);
+      expect(container.querySelector(".mt-auto")).toBeNull();
+    });
+
+    it("renders the children wrapper when children are provided", () => {
+      const { container } = render(
+        <ChartCard title="Revenue" subtitle="$1,234">
+          <div>chart</div>
+        </ChartCard>,
+      );
+      expect(container.querySelector(".mt-auto")).not.toBeNull();
+    });
+
+    it("renders a 32px circular tooltip trigger with interactive states", () => {
+      render(<ChartCard title="Revenue" tooltip="Total revenue." />);
+      const trigger = screen.getByRole("button", { name: "More info" });
+      expect(trigger).toHaveClass("size-8", "rounded-full");
+      expect(trigger).toHaveClass("not-disabled:hover:bg-buttons-tertiary-hover");
+      expect(trigger).toHaveClass("not-disabled:active:bg-buttons-tertiary-hover");
+      expect(trigger).toHaveClass("focus-visible:shadow-focus-ring");
+    });
+
     it("applies flex-wrap and whitespace-nowrap to prevent trendChip truncation", () => {
       render(
         <ChartCard
@@ -266,6 +305,91 @@ describe("Chart", () => {
       expect(chip).toBeInTheDocument();
       expect(chip).toHaveClass("whitespace-nowrap");
       expect(chip.parentElement).toHaveClass("flex-wrap");
+    });
+  });
+
+  describe("ChartSeriesToggle", () => {
+    const TOGGLE_ITEMS = [
+      { key: "a", label: "Series A", color: "rgb(40, 186, 142)" },
+      { key: "b", label: "Series B", color: "rgb(79, 178, 249)" },
+    ];
+
+    it("renders each series as a chip button reflecting selection via aria-pressed", () => {
+      render(
+        <ChartSeriesToggle items={TOGGLE_ITEMS} value={new Set(["a"])} onValueChange={() => {}} />,
+      );
+      expect(screen.getByRole("button", { name: "Series A" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByRole("button", { name: "Series B" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("uses the V2 chip tokens for selected and unselected series", () => {
+      render(
+        <ChartSeriesToggle items={TOGGLE_ITEMS} value={new Set(["a"])} onValueChange={() => {}} />,
+      );
+      expect(screen.getByRole("button", { name: "Series A" })).toHaveClass(
+        "bg-buttons-chip-active",
+      );
+      expect(screen.getByRole("button", { name: "Series B" })).toHaveClass(
+        "bg-buttons-chip-default",
+        "hover:bg-buttons-chip-hover",
+      );
+    });
+
+    it("renders a colour dot per series", () => {
+      render(
+        <ChartSeriesToggle
+          items={TOGGLE_ITEMS}
+          value={new Set(["a", "b"])}
+          onValueChange={() => {}}
+        />,
+      );
+      const dot = screen
+        .getByRole("button", { name: "Series A" })
+        .querySelector<HTMLElement>(".size-2");
+      expect(dot).not.toBeNull();
+      expect(dot).toHaveStyle({ backgroundColor: "rgb(40, 186, 142)" });
+    });
+
+    it("adds a key to the Set when toggling an unselected series on", async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(
+        <ChartSeriesToggle
+          items={TOGGLE_ITEMS}
+          value={new Set(["a"])}
+          onValueChange={onValueChange}
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: "Series B" }));
+      expect(onValueChange).toHaveBeenCalledWith(new Set(["a", "b"]));
+    });
+
+    it("removes a key from the Set when toggling a selected series off", async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(
+        <ChartSeriesToggle
+          items={TOGGLE_ITEMS}
+          value={new Set(["a", "b"])}
+          onValueChange={onValueChange}
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: "Series A" }));
+      expect(onValueChange).toHaveBeenCalledWith(new Set(["b"]));
+    });
+
+    it("does not mutate the Set it was given", async () => {
+      const user = userEvent.setup();
+      const value = new Set(["a"]);
+      render(<ChartSeriesToggle items={TOGGLE_ITEMS} value={value} onValueChange={() => {}} />);
+      await user.click(screen.getByRole("button", { name: "Series B" }));
+      expect(value).toEqual(new Set(["a"]));
     });
   });
 

--- a/src/components/Chart/ChartCard.tsx
+++ b/src/components/Chart/ChartCard.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
-import { Card } from "../Card/Card";
+import { Card, type CardHierarchy } from "../Card/Card";
 import { IconButton } from "../IconButton/IconButton";
 import { InfoCircleIcon } from "../Icons/InfoCircleIcon";
 import { Skeleton } from "../Skeleton/Skeleton";
@@ -8,6 +8,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../Too
 
 /** Props for {@link ChartCard}. */
 export interface ChartCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+  /** Surface treatment of the underlying {@link Card}. @default "primary" */
+  hierarchy?: CardHierarchy;
   /** Card title text. Pass translated string for i18n. */
   title: React.ReactNode;
   /** Large subtitle value (e.g. formatted price or count). */
@@ -41,6 +43,9 @@ const TREND_CLASSES: Record<"positive" | "negative", string> = {
  * optional trend chip, date range label, info tooltip, and a loading
  * skeleton state.
  *
+ * The surface treatment comes from the underlying {@link Card} and is driven by
+ * the `hierarchy` prop.
+ *
  * @example
  * ```tsx
  * <ChartCard
@@ -58,6 +63,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
   (
     {
       className,
+      hierarchy = "primary",
       title,
       subtitle,
       tooltip,
@@ -71,7 +77,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
     ref,
   ) => {
     return (
-      <Card ref={ref} variant="outlined" noPadding className={className} {...props}>
+      <Card ref={ref} hierarchy={hierarchy} noPadding className={className} {...props}>
         <div className="flex flex-col gap-2 p-4">
           {loading ? (
             <>
@@ -91,9 +97,10 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                       <TooltipTrigger asChild>
                         <IconButton
                           variant="tertiary"
-                          size="24"
+                          size="32"
                           aria-label={tooltipAriaLabel}
-                          icon={<InfoCircleIcon className="size-4 text-content-tertiary" />}
+                          className="text-content-tertiary hover:text-content-primary focus-visible:text-content-primary active:text-content-primary"
+                          icon={<InfoCircleIcon />}
                         />
                       </TooltipTrigger>
                       <TooltipContent>{tooltip}</TooltipContent>
@@ -125,7 +132,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
               )}
             </>
           )}
-          <div className="mt-auto">{children}</div>
+          {children && <div className="mt-auto">{children}</div>}
         </div>
       </Card>
     );

--- a/src/components/Chart/ChartHelpers.stories.tsx
+++ b/src/components/Chart/ChartHelpers.stories.tsx
@@ -56,6 +56,49 @@ export const CardWithTooltip: Story = {
   ),
 };
 
+export const CardHierarchies: Story = {
+  render: () => (
+    <div className="flex w-full max-w-lg flex-col gap-4">
+      <ChartCard
+        hierarchy="primary"
+        title="Primary surface"
+        subtitle="$4,523"
+        dateInfo="Mar 1 - Mar 14"
+      >
+        <SimpleLineChart config={simpleLineConfig} />
+      </ChartCard>
+      <ChartCard
+        hierarchy="secondary"
+        title="Secondary surface"
+        subtitle="$4,523"
+        dateInfo="Mar 1 - Mar 14"
+      >
+        <SimpleLineChart config={simpleLineConfig} />
+      </ChartCard>
+    </div>
+  ),
+};
+
+export const CardMetricTilesWithoutChildren: Story = {
+  render: () => (
+    <div className="grid w-full max-w-3xl gap-4 sm:grid-cols-3">
+      <ChartCard
+        title="Total Earnings"
+        subtitle="$4,523"
+        trendChip={{ label: "12.5%", trend: "positive" }}
+        dateInfo="Mar 1 - Mar 14"
+      />
+      <ChartCard
+        title="Subscribers"
+        subtitle="1,284"
+        trendChip={{ label: "3.1%", trend: "negative" }}
+        dateInfo="Mar 1 - Mar 14"
+      />
+      <ChartCard title="Avg. Spend" subtitle="$18.40" dateInfo="Mar 1 - Mar 14" />
+    </div>
+  ),
+};
+
 export const LoadingOverlay: Story = {
   render: () => (
     <div className="w-full max-w-lg">
@@ -97,6 +140,29 @@ function SeriesToggleInteractive() {
 
 export const SeriesToggle: Story = {
   render: () => <SeriesToggleInteractive />,
+};
+
+function SeriesTogglePartialInteractive() {
+  const [visible, setVisible] = useState(new Set(["photos", "messages"]));
+  return (
+    <div className="w-full max-w-lg">
+      <ChartSeriesToggle
+        items={[
+          { key: "photos", label: "Photos", color: "var(--color-special-chart-teal)" },
+          { key: "videos", label: "Videos", color: "var(--color-special-chart-sky)" },
+          { key: "messages", label: "Messages", color: "var(--color-special-chart-orange)" },
+          { key: "tips", label: "Tips", color: "var(--color-special-chart-gray)" },
+          { key: "subs", label: "Subscriptions", color: "var(--color-special-chart-pink)" },
+        ]}
+        value={visible}
+        onValueChange={setVisible}
+      />
+    </div>
+  );
+}
+
+export const SeriesTogglePartialSelection: Story = {
+  render: () => <SeriesTogglePartialInteractive />,
 };
 
 export const PieLegendDefault: Story = {

--- a/src/components/Chart/ChartSeriesToggle.tsx
+++ b/src/components/Chart/ChartSeriesToggle.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { Chip } from "../Chip/Chip";
 
 /** A single toggleable series in a {@link ChartSeriesToggle}. */
 export interface ChartSeriesToggleItem {
@@ -22,8 +23,9 @@ export interface ChartSeriesToggleProps extends React.HTMLAttributes<HTMLDivElem
 }
 
 /**
- * Renders a grid of toggleable chips that control which series are visible
- * on a multi-series chart. Each toggle shows a color indicator dot and a label.
+ * Renders a grid of toggleable {@link Chip}s that control which series are
+ * visible on a multi-series chart. Each toggle shows a series colour dot and a
+ * label, and exposes its state through `aria-pressed`.
  *
  * @example
  * ```tsx
@@ -54,29 +56,20 @@ export const ChartSeriesToggle = React.forwardRef<HTMLDivElement, ChartSeriesTog
 
     return (
       <div ref={ref} className={cn("grid grid-cols-2 gap-2 sm:grid-cols-3", className)} {...props}>
-        {items.map((item) => {
-          const isActive = value.has(item.key);
-          return (
-            <button
-              key={item.key}
-              type="button"
-              aria-pressed={isActive}
-              className={cn(
-                "typography-description-12px-regular flex items-center gap-2 rounded-full border px-3 py-1.5 text-content-primary transition-opacity hover:opacity-100",
-                isActive
-                  ? "border-neutral-alphas-200 bg-surface-primary"
-                  : "border-transparent bg-transparent opacity-50",
-              )}
-              onClick={() => toggle(item.key)}
-            >
-              <span
-                className="size-2 shrink-0 rounded-full"
-                style={{ backgroundColor: item.color }}
-              />
-              <span>{item.label}</span>
-            </button>
-          );
-        })}
+        {items.map((item) => (
+          <Chip
+            key={item.key}
+            size="32"
+            className="justify-start"
+            selected={value.has(item.key)}
+            onClick={() => toggle(item.key)}
+            leftIcon={
+              <span className="size-2 rounded-full" style={{ backgroundColor: item.color }} />
+            }
+          >
+            {item.label}
+          </Chip>
+        ))}
       </div>
     );
   },

--- a/src/docs/ChartsV2Migration.mdx
+++ b/src/docs/ChartsV2Migration.mdx
@@ -1,0 +1,137 @@
+# Charts V2 Migration (3.21.0)
+
+`@fanvue/ui/charts` shipped `ChartCard` and `ChartSeriesToggle` on V1 surfaces and V1 chips. Release 3.21.0 moves both onto the V2 design system. There are **no API removals or renames** — every existing call site keeps compiling. The changes are visual, so read [What changes visually](#what-changes-visually) before you take a screenshot diff.
+
+## TL;DR
+
+- `ChartCard` now renders the **V2 primary card surface** instead of the legacy `variant="outlined"` surface. This affects every consumer with no code change on your side.
+- New optional `hierarchy` prop on `ChartCard` (`"primary" | "secondary"`, default `"primary"`) if you want the denser secondary surface.
+- `ChartCard` vertical padding is now symmetric when you pass no `children`.
+- The `ChartCard` info-tooltip trigger grows from 24px squared to **32px circular** with working hover / active / focus-visible states.
+- `ChartSeriesToggle` is now composed on the V2 `Chip`. The `value` / `onValueChange` `Set` contract and `aria-pressed` semantics are unchanged.
+- The chart colour ramp is **not** part of this release. `--color-special-chart-*` is untouched.
+
+---
+
+## 1. `ChartCard` surface: V1 → V2
+
+### Before
+
+```tsx
+<Card variant="outlined" noPadding>
+```
+
+`variant` is `@deprecated` on `CardProps`, and passing it at all puts `Card` into its legacy branch (`isLegacy = variant !== undefined`). That applied `rounded-md border-neutral-alphas-200 bg-surface-primary shadow-sm` and skipped the V2 hierarchy classes entirely, so every `ChartCard` consumer was pinned to the V1 look.
+
+### After
+
+```tsx
+<Card hierarchy={hierarchy} noPadding>
+```
+
+| | V1 (before) | V2 primary (now) |
+| --- | --- | --- |
+| Radius | `rounded-md` (6px) | `rounded-lg` (8px) |
+| Border | `border-neutral-alphas-200` | `border-border-primary` |
+| Background | `bg-surface-primary` | `bg-surface-primary` (unchanged) |
+| Shadow | `shadow-sm` | none |
+
+### Action required
+
+None to keep compiling. **Do re-QA any screen that renders `ChartCard`** — corner radius, border colour, and the dropped shadow are all visible. If a card sits inside another card or a dense panel and the primary surface is too heavy, opt into the secondary treatment:
+
+```tsx
+<ChartCard hierarchy="secondary" title="Avg. Spend" subtitle="$18.40" />
+```
+
+`CardHierarchy` is re-exported from `@fanvue/ui/charts` so you do not need a second import from the root entrypoint.
+
+## 2. Symmetric vertical padding on childless cards
+
+The card body is `flex flex-col gap-2 p-4`, and the children wrapper used to render unconditionally:
+
+```tsx
+<div className="mt-auto">{children}</div>
+```
+
+With `children` null — the shape metric tiles take when there is no error and no sub-value — the empty `div` still participated in `gap-2`, so the card measured 16px top and 16px + 8px bottom. The wrapper is now conditional:
+
+```tsx
+{children && <div className="mt-auto">{children}</div>}
+```
+
+### Action required
+
+None. Childless `ChartCard`s get 8px shorter. If you were compensating with a negative bottom margin or a `pb-*` override via `className`, remove it.
+
+## 3. Info-tooltip trigger
+
+| | Before | After |
+| --- | --- | --- |
+| Size | `IconButton size="24"` | `IconButton size="32"` |
+| Shape | squared (`rounded-xs`) | circular (`rounded-full`) |
+| Icon colour | pinned `text-content-tertiary` on the icon | `text-content-tertiary`, → `text-content-primary` on hover / active / focus-visible |
+| Hit target | 24×24 | 32×32 |
+
+Per the size-driven shape rule documented on `IconButtonVariant`, `24` is the only size that renders squared; every larger size is circular. The icon colour moved from the SVG onto the button so `currentColor` follows the button's interactive states instead of staying fixed.
+
+### Action required
+
+None, unless you were relying on the header row height. The header row grows from 24px to 32px on cards that pass `tooltip`.
+
+## 4. `ChartSeriesToggle` chips: V1 → V2
+
+The component used to hand-roll its pills:
+
+```tsx
+// before
+"rounded-full border px-3 py-1.5 typography-description-12px-regular"
+isActive ? "border-neutral-alphas-200 bg-surface-primary"
+         : "border-transparent bg-transparent opacity-50"
+```
+
+None of the `buttons-chip-*` tokens were involved. It is now composed on `Chip`:
+
+```tsx
+// after
+<Chip
+  size="32"
+  className="justify-start"
+  selected={value.has(item.key)}
+  onClick={() => toggle(item.key)}
+  leftIcon={<span className="size-2 rounded-full" style={{ backgroundColor: item.color }} />}
+>
+  {item.label}
+</Chip>
+```
+
+No new `Chip` API was needed. The per-series colour dot goes through `leftIcon` rather than `leftDot`, because `leftDot`'s dot is `bg-current` and cannot carry a per-series colour.
+
+### What changes visually
+
+| | Before | After |
+| --- | --- | --- |
+| Selected | white/`surface-primary` fill, 1px neutral border | `bg-buttons-chip-active` fill, `text-content-primary-inverted`, no border |
+| Unselected | transparent, `opacity-50` | `bg-buttons-chip-default`, full-opacity text |
+| Hover | opacity back to 100% | `bg-buttons-chip-hover` (unselected only) |
+| Focus | browser default outline | `shadow-focus-ring` |
+| Height | ~28px (`py-1.5`) | 32px (`Chip` `size="32"`) |
+| Type | `typography-description-12px-regular` | `typography-description-12px-semibold` |
+| Dot → label gap | 8px | 2px, matching `Chip`'s built-in `leftDot` spacing |
+
+The selected state inverts rather than lightens — that is the single biggest difference, and it is the V2 chip spec.
+
+### What does not change
+
+- `value: Set<string>` / `onValueChange: (value: Set<string>) => void`. The handler still receives a **new** `Set`; the one you passed in is never mutated.
+- `aria-pressed` on each toggle, now supplied by `Chip`'s interactive path.
+- The `grid grid-cols-2 gap-2 sm:grid-cols-3` wrapper and its `className` passthrough. `justify-start` is applied to each chip so labels stay left-aligned in their grid cell instead of centring.
+
+### Action required
+
+None. If you were targeting the old classes in tests or overrides, note that each toggle now also carries `data-testid="chip"` and `data-selected` (when selected) from `Chip`.
+
+## 5. Not in this release
+
+- **Chart colour ramp.** DES-802 also asks for a brown-led palette instead of green, and `--color-special-chart-green` is absent from `theme.css`. That is tracked separately. No `--color-special-chart-*` token was added, removed, or changed here.
+- **A rebuilt chart surface.** DES-802 also asks for the graphs themselves to be rebuilt on a new higher-level chart kit. That is an additive surface rather than a fix to the existing one, so it is scoped as its own release and gated on the colour ramp above. The Recharts-based primitives (`ChartContainer`, `ChartTooltip`, `ChartLegend`, `useChart`, …) are unchanged and stay supported.


### PR DESCRIPTION
## What

Design QA against the Manager Insights screen (DES-802) flagged four issues in the components Eden consumes from `@fanvue/ui/charts`. All four are fixed here. **No API is removed or renamed** — every existing call site keeps compiling.

### 1. `ChartCard` rendered a legacy V1 surface

`ChartCard` passed `variant="outlined"`, and passing `variant` at all puts `Card` into its legacy branch (`isLegacy = variant !== undefined`), which applies the V1 outlined classes and skips `HIERARCHY_CLASSES.primary`. `CardProps.variant` is itself `@deprecated`, so every `ChartCard` consumer was pinned to the V1 look.

Now renders `<Card hierarchy={hierarchy} noPadding>`, with a new `hierarchy?: CardHierarchy` passthrough defaulting to `"primary"`. `CardHierarchy` is re-exported from the `/charts` entrypoint so consumers don't need a second import.

| | Before | After |
| --- | --- | --- |
| Radius | `rounded-md` (6px) | `rounded-lg` (8px) |
| Border | `border-neutral-alphas-200` | `border-border-primary` |
| Shadow | `shadow-sm` | none |

### 2. Asymmetric vertical padding

The children wrapper rendered unconditionally, so a card with no children (the shape Eden's metric tiles take when there's no error and no sub-value) still contributed to the body's `gap-2` — 16px top against 16px + 8px bottom. The wrapper is now conditional. Measured in-browser at **17px top / 17px bottom** (16px + 1px border) both with and without children.

### 3. Tooltip trigger too small, states missing

`IconButton` moves from `size="24"` to `"32"`. `24` is the only size that renders squared; every larger size is circular, per the size-driven shape rule on `IconButtonVariant`. The icon colour moved off the SVG onto the button so `currentColor` tracks hover / active / focus-visible — the pinned `text-content-tertiary` was masking the states the `tertiary` variant already provides.

### 4. `ChartSeriesToggle` used hand-rolled V1 chips

The old pills used none of the `buttons-chip-*` tokens. Recomposed on the V2 `Chip` with **no new Chip API**: `selected`, `size`, `onClick` and `leftIcon` cover it, with the per-series colour dot going through `leftIcon` because `leftDot`'s dot is `bg-current`. The `Set`-based `value`/`onValueChange` contract, its non-mutation, and `aria-pressed` are all preserved. Chips are left-aligned in their grid cell so the shipped layout is unchanged.

## Verification

- 3470 unit tests pass, including 12 new ones: surface classes, both hierarchies, children wrapper present/absent, 32px circular trigger with its state classes, chip tokens for selected/unselected, dot colour, `Set` add/remove, non-mutation.
- 946 Storybook browser tests pass, including 3 new stories: `CardHierarchies`, `CardMetricTilesWithoutChildren`, `SeriesTogglePartialSelection`.
- `pnpm lint` exit 0, `pnpm typecheck` clean, `pnpm build` clean. `dist/charts.d.ts` exports `hierarchy` and `CardHierarchy`.
- Screenshots captured via Playwright against Storybook in light and dark, covering card surfaces, metric tiles, partial chip selection, and hover + focus-visible for both the tooltip trigger and an unselected chip.

## Needs design sign-off before release

1. **Every `ChartCard` changes appearance** — 6px → 8px radius, new border token, `shadow-sm` dropped. Widest blast radius.
2. **Childless cards get 8px shorter**, so Eden's metric tile row reflows slightly.
3. **Chip selected state inverts** (`bg-buttons-chip-active` + inverted text) instead of the old light fill; unselected goes from `opacity-50` to a solid `bg-buttons-chip-default`. Height 28 → 32px, type 12px-regular → 12px-semibold.
4. **Dot-to-label gap drops 8px → 2px**, matching `Chip`'s built-in `leftDot` spacing. Consistent with every other V2 chip, but it reads tight — a Chip-level spacing change would be the fix if design disagrees.
5. **Header row grows 24 → 32px** on cards that pass `tooltip`.

## Release

Minor bump, `3.20.0` → `3.21.0` (additive prop, nothing removed). Consumer migration notes are in `src/docs/ChartsV2Migration.mdx`.