### PR TITLE
fix(ChartSeriesToggle): size chips to their labels instead of stretching (DES-802)

### DIFF
--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -328,6 +328,16 @@ describe("Chart", () => {
       );
     });
 
+    it("lays chips out in a wrapping row so each sizes to its label", () => {
+      const { container } = render(
+        <ChartSeriesToggle items={TOGGLE_ITEMS} value={new Set(["a"])} onValueChange={() => {}} />,
+      );
+      const wrapper = container.firstElementChild;
+      expect(wrapper).toHaveClass("flex", "flex-wrap", "gap-2");
+      expect(wrapper?.className).not.toMatch(/\bgrid\b/);
+      expect(screen.getByRole("button", { name: "Series A" })).not.toHaveClass("justify-start");
+    });
+
     it("uses the V2 chip tokens for selected and unselected series", () => {
       render(
         <ChartSeriesToggle items={TOGGLE_ITEMS} value={new Set(["a"])} onValueChange={() => {}} />,

--- a/src/components/Chart/ChartHelpers.stories.tsx
+++ b/src/components/Chart/ChartHelpers.stories.tsx
@@ -165,6 +165,31 @@ export const SeriesTogglePartialSelection: Story = {
   render: () => <SeriesTogglePartialInteractive />,
 };
 
+function SeriesToggleManyInteractive() {
+  const [visible, setVisible] = useState(new Set(["total"]));
+  return (
+    <div className="w-full max-w-3xl">
+      <ChartSeriesToggle
+        items={[
+          { key: "total", label: "Total", color: "var(--color-special-chart-purple)" },
+          { key: "subs", label: "Subs", color: "var(--color-special-chart-sky)" },
+          { key: "messages", label: "Messages", color: "var(--color-special-chart-orange)" },
+          { key: "posts", label: "Posts", color: "var(--color-special-chart-magenta)" },
+          { key: "tips", label: "Tips", color: "var(--color-special-chart-teal)" },
+          { key: "referrals", label: "Referrals", color: "var(--color-special-chart-pink)" },
+          { key: "other", label: "Other", color: "var(--color-special-chart-gray)" },
+        ]}
+        value={visible}
+        onValueChange={setVisible}
+      />
+    </div>
+  );
+}
+
+export const SeriesToggleManySeries: Story = {
+  render: () => <SeriesToggleManyInteractive />,
+};
+
 export const PieLegendDefault: Story = {
   render: () => (
     <div className="w-full max-w-lg">

--- a/src/components/Chart/ChartSeriesToggle.tsx
+++ b/src/components/Chart/ChartSeriesToggle.tsx
@@ -23,9 +23,9 @@ export interface ChartSeriesToggleProps extends React.HTMLAttributes<HTMLDivElem
 }
 
 /**
- * Renders a grid of toggleable {@link Chip}s that control which series are
- * visible on a multi-series chart. Each toggle shows a series colour dot and a
- * label, and exposes its state through `aria-pressed`.
+ * Renders a wrapping row of toggleable {@link Chip}s that control which series
+ * are visible on a multi-series chart. Each chip sizes to its label, shows a
+ * series colour dot, and exposes its state through `aria-pressed`.
  *
  * @example
  * ```tsx
@@ -55,12 +55,11 @@ export const ChartSeriesToggle = React.forwardRef<HTMLDivElement, ChartSeriesTog
     };
 
     return (
-      <div ref={ref} className={cn("grid grid-cols-2 gap-2 sm:grid-cols-3", className)} {...props}>
+      <div ref={ref} className={cn("flex flex-wrap gap-2", className)} {...props}>
         {items.map((item) => (
           <Chip
             key={item.key}
             size="32"
-            className="justify-start"
             selected={value.has(item.key)}
             onClick={() => toggle(item.key)}
             leftIcon={

--- a/src/docs/ChartsV2Migration.mdx
+++ b/src/docs/ChartsV2Migration.mdx
@@ -125,7 +125,9 @@ The selected state inverts rather than lightens — that is the single biggest d
 
 - `value: Set<string>` / `onValueChange: (value: Set<string>) => void`. The handler still receives a **new** `Set`; the one you passed in is never mutated.
 - `aria-pressed` on each toggle, now supplied by `Chip`'s interactive path.
-- The `grid grid-cols-2 gap-2 sm:grid-cols-3` wrapper and its `className` passthrough. `justify-start` is applied to each chip so labels stay left-aligned in their grid cell instead of centring.
+- The `className` passthrough on the wrapper.
+
+> **Changed again in 3.21.1.** 3.21.0 kept the original `grid grid-cols-2 sm:grid-cols-3` wrapper. Grid items are blockified and stretch to fill their column, so each chip rendered as a full-cell-width pill. That went unnoticed under V1 because unselected chips were transparent — the stretched box was invisible. With the V2 fill it is not. The wrapper is now `flex flex-wrap gap-2`, so chips size to their labels and wrap. If you passed a `className` that assumed grid semantics (column counts, `col-span-*`), it no longer applies.
 
 ### Action required
 


### PR DESCRIPTION
## The bug

3.21.0 recomposed the series toggles on the V2 `Chip` but kept the component's original `grid grid-cols-2 sm:grid-cols-3` wrapper. Grid items are blockified and stretch to fill their column, so every chip rendered as a **full-cell-width pill** instead of hugging its label. With `justify-start` on each chip, the label sat at the far left of a very wide box.

On Manager Insights' nine-series Earnings by Type this comes out as three rows of stretched pills.

**Why 3.21.0 shipped with it:** the stretch was already there under V1 — but unselected chips were `bg-transparent border-transparent opacity-50`, so the stretched box was invisible and only the selected chip showed an outline. The V2 fill (`bg-buttons-chip-default`) exposed it. I kept the grid in #611 on the grounds that it "preserved the shipped layout"; it preserved a layout that only worked because the chips had no fill. My call, wrong one.

## The fix

```diff
-<div ref={ref} className={cn("grid grid-cols-2 gap-2 sm:grid-cols-3", className)} {...props}>
+<div ref={ref} className={cn("flex flex-wrap gap-2", className)} {...props}>
   {items.map((item) => (
     <Chip
       key={item.key}
       size="32"
-      className="justify-start"
       selected={value.has(item.key)}
```

Chips now size to their content and wrap onto as many rows as needed. `justify-start` goes away — it only existed to left-align labels inside a stretched cell. This also matches the design mock, which is a single wrapping row of hug-width chips.

## No API change

The `Set`-based `value` / `onValueChange` contract, its non-mutation, `aria-pressed`, and the wrapper's `className` passthrough are all untouched. Eden picks this up on a version bump with no code change.

One behavioural note for consumers: a `className` that assumed grid semantics (column counts, `col-span-*`) no longer applies. `src/docs/ChartsV2Migration.mdx` records this under a "Changed again in 3.21.1" callout.

## Verification

- **1100px:** all seven chips fit one row, each sized to its label.
- **420px:** wraps to two rows, `scrollWidth > clientWidth` is `false` — no horizontal overflow.
- Light and dark both captured.
- New story `SeriesToggleManySeries` (seven series) covers the reported density.
- New test asserts the wrapper carries `flex flex-wrap gap-2`, does not match `/\bgrid\b/`, and that chips no longer carry `justify-start`.
- `pnpm test` → **4418 tests / 176 files, all passing**. `pnpm lint` exit 0, `pnpm typecheck` exit 0.

Chromatic will diff every `ChartSeriesToggle` story — expected, that's the point of the change.

## Release

Patch, `3.21.0` → **3.21.1**, via release-please on merge.

## Still open, not in this PR

The unselected chip treatment itself. The design mock shows white-with-a-border; we render a grey fill (`bg-buttons-chip-default` = `#1515151a`). There is no outlined chip variant in `Chip` today, so that needs a design-system decision rather than a chart-level one. The 2px dot-to-label gap (inherited from `Chip`'s `leftDot` spacing) is unchanged here too.