### PR TITLE
feat(ChartCard): move insight cards to the V2 Insight Card spec

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5873,7 +5873,7 @@ function ChartsDemo() {
       <ChartCard
         title="Total Earnings"
         subtitle="$4,523"
-        trendChip={{ label: "12.5%", trend: "positive" }}
+        trendChip={{ label: "12.5% vs prev", trend: "positive" }}
         dateInfo="Mar 1 – Mar 14"
       >
         <ChartContainer config={simpleLineConfig} className="h-48 w-full">
@@ -5907,13 +5907,13 @@ function ChartsDemo() {
           title="Total Earnings"
           subtitle="$4,523"
           tooltip="Total earnings for the selected period."
-          trendChip={{ label: "12.5%", trend: "positive" }}
+          trendChip={{ label: "12.5% vs prev", trend: "positive" }}
           dateInfo="Mar 1 – Mar 14"
         />
         <ChartCard
           title="Subscribers"
           subtitle="1,284"
-          trendChip={{ label: "3.1%", trend: "negative" }}
+          trendChip={{ label: "3.1% vs prev", trend: "negative" }}
           dateInfo="Mar 1 – Mar 14"
         />
         <ChartCard

--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -252,11 +252,45 @@ describe("Chart", () => {
   });
 
   describe("ChartCard", () => {
-    it("renders the V2 primary card surface by default", () => {
+    it("renders the V2 Insight Card surface by default", () => {
       const { container } = render(<ChartCard title="Revenue" />);
       const card = container.firstElementChild;
-      expect(card).toHaveClass("rounded-lg", "border-border-primary", "bg-surface-primary");
+      expect(card).toHaveClass("rounded-sm", "border-border-strong", "bg-background-primary");
+      expect(card).not.toHaveClass("rounded-lg", "border-border-primary", "bg-surface-primary");
       expect(card).not.toHaveClass("shadow-sm");
+    });
+
+    it("renders the title in the secondary content colour at regular weight", () => {
+      render(<ChartCard title="Revenue" />);
+      const title = screen.getByText("Revenue");
+      expect(title).toHaveClass("typography-body-small-14px-regular", "text-content-secondary");
+    });
+
+    it("renders the trend as coloured text with a directional arrow, not a filled chip", () => {
+      const { container } = render(
+        <ChartCard
+          title="ARPU"
+          subtitle="$135.84"
+          trendChip={{ label: "1.3% vs prev", trend: "negative" }}
+        />,
+      );
+      const label = screen.getByText("1.3% vs prev");
+      const trend = label.parentElement;
+      expect(trend).toHaveClass("text-error-content");
+      expect(trend).not.toHaveClass("bg-error-surface", "rounded-full");
+      expect(container.querySelector("svg.rotate-90")).not.toBeNull();
+    });
+
+    it("points the trend arrow up and green for a positive trend", () => {
+      const { container } = render(
+        <ChartCard
+          title="New Fans"
+          subtitle="1,389"
+          trendChip={{ label: "13.1% vs prev", trend: "positive" }}
+        />,
+      );
+      expect(screen.getByText("13.1% vs prev").parentElement).toHaveClass("text-success-content");
+      expect(container.querySelector("svg.rotate-90")).toBeNull();
     });
 
     it("applies the secondary surface when hierarchy is secondary", () => {
@@ -301,10 +335,10 @@ describe("Chart", () => {
           <div>chart</div>
         </ChartCard>,
       );
-      const chip = screen.getByText("$455.68 vs Mar");
-      expect(chip).toBeInTheDocument();
-      expect(chip).toHaveClass("whitespace-nowrap");
-      expect(chip.parentElement).toHaveClass("flex-wrap");
+      const label = screen.getByText("$455.68 vs Mar");
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveClass("whitespace-nowrap");
+      expect(label.closest(".flex-wrap")).not.toBeNull();
     });
   });
 

--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -315,6 +315,14 @@ describe("Chart", () => {
       expect(container.querySelector(".mt-auto")).not.toBeNull();
     });
 
+    it("renders the outlined info glyph rather than the filled disc", () => {
+      render(<ChartCard title="Revenue" tooltip="Total revenue." />);
+      const svg = screen.getByRole("button", { name: "More info" }).querySelector("svg");
+      expect(svg).toHaveAttribute("viewBox", "0 0 16 16");
+      expect(svg?.querySelector("path[stroke='currentColor']")).not.toBeNull();
+      expect(svg?.querySelector("g.opacity-100")).not.toBeNull();
+    });
+
     it("renders a 32px circular tooltip trigger with interactive states", () => {
       render(<ChartCard title="Revenue" tooltip="Total revenue." />);
       const trigger = screen.getByRole("button", { name: "More info" });

--- a/src/components/Chart/ChartCard.tsx
+++ b/src/components/Chart/ChartCard.tsx
@@ -3,7 +3,7 @@ import { cn } from "../../utils/cn";
 import { Card, type CardHierarchy } from "../Card/Card";
 import { IconButton } from "../IconButton/IconButton";
 import { ArrowUpRightIcon } from "../Icons/ArrowUpRightIcon";
-import { InfoCircleIcon } from "../Icons/InfoCircleIcon";
+import { InfoIcon } from "../Icons/InfoIcon";
 import { Skeleton } from "../Skeleton/Skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../Tooltip/Tooltip";
 
@@ -119,7 +119,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                           size="32"
                           aria-label={tooltipAriaLabel}
                           className="text-icons-primary hover:text-content-primary focus-visible:text-content-primary active:text-content-primary"
-                          icon={<InfoCircleIcon />}
+                          icon={<InfoIcon size={16} />}
                         />
                       </TooltipTrigger>
                       <TooltipContent>{tooltip}</TooltipContent>

--- a/src/components/Chart/ChartCard.tsx
+++ b/src/components/Chart/ChartCard.tsx
@@ -2,13 +2,18 @@ import * as React from "react";
 import { cn } from "../../utils/cn";
 import { Card, type CardHierarchy } from "../Card/Card";
 import { IconButton } from "../IconButton/IconButton";
+import { ArrowUpRightIcon } from "../Icons/ArrowUpRightIcon";
 import { InfoCircleIcon } from "../Icons/InfoCircleIcon";
 import { Skeleton } from "../Skeleton/Skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../Tooltip/Tooltip";
 
 /** Props for {@link ChartCard}. */
 export interface ChartCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
-  /** Surface treatment of the underlying {@link Card}. @default "primary" */
+  /**
+   * Surface treatment. `primary` follows the V2 Insight Card spec (white fill,
+   * strong border, 12px radius); `secondary` uses the {@link Card} secondary
+   * surface. @default "primary"
+   */
   hierarchy?: CardHierarchy;
   /** Card title text. Pass translated string for i18n. */
   title: React.ReactNode;
@@ -20,11 +25,14 @@ export interface ChartCardProps extends Omit<React.HTMLAttributes<HTMLDivElement
   tooltipAriaLabel?: string;
   /** Date range or period label shown below the subtitle. */
   dateInfo?: React.ReactNode;
-  /** Trend indicator chip config. Only rendered when {@link subtitle} is also provided. */
+  /**
+   * Trend indicator config. Rendered as a coloured directional arrow and label
+   * beside the subtitle, so it is only shown when {@link subtitle} is provided.
+   */
   trendChip?: {
-    /** Display label (e.g. "12.5%"). */
+    /** Display label (e.g. "12.5% vs prev"). */
     label: React.ReactNode;
-    /** Whether the trend is positive (green) or negative (red). */
+    /** Whether the trend is positive (green, arrow up) or negative (red, arrow down). */
     trend: "positive" | "negative";
   };
   /** Show loading skeleton instead of content. @default false */
@@ -34,17 +42,22 @@ export interface ChartCardProps extends Omit<React.HTMLAttributes<HTMLDivElement
 }
 
 const TREND_CLASSES: Record<"positive" | "negative", string> = {
-  positive: "bg-success-surface text-success-content",
-  negative: "bg-error-surface text-error-content",
+  positive: "text-success-content",
+  negative: "text-error-content",
+};
+
+const SURFACE_CLASSES: Partial<Record<CardHierarchy, string>> = {
+  primary: "rounded-sm border-border-strong bg-background-primary",
 };
 
 /**
  * Wraps any chart with a structured header containing title, subtitle,
- * optional trend chip, date range label, info tooltip, and a loading
+ * optional trend indicator, date range label, info tooltip, and a loading
  * skeleton state.
  *
- * The surface treatment comes from the underlying {@link Card} and is driven by
- * the `hierarchy` prop.
+ * At `hierarchy="primary"` this implements the V2 Insight Card surface, which
+ * differs from {@link Card}'s own primary hierarchy: a white fill, the strong
+ * border, and a 12px radius.
  *
  * @example
  * ```tsx
@@ -77,7 +90,13 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
     ref,
   ) => {
     return (
-      <Card ref={ref} hierarchy={hierarchy} noPadding className={className} {...props}>
+      <Card
+        ref={ref}
+        hierarchy={hierarchy}
+        noPadding
+        className={cn(SURFACE_CLASSES[hierarchy], className)}
+        {...props}
+      >
         <div className="flex flex-col gap-2 p-4">
           {loading ? (
             <>
@@ -87,8 +106,8 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
             </>
           ) : (
             <>
-              <div className="flex items-center gap-1.5">
-                <span className="typography-body-small-14px-semibold text-content-primary">
+              <div className="flex items-center gap-1">
+                <span className="typography-body-small-14px-regular text-content-secondary">
                   {title}
                 </span>
                 {tooltip && (
@@ -99,7 +118,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                           variant="tertiary"
                           size="32"
                           aria-label={tooltipAriaLabel}
-                          className="text-content-tertiary hover:text-content-primary focus-visible:text-content-primary active:text-content-primary"
+                          className="text-icons-primary hover:text-content-primary focus-visible:text-content-primary active:text-content-primary"
                           icon={<InfoCircleIcon />}
                         />
                       </TooltipTrigger>
@@ -109,18 +128,26 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                 )}
               </div>
               {subtitle && (
-                <div className="flex flex-wrap items-center gap-2">
+                <div className="flex flex-wrap items-end gap-2">
                   <span className="typography-header-heading-sm text-content-primary">
                     {subtitle}
                   </span>
                   {trendChip && (
                     <span
                       className={cn(
-                        "typography-description-12px-semibold whitespace-nowrap rounded-full px-2 py-0.5",
+                        "flex items-center gap-1 pb-px",
                         TREND_CLASSES[trendChip.trend],
                       )}
                     >
-                      {trendChip.label}
+                      <ArrowUpRightIcon
+                        className={cn(
+                          "size-4 shrink-0",
+                          trendChip.trend === "negative" && "rotate-90",
+                        )}
+                      />
+                      <span className="typography-body-small-14px-regular whitespace-nowrap">
+                        {trendChip.label}
+                      </span>
                     </span>
                   )}
                 </div>

--- a/src/components/Chart/ChartHelpers.stories.tsx
+++ b/src/components/Chart/ChartHelpers.stories.tsx
@@ -22,7 +22,7 @@ export const CardDefault: Story = {
       <ChartCard
         title="Total Earnings"
         subtitle="$4,523"
-        trendChip={{ label: "12.5%", trend: "positive" }}
+        trendChip={{ label: "12.5% vs prev", trend: "positive" }}
         dateInfo="Mar 1 - Mar 14"
       >
         <SimpleLineChart config={simpleLineConfig} />
@@ -85,13 +85,13 @@ export const CardMetricTilesWithoutChildren: Story = {
       <ChartCard
         title="Total Earnings"
         subtitle="$4,523"
-        trendChip={{ label: "12.5%", trend: "positive" }}
+        trendChip={{ label: "12.5% vs prev", trend: "positive" }}
         dateInfo="Mar 1 - Mar 14"
       />
       <ChartCard
         title="Subscribers"
         subtitle="1,284"
-        trendChip={{ label: "3.1%", trend: "negative" }}
+        trendChip={{ label: "3.1% vs prev", trend: "negative" }}
         dateInfo="Mar 1 - Mar 14"
       />
       <ChartCard title="Avg. Spend" subtitle="$18.40" dateInfo="Mar 1 - Mar 14" />

--- a/src/docs/ChartsV2Migration.mdx
+++ b/src/docs/ChartsV2Migration.mdx
@@ -146,7 +146,7 @@ Every token below already existed in `theme.css` — `ChartCard` was pointing at
 | Radius | `rounded-lg` (24px) | `rounded-sm` (12px) |
 | Title | 14px semibold, `content-primary` | 14px **regular**, `content-secondary` |
 | Title → icon gap | `gap-1.5` (6px) | `gap-1` (4px) |
-| Info icon colour | `content-tertiary` | `icons-primary` |
+| Info icon | filled `InfoCircleIcon`, `content-tertiary` | **outlined** `InfoIcon` at 16px, `icons-primary` |
 | Trend | filled pill, `bg-success-surface` / `bg-error-surface`, 12px semibold | **coloured text + directional arrow**, 14px regular, `success-content` / `error-content` |
 | Subtitle row | `items-center` | `items-end` |
 

--- a/src/docs/ChartsV2Migration.mdx
+++ b/src/docs/ChartsV2Migration.mdx
@@ -133,7 +133,44 @@ The selected state inverts rather than lightens — that is the single biggest d
 
 None. If you were targeting the old classes in tests or overrides, note that each toggle now also carries `data-testid="chip"` and `data-selected` (when selected) from `Chip`.
 
-## 5. Not in this release
+## 5. `ChartCard` matches the V2 Insight Card (3.22.0)
+
+3.21.0 moved `ChartCard` off the legacy `variant="outlined"` surface and onto `Card`'s own `hierarchy="primary"`. That was the wrong target. The design system has a dedicated **V2 Insight Card** component, and its tokens differ from `Card`'s primary hierarchy. `ChartCard` now implements the Insight Card spec directly.
+
+Every token below already existed in `theme.css` — `ChartCard` was pointing at the wrong ones. No token was added or changed.
+
+| | 3.21.0 | 3.22.0 (V2 Insight Card) |
+| --- | --- | --- |
+| Fill | `bg-surface-primary` `#fafafa` | `bg-background-primary` `#ffffff` |
+| Border | `border-border-primary` `#f0f0f0` | `border-border-strong` `#d4d4d4` |
+| Radius | `rounded-lg` (24px) | `rounded-sm` (12px) |
+| Title | 14px semibold, `content-primary` | 14px **regular**, `content-secondary` |
+| Title → icon gap | `gap-1.5` (6px) | `gap-1` (4px) |
+| Info icon colour | `content-tertiary` | `icons-primary` |
+| Trend | filled pill, `bg-success-surface` / `bg-error-surface`, 12px semibold | **coloured text + directional arrow**, 14px regular, `success-content` / `error-content` |
+| Subtitle row | `items-center` | `items-end` |
+
+> **Note on the radius.** `--radius-*` is declared in `@theme`, so this project's `rounded-*` scale is not Tailwind's default: `rounded-sm` is 12px, `rounded-md` 16px, `rounded-lg` 24px. The 3.21.0 release notes described this as an 8px radius; it was 24px.
+
+### `trendChip` renders differently
+
+The prop shape is unchanged — `{ label, trend }` still works, so no code change is needed:
+
+```tsx
+<ChartCard title="ARPU" subtitle="$135.84" trendChip={{ label: "1.3% vs prev", trend: "negative" }} />
+```
+
+It is no longer a chip. `positive` renders an up-right arrow in `success-content`; `negative` renders the same glyph rotated to point down-right, in `error-content`. The prop keeps its name for backwards compatibility. Pass the full label including any suffix (e.g. `"1.3% vs prev"`), since there is no longer a pill to keep short.
+
+### `hierarchy` still works
+
+`primary` is the Insight Card surface above. `secondary` continues to use `Card`'s secondary hierarchy, unchanged.
+
+### Known divergence
+
+`Card`'s own `HIERARCHY_CLASSES.primary` still renders `#fafafa` / `border-primary` / 24px, which does not match the V2 Insight Card. That is deliberate here — reconciling `Card` affects every consumer in the library and is tracked separately. `ChartCard` overrides the three properties it needs via `className`, so `Card` is untouched.
+
+## 6. Not in this release
 
 - **Chart colour ramp.** DES-802 also asks for a brown-led palette instead of green, and `--color-special-chart-green` is absent from `theme.css`. That is tracked separately. No `--color-special-chart-*` token was added, removed, or changed here.
 - **A rebuilt chart surface.** DES-802 also asks for the graphs themselves to be rebuilt on a new higher-level chart kit. That is an additive surface rather than a fix to the existing one, so it is scoped as its own release and gated on the colour ramp above. The Recharts-based primitives (`ChartContainer`, `ChartTooltip`, `ChartLegend`, `useChart`, …) are unchanged and stay supported.


### PR DESCRIPTION
## What this fixes

3.21.0 (#611) took `ChartCard` off the legacy `variant="outlined"` surface and onto `Card`'s own `hierarchy="primary"`. **That was the wrong target.** The design library has a dedicated **V2 Insight Card** component whose tokens differ from `Card`'s primary hierarchy — and it's what DES-802 meant by *"Insight card is still the v1 component. Replace with v2."*

I implemented #611 from the code rather than the design source, so it approximated the Insight Card with a generic V2 `Card`. This reads the real spec and matches it.

Source: *Creator - Management — Teams*, `↳ Handover (17/06/26)`, Desktop → Light Mode, node `7393:62158` (`V2 Insight Card`), via Figma MCP.

## Token mapping

Every token below **already existed in `theme.css`** and matches its Figma variable exactly. `ChartCard` was pointing at the wrong ones. **No token added, removed, or changed.**

| | 3.21.0 | This PR | Figma variable |
| --- | --- | --- | --- |
| Fill | `bg-surface-primary` `#fafafa` | `bg-background-primary` `#ffffff` | `Color/Background/Primary` |
| Border | `border-border-primary` `#f0f0f0` | `border-border-strong` `#d4d4d4` | `Color/Border/Strong` |
| Radius | `rounded-lg` **24px** | `rounded-sm` **12px** | `Radius/rounded-sm` |
| Padding | `p-4` 16px | unchanged | `Spacing/Global/md` |
| Title | 14px semibold, `content-primary` | 14px **regular**, `content-secondary` `#404040` | `Body Small 14px/Regular` + `Color/Content/Secondary` |
| Title → icon gap | `gap-1.5` 6px | `gap-1` 4px | `Spacing/Global/2xs` |
| Info icon | filled `InfoCircleIcon`, `content-tertiary` | **outlined** `InfoIcon` at 16px, `icons-primary` `#262626` | `Color/Icons/Primary` |
| Trend | filled pill, `bg-*-surface`, 12px semibold | **coloured text + arrow**, 14px regular | `Color/Success/Content` `#0b8e29` / `Color/Error/Content` `#f01932` |
| Subtitle row | `items-center` | `items-end` | — |

### Correction on the radius

`--radius-*` is declared inside `@theme`, so this project's `rounded-*` scale is **not** Tailwind's default — `rounded-sm` is 12px, `rounded-md` 16px, `rounded-lg` 24px. I described #611's change as "6px → 8px" in that PR; it was actually **16px → 24px**, i.e. it moved away from the 12px spec and ended up double it. The migration guide now records this.

## `trendChip` renders differently, same API

The prop keeps its `{ label, trend }` shape, so **no consumer code changes**:

```tsx
<ChartCard title="ARPU" subtitle="$135.84" trendChip={{ label: "1.3% vs prev", trend: "negative" }} />
```

It's no longer a chip. `positive` → up-right arrow in `success-content`; `negative` → the same `ArrowUpRightIcon` rotated 90° to point down-right, in `error-content`. Name retained for backwards compatibility. Demo labels now carry a `vs prev` suffix, since there's no pill to keep short.

## `Card` is deliberately untouched

`Card`'s `HIERARCHY_CLASSES.primary` still renders `#fafafa` / `border-primary` / 24px, which does **not** match the V2 Insight Card. Reconciling that affects every `Card` consumer in the library and needs its own design review — tracked separately. `ChartCard` overrides only the three properties it needs via `className`, and `hierarchy="secondary"` still defers to `Card` unchanged.

## Verification

Computed styles read from the live story, each matching its Figma variable:

Light mode:

```
background  rgb(255, 255, 255)   #ffffff
border      rgb(212, 212, 212)   #d4d4d4
radius      12px
padding     16px
title       rgb(64, 64, 64), weight 400, 14px
trend       rgb(11, 142, 41)     #0b8e29
```

Dark mode, against the Figma dark-mode variables on the same component:

```
background  rgb(21, 21, 21)      #151515
border      rgb(64, 64, 64)      #404040
title       rgb(212, 212, 212)   #d4d4d4
value       rgb(255, 255, 255)   #ffffff
trend       rgb(73, 242, 100)    #49f264
```

Info glyph: `viewBox="0 0 16 16"`, 16px rendered, one stroked path, filled layer at `opacity-0`, colour `rgb(38, 38, 38)`.

- Light and dark captured.
- 4 new tests: Insight Card surface (and explicit assertions it is *not* the old classes), title weight/colour, and both trend directions including arrow rotation.
- `pnpm test` → **4421 tests / 176 files passing**. `pnpm lint` exit 0, `pnpm typecheck` exit 0.

Chromatic will diff every `ChartCard` story again — expected.

## Release

Additive minor, `3.21.1` -> **3.22.0**, via release-please on merge. Eden picks it up with a version bump and no code change.
