### PR TITLE
feat(CreatorTile): add banner ratio, and AI-disclosure badge to user components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5439,7 +5439,7 @@ function CreatorTileDemo() {
 
       <h3 className="typography-body-default-16px-semibold mt-4">Aspect ratio</h3>
       <div className="flex flex-wrap items-start gap-4">
-        {(["tall", "medium", "short", "wide"] as const).map((aspectRatio) => (
+        {(["tall", "medium", "short", "banner"] as const).map((aspectRatio) => (
           <div key={aspectRatio} className="flex w-[280px] flex-col gap-2">
             <CreatorTile
               background={<img src={sampleImage} alt="" loading="lazy" />}
@@ -5465,7 +5465,7 @@ function CreatorTileDemo() {
         ))}
       </div>
 
-      <h3 className="typography-body-default-16px-semibold mt-4">Wide banner with badges</h3>
+      <h3 className="typography-body-default-16px-semibold mt-4">Banner ratio with badges</h3>
       <div className="w-[400px]">
         <CreatorTile
           background={<img src={sampleImage} alt="" loading="lazy" />}
@@ -5481,7 +5481,7 @@ function CreatorTileDemo() {
               View Profile
             </Button>
           }
-          aspectRatio="wide"
+          aspectRatio="banner"
           className="rounded-lg"
         />
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -262,6 +262,7 @@ import {
   TwitterIcon,
   UploadIcon,
   UserCircleIcon,
+  UserDisplayName,
   UserIcon,
   UsersIcon,
   VideoIcon,
@@ -5438,7 +5439,7 @@ function CreatorTileDemo() {
 
       <h3 className="typography-body-default-16px-semibold mt-4">Aspect ratio</h3>
       <div className="flex flex-wrap items-start gap-4">
-        {(["tall", "medium", "short"] as const).map((aspectRatio) => (
+        {(["tall", "medium", "short", "wide"] as const).map((aspectRatio) => (
           <div key={aspectRatio} className="flex w-[280px] flex-col gap-2">
             <CreatorTile
               background={<img src={sampleImage} alt="" loading="lazy" />}
@@ -5462,6 +5463,27 @@ function CreatorTileDemo() {
             </p>
           </div>
         ))}
+      </div>
+
+      <h3 className="typography-body-default-16px-semibold mt-4">Wide banner with badges</h3>
+      <div className="w-[400px]">
+        <CreatorTile
+          background={<img src={sampleImage} alt="" loading="lazy" />}
+          avatar={{ src: sampleAvatar, alt: "Jane Doe", fallback: "JD" }}
+          name={
+            <UserDisplayName verified aiDisclosure className="text-white">
+              Jane Doe
+            </UserDisplayName>
+          }
+          tagline="@jane_doe"
+          action={
+            <Button variant="white" size="32" className="rounded-full">
+              View Profile
+            </Button>
+          }
+          aspectRatio="wide"
+          className="rounded-lg"
+        />
       </div>
     </div>
   );

--- a/src/components/CreatorTile/CreatorTile.stories.tsx
+++ b/src/components/CreatorTile/CreatorTile.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "../Button/Button";
+import { UserDisplayName } from "../UserDisplayName/UserDisplayName";
 import { CreatorTile } from "./CreatorTile";
 
 const SAMPLE_BACKGROUND =
@@ -21,7 +22,7 @@ const meta = {
   argTypes: {
     aspectRatio: {
       control: "select",
-      options: ["tall", "medium", "short"],
+      options: ["tall", "medium", "short", "wide"],
     },
   },
   args: {
@@ -74,10 +75,38 @@ export const WithoutAction: Story = {
   ),
 };
 
+/**
+ * The `wide` ratio is a slim banner. Compose {@link UserDisplayName} into `name`
+ * when the creator needs verified or AI-disclosure badges beside it.
+ */
+export const Wide: Story = {
+  args: { aspectRatio: "wide" },
+  render: (args) => (
+    <div className="w-100">
+      <CreatorTile
+        {...args}
+        className="rounded-lg"
+        name={
+          <UserDisplayName verified aiDisclosure className="text-white">
+            Jane Doe
+          </UserDisplayName>
+        }
+        tagline="@jane_doe"
+        avatar={{ src: SAMPLE_AVATAR, alt: "Jane Doe", fallback: "JD" }}
+        action={
+          <Button variant="white" size="32" className="rounded-full">
+            View Profile
+          </Button>
+        }
+      />
+    </div>
+  ),
+};
+
 export const AspectRatios: Story = {
   render: (args) => (
     <div className="flex flex-wrap items-start gap-4">
-      {(["tall", "medium", "short"] as const).map((aspectRatio) => (
+      {(["tall", "medium", "short", "wide"] as const).map((aspectRatio) => (
         <div key={aspectRatio} className="flex w-[280px] flex-col gap-2">
           <CreatorTile {...args} aspectRatio={aspectRatio} className="rounded-lg" />
           <p className="typography-description-12px-regular text-content-secondary">

--- a/src/components/CreatorTile/CreatorTile.stories.tsx
+++ b/src/components/CreatorTile/CreatorTile.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
   argTypes: {
     aspectRatio: {
       control: "select",
-      options: ["tall", "medium", "short", "wide"],
+      options: ["tall", "medium", "short", "banner"],
     },
   },
   args: {
@@ -76,11 +76,11 @@ export const WithoutAction: Story = {
 };
 
 /**
- * The `wide` ratio is a slim banner. Compose {@link UserDisplayName} into `name`
- * when the creator needs verified or AI-disclosure badges beside it.
+ * The `banner` ratio is the slimmest preset. Compose {@link UserDisplayName} into
+ * `name` when the creator needs verified or AI-disclosure badges beside it.
  */
-export const Wide: Story = {
-  args: { aspectRatio: "wide" },
+export const Banner: Story = {
+  args: { aspectRatio: "banner" },
   render: (args) => (
     <div className="w-100">
       <CreatorTile
@@ -106,7 +106,7 @@ export const Wide: Story = {
 export const AspectRatios: Story = {
   render: (args) => (
     <div className="flex flex-wrap items-start gap-4">
-      {(["tall", "medium", "short", "wide"] as const).map((aspectRatio) => (
+      {(["tall", "medium", "short", "banner"] as const).map((aspectRatio) => (
         <div key={aspectRatio} className="flex w-[280px] flex-col gap-2">
           <CreatorTile {...args} aspectRatio={aspectRatio} className="rounded-lg" />
           <p className="typography-description-12px-regular text-content-secondary">

--- a/src/components/CreatorTile/CreatorTile.test.tsx
+++ b/src/components/CreatorTile/CreatorTile.test.tsx
@@ -45,7 +45,11 @@ describe("CreatorTile", () => {
       render(
         <CreatorTile
           {...baseProps}
-          avatar={{ fallback: "AL", className: "custom-avatar", onlineIndicator: true }}
+          avatar={{
+            fallback: "AL",
+            className: "custom-avatar",
+            onlineIndicator: true,
+          }}
         />,
       );
       const avatar = screen.getByTestId("avatar");
@@ -94,6 +98,7 @@ describe("CreatorTile", () => {
       ["tall", "aspect-5/4"],
       ["medium", "aspect-3/2"],
       ["short", "aspect-9/5"],
+      ["banner", "aspect-5/2"],
     ] as const)("applies %s ratio class", (aspectRatio, expectedClass) => {
       render(<CreatorTile {...baseProps} data-testid="tile" aspectRatio={aspectRatio} />);
       expect(screen.getByTestId("tile")).toHaveClass(expectedClass);

--- a/src/components/CreatorTile/CreatorTile.tsx
+++ b/src/components/CreatorTile/CreatorTile.tsx
@@ -3,13 +3,13 @@ import { cn } from "../../utils/cn";
 import { Avatar } from "../Avatar/Avatar";
 
 /** Width-to-height ratio preset for the tile. */
-export type CreatorTileAspectRatio = "tall" | "medium" | "short" | "wide";
+export type CreatorTileAspectRatio = "tall" | "medium" | "short" | "banner";
 
 const ASPECT_RATIO_CLASSES: Record<CreatorTileAspectRatio, string> = {
   tall: "aspect-5/4",
   medium: "aspect-3/2",
   short: "aspect-9/5",
-  wide: "aspect-5/2",
+  banner: "aspect-5/2",
 };
 
 export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -32,7 +32,12 @@ export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
    * - `tall` – 5:4, closest to square
    * - `medium` – 3:2 landscape
    * - `short` – 9:5 landscape
-   * - `wide` – 5:2, a slim banner
+   * - `banner` – 5:2, the slimmest preset
+   *
+   * The profile row is a fixed ~74px tall, so `banner` needs at least 185px of
+   * width before the ratio makes the tile shorter than its own row and the top
+   * of the row is clipped. The taller presets reach that floor at widths too
+   * narrow to be practical.
    *
    * @default "medium"
    */

--- a/src/components/CreatorTile/CreatorTile.tsx
+++ b/src/components/CreatorTile/CreatorTile.tsx
@@ -3,12 +3,13 @@ import { cn } from "../../utils/cn";
 import { Avatar } from "../Avatar/Avatar";
 
 /** Width-to-height ratio preset for the tile. */
-export type CreatorTileAspectRatio = "tall" | "medium" | "short";
+export type CreatorTileAspectRatio = "tall" | "medium" | "short" | "wide";
 
 const ASPECT_RATIO_CLASSES: Record<CreatorTileAspectRatio, string> = {
   tall: "aspect-5/4",
   medium: "aspect-3/2",
   short: "aspect-9/5",
+  wide: "aspect-5/2",
 };
 
 export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -28,9 +29,10 @@ export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Width-to-height ratio preset.
    *
-   * - `tall` – 1:2 narrow portrait
-   * - `medium` – 361:200 landscape banner (default)
-   * - `short` – 4:5 closer to square
+   * - `tall` – 5:4, closest to square
+   * - `medium` – 3:2 landscape
+   * - `short` – 9:5 landscape
+   * - `wide` – 5:2, a slim banner
    *
    * @default "medium"
    */

--- a/src/components/UserDisplayName/UserDisplayName.stories.tsx
+++ b/src/components/UserDisplayName/UserDisplayName.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
+    aiDisclosure: { control: "boolean" },
     ambassador: { control: "boolean" },
     verified: { control: "boolean" },
     showOnlineStatus: { control: "boolean" },
@@ -60,8 +61,41 @@ export const AmbassadorTakesPrecedence: Story = {
   args: { ambassador: true, verified: true },
 };
 
+export const AiDisclosure: Story = {
+  name: "AI disclosure",
+  args: { aiDisclosure: true },
+};
+
+/**
+ * AI disclosure describes how an account is operated rather than ranking it, so
+ * it renders alongside whichever status badge is shown instead of replacing it.
+ */
+export const AiDisclosureWithStatusBadges: Story = {
+  name: "AI disclosure + status badges",
+  render: () => (
+    <div className="flex w-72 flex-col gap-4">
+      <UserDisplayName className="typography-body-small-14px-semibold" aiDisclosure verified>
+        Jane Doe
+      </UserDisplayName>
+      <UserDisplayName className="typography-body-small-14px-semibold" aiDisclosure ambassador>
+        Jane Doe
+      </UserDisplayName>
+      <UserDisplayName
+        className="typography-body-small-14px-semibold"
+        aiDisclosure
+        verified
+        showOnlineStatus
+      >
+        Jane Doe
+      </UserDisplayName>
+    </div>
+  ),
+};
+
 export const Truncated: Story = {
-  args: { children: "Aitana Lopez de la Vega Hernández Rodríguez del Castillo" },
+  args: {
+    children: "Aitana Lopez de la Vega Hernández Rodríguez del Castillo",
+  },
 };
 
 const LONG_NAME = "Aitana Lopez de la Vega Hernández Rodríguez del Castillo";

--- a/src/components/UserDisplayName/UserDisplayName.test.tsx
+++ b/src/components/UserDisplayName/UserDisplayName.test.tsx
@@ -103,6 +103,40 @@ describe("UserDisplayName", () => {
       render(<UserDisplayName>Aitana</UserDisplayName>);
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
+
+    it("renders an AI-disclosure badge with an accessible label", () => {
+      render(<UserDisplayName aiDisclosure>Aitana</UserDisplayName>);
+      expect(screen.getByRole("img", { name: "AI creator" })).toBeInTheDocument();
+    });
+
+    it("supports a custom AI-disclosure label", () => {
+      render(
+        <UserDisplayName aiDisclosure aiDisclosureLabel="Operated with AI">
+          Aitana
+        </UserDisplayName>,
+      );
+      expect(screen.getByRole("img", { name: "Operated with AI" })).toBeInTheDocument();
+    });
+
+    it("renders the AI-disclosure badge alongside a status badge rather than replacing it", () => {
+      render(
+        <UserDisplayName aiDisclosure verified>
+          Aitana
+        </UserDisplayName>,
+      );
+      expect(screen.getByRole("img", { name: "Verified" })).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "AI creator" })).toBeInTheDocument();
+    });
+
+    it("renders the AI-disclosure badge alongside the ambassador badge", () => {
+      render(
+        <UserDisplayName aiDisclosure ambassador>
+          Aitana
+        </UserDisplayName>,
+      );
+      expect(screen.getByRole("img", { name: "Ambassador" })).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "AI creator" })).toBeInTheDocument();
+    });
   });
 
   describe("online status", () => {
@@ -130,6 +164,15 @@ describe("UserDisplayName", () => {
     it("has no accessibility violations with badges and online status", async () => {
       const { container } = render(
         <UserDisplayName ambassador showOnlineStatus>
+          Aitana Lopez
+        </UserDisplayName>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations with the AI-disclosure badge", async () => {
+      const { container } = render(
+        <UserDisplayName aiDisclosure verified showOnlineStatus>
           Aitana Lopez
         </UserDisplayName>,
       );

--- a/src/components/UserDisplayName/UserDisplayName.test.tsx
+++ b/src/components/UserDisplayName/UserDisplayName.test.tsx
@@ -104,6 +104,24 @@ describe("UserDisplayName", () => {
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
 
+    // Surfaces that fix their own text colour, such as a row over a cover image, need the
+    // badges to follow it. A theme-dependent tint renders black against white text in light
+    // mode.
+    it("inherits the name's colour for the verified and AI-disclosure badges", () => {
+      render(
+        <UserDisplayName verified aiDisclosure>
+          Aitana
+        </UserDisplayName>,
+      );
+      expect(screen.getByRole("img", { name: "Verified" })).toHaveClass("text-current");
+      expect(screen.getByRole("img", { name: "AI creator" })).toHaveClass("text-current");
+    });
+
+    it("keeps the ambassador badge on its own tint rather than inheriting", () => {
+      render(<UserDisplayName ambassador>Aitana</UserDisplayName>);
+      expect(screen.getByRole("img", { name: "Ambassador" })).toHaveClass("text-success-content");
+    });
+
     it("renders an AI-disclosure badge with an accessible label", () => {
       render(<UserDisplayName aiDisclosure>Aitana</UserDisplayName>);
       expect(screen.getByRole("img", { name: "AI creator" })).toBeInTheDocument();

--- a/src/components/UserDisplayName/UserDisplayName.test.tsx
+++ b/src/components/UserDisplayName/UserDisplayName.test.tsx
@@ -104,9 +104,6 @@ describe("UserDisplayName", () => {
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
 
-    // Surfaces that fix their own text colour, such as a row over a cover image, need the
-    // badges to follow it. A theme-dependent tint renders black against white text in light
-    // mode.
     it("inherits the name's colour for the verified and AI-disclosure badges", () => {
       render(
         <UserDisplayName verified aiDisclosure>

--- a/src/components/UserDisplayName/UserDisplayName.tsx
+++ b/src/components/UserDisplayName/UserDisplayName.tsx
@@ -1,9 +1,14 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
+import { AIDisclosureIcon } from "../Icons/AIDisclosureIcon";
 import { VerifiedIcon } from "../Icons/VerifiedIcon";
 import { ProfileOnlineStatus } from "../ProfileOnlineStatus/ProfileOnlineStatus";
 
 export interface UserDisplayNameProps extends React.HTMLAttributes<HTMLElement> {
+  /** Render an AI-disclosure badge after the name, alongside any status badge. */
+  aiDisclosure?: boolean;
+  /** Accessible label for the AI-disclosure badge. @default "AI creator" */
+  aiDisclosureLabel?: string;
   /** Render an ambassador badge after the name. */
   ambassador?: boolean;
   /** Accessible label for the ambassador badge. @default "Ambassador" */
@@ -32,7 +37,11 @@ export interface UserDisplayNameProps extends React.HTMLAttributes<HTMLElement> 
  * for the standard display-name scale.
  *
  * When both `ambassador` and `verified` are set, the ambassador badge takes
- * precedence. Its tint uses `text-success-content` (not `text-icons-brand-green`)
+ * precedence. `aiDisclosure` is independent of both and renders after whichever
+ * status badge is shown, since it discloses how the account is operated rather
+ * than ranking it.
+ *
+ * The ambassador tint uses `text-success-content` (not `text-icons-brand-green`)
  * so the green darkens in light mode and lightens in dark mode, matching
  * {@link ProfileOnlineStatus}; `text-icons-brand-green` is fixed across modes.
  *
@@ -44,6 +53,8 @@ export interface UserDisplayNameProps extends React.HTMLAttributes<HTMLElement> 
 export const UserDisplayName = React.forwardRef<HTMLElement, UserDisplayNameProps>(
   (
     {
+      aiDisclosure,
+      aiDisclosureLabel = "AI creator",
       ambassador,
       ambassadorLabel = "Ambassador",
       children,
@@ -80,6 +91,15 @@ export const UserDisplayName = React.forwardRef<HTMLElement, UserDisplayNameProp
             className={cn("ml-2 inline-flex shrink-0 items-center", badge.tint)}
           >
             <VerifiedIcon size={16} />
+          </span>
+        )}
+        {aiDisclosure && (
+          <span
+            role="img"
+            aria-label={aiDisclosureLabel}
+            className="ml-2 inline-flex shrink-0 items-center text-content-primary"
+          >
+            <AIDisclosureIcon size={16} />
           </span>
         )}
         {showOnlineStatus && <ProfileOnlineStatus label={onlineLabel} className="shrink-0 ml-2" />}

--- a/src/components/UserDisplayName/UserDisplayName.tsx
+++ b/src/components/UserDisplayName/UserDisplayName.tsx
@@ -41,9 +41,15 @@ export interface UserDisplayNameProps extends React.HTMLAttributes<HTMLElement> 
  * status badge is shown, since it discloses how the account is operated rather
  * than ranking it.
  *
- * The ambassador tint uses `text-success-content` (not `text-icons-brand-green`)
- * so the green darkens in light mode and lightens in dark mode, matching
- * {@link ProfileOnlineStatus}; `text-icons-brand-green` is fixed across modes.
+ * The verified and AI-disclosure badges inherit the name's colour, so setting a
+ * colour on the root tints them with it. That keeps them legible on surfaces
+ * that fix their own text colour — over a cover image, for example, where a
+ * theme-dependent tint would turn black against white text in light mode.
+ *
+ * The ambassador tint is deliberately not inherited: it uses `text-success-content`
+ * (not `text-icons-brand-green`) so the green darkens in light mode and lightens
+ * in dark mode, matching {@link ProfileOnlineStatus}; `text-icons-brand-green` is
+ * fixed across modes.
  *
  * @example
  * ```tsx
@@ -74,7 +80,7 @@ export const UserDisplayName = React.forwardRef<HTMLElement, UserDisplayNameProp
     const badge = ambassador
       ? { label: ambassadorLabel, tint: "text-success-content" }
       : verified
-        ? { label: verifiedLabel, tint: "text-content-primary" }
+        ? { label: verifiedLabel, tint: "text-current" }
         : null;
 
     return (
@@ -97,7 +103,7 @@ export const UserDisplayName = React.forwardRef<HTMLElement, UserDisplayNameProp
           <span
             role="img"
             aria-label={aiDisclosureLabel}
-            className="ml-2 inline-flex shrink-0 items-center text-content-primary"
+            className="ml-2 inline-flex shrink-0 items-center text-current"
           >
             <AIDisclosureIcon size={16} />
           </span>

--- a/src/components/UserItem/UserItem.stories.tsx
+++ b/src/components/UserItem/UserItem.stories.tsx
@@ -22,11 +22,13 @@ const meta = {
       control: "select",
       options: [16, 24, 32, 40, 48, 64, 88, 148],
     },
+    aiDisclosure: { control: "boolean" },
     isMuted: { control: "boolean" },
     isOnline: { control: "boolean" },
     showAvatar: { control: "boolean" },
     showHandle: { control: "boolean" },
     showOnlineStatus: { control: "boolean" },
+    verified: { control: "boolean" },
   },
   args: {
     user: sampleUser,
@@ -35,6 +37,8 @@ const meta = {
     showAvatar: true,
     showHandle: true,
     showOnlineStatus: false,
+    aiDisclosure: false,
+    verified: false,
   },
   render: (args) => (
     <div className="w-72">
@@ -70,6 +74,20 @@ export const FallbackInitials: Story = {
 
 export const Muted: Story = {
   args: { isMuted: true },
+};
+
+export const Verified: Story = {
+  args: { verified: true },
+};
+
+export const AiDisclosure: Story = {
+  name: "AI disclosure",
+  args: { aiDisclosure: true },
+};
+
+export const VerifiedAiCreator: Story = {
+  name: "Verified AI creator",
+  args: { verified: true, aiDisclosure: true },
 };
 
 export const OnlineIndicator: Story = {

--- a/src/components/UserItem/UserItem.test.tsx
+++ b/src/components/UserItem/UserItem.test.tsx
@@ -119,10 +119,31 @@ describe("UserItem", () => {
     });
   });
 
+  describe("badges", () => {
+    it("renders no badges by default", () => {
+      render(<UserItem user={baseUser} />);
+      expect(screen.queryByRole("img", { name: "Verified" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("img", { name: "AI creator" })).not.toBeInTheDocument();
+    });
+
+    it("forwards verified and AI disclosure to the display name", () => {
+      render(<UserItem user={baseUser} verified aiDisclosure />);
+      expect(screen.getByRole("img", { name: "Verified" })).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "AI creator" })).toBeInTheDocument();
+    });
+  });
+
   describe("accessibility", () => {
     it("has no accessibility violations", async () => {
       const { container } = render(
         <UserItem user={{ ...baseUser, nickname: "JD" }} isMuted isOnline showOnlineStatus />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations with badges", async () => {
+      const { container } = render(
+        <UserItem user={baseUser} verified aiDisclosure showAvatar={false} />,
       );
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/src/components/UserItem/UserItem.test.tsx
+++ b/src/components/UserItem/UserItem.test.tsx
@@ -131,6 +131,20 @@ describe("UserItem", () => {
       expect(screen.getByRole("img", { name: "Verified" })).toBeInTheDocument();
       expect(screen.getByRole("img", { name: "AI creator" })).toBeInTheDocument();
     });
+
+    it("forwards custom badge labels to the display name", () => {
+      render(
+        <UserItem
+          user={baseUser}
+          verified
+          verifiedLabel="Cuenta verificada"
+          aiDisclosure
+          aiDisclosureLabel="Creador con IA"
+        />,
+      );
+      expect(screen.getByRole("img", { name: "Cuenta verificada" })).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "Creador con IA" })).toBeInTheDocument();
+    });
   });
 
   describe("accessibility", () => {

--- a/src/components/UserItem/UserItem.tsx
+++ b/src/components/UserItem/UserItem.tsx
@@ -38,11 +38,15 @@ export interface UserItemProps extends React.HTMLAttributes<HTMLDivElement> {
   showHandle?: boolean;
   /** Enable the avatar online indicator (combined with `isOnline`). */
   showOnlineStatus?: boolean;
+  /** Render an AI-disclosure badge after the display name. @default false */
+  aiDisclosure?: boolean;
+  /** Render a verified badge after the display name. @default false */
+  verified?: boolean;
 }
 
 /**
  * A compact user row showing an avatar, display name (or nickname) and handle,
- * with optional online and muted indicators.
+ * with optional verified and AI-disclosure badges and online and muted indicators.
  *
  * @example
  * ```tsx
@@ -59,6 +63,8 @@ export const UserItem = React.forwardRef<HTMLDivElement, UserItemProps>(
       showOnlineStatus,
       showHandle = true,
       showAvatar = true,
+      aiDisclosure = false,
+      verified = false,
       className,
       ...props
     },
@@ -85,7 +91,11 @@ export const UserItem = React.forwardRef<HTMLDivElement, UserItemProps>(
           />
         )}
         <div className="flex-1 overflow-hidden pl-2">
-          <UserDisplayName className="typography-body-small-14px-semibold">
+          <UserDisplayName
+            aiDisclosure={aiDisclosure}
+            verified={verified}
+            className="typography-body-small-14px-semibold"
+          >
             {user.nickname || user.displayName}
           </UserDisplayName>
           {showHandle && <UserHandle>{user.handle}</UserHandle>}

--- a/src/components/UserItem/UserItem.tsx
+++ b/src/components/UserItem/UserItem.tsx
@@ -40,8 +40,12 @@ export interface UserItemProps extends React.HTMLAttributes<HTMLDivElement> {
   showOnlineStatus?: boolean;
   /** Render an AI-disclosure badge after the display name. @default false */
   aiDisclosure?: boolean;
+  /** Accessible label for the AI-disclosure badge. @default "AI creator" */
+  aiDisclosureLabel?: string;
   /** Render a verified badge after the display name. @default false */
   verified?: boolean;
+  /** Accessible label for the verified badge. @default "Verified" */
+  verifiedLabel?: string;
 }
 
 /**
@@ -64,7 +68,9 @@ export const UserItem = React.forwardRef<HTMLDivElement, UserItemProps>(
       showHandle = true,
       showAvatar = true,
       aiDisclosure = false,
+      aiDisclosureLabel,
       verified = false,
+      verifiedLabel,
       className,
       ...props
     },
@@ -93,7 +99,9 @@ export const UserItem = React.forwardRef<HTMLDivElement, UserItemProps>(
         <div className="flex-1 overflow-hidden pl-2">
           <UserDisplayName
             aiDisclosure={aiDisclosure}
+            aiDisclosureLabel={aiDisclosureLabel}
             verified={verified}
+            verifiedLabel={verifiedLabel}
             className="typography-body-small-14px-semibold"
           >
             {user.nickname || user.displayName}


### PR DESCRIPTION
Additive changes so a creator tile can be rendered as a slim inline banner, and so a user's name can disclose that the account is AI-operated.

Everything here is an addition to an existing component. No removals, and no changes to how current props render — with one deliberate exception, called out under **Behaviour change** below.

## Changes

**`CreatorTile` — `aspectRatio="banner"` (5:2)**
The existing presets stop at 9:5, which is still too tall for a tile placed inline in a narrow column. `banner` sits at the short end of the scale.

Named for the slot rather than the axis: `wide` (its name in the first three commits) read on a different axis to `tall`/`medium`/`short`, so from autocomplete alone you could not tell whether it sat above or below `short`. Renamed before release, so no consumer is affected.

This commit also corrects the `aspectRatio` JSDoc, which documented all three existing ratios incorrectly: it claimed 1:2, 361:200 and 4:5 where the code has 5:4, 3:2 and 9:5. I would normally leave adjacent code alone, but adding a fourth entry next to three wrong ones would have compounded a mistake in a public API reference.

**`UserDisplayName` — `aiDisclosure` + `aiDisclosureLabel`**
Surfaces the existing `AIDisclosureIcon` beside the name so callers stop composing it by hand at each call site.

It renders _alongside_ the verified or ambassador badge rather than replacing it. Disclosure describes how an account is operated, so it is orthogonal to the status badges, which stay mutually exclusive with each other.

**`UserItem` — forwards `verified`, `aiDisclosure` and their labels**
`UserItem` already renders `UserDisplayName` but never passed the badge props through, so a row could not show either badge without rebuilding it by hand. The labels are forwarded too, so a non-English consumer can localise them; both stay `undefined` here so `UserDisplayName` remains the single source of the default strings.

## Behaviour change

**The verified and AI-disclosure badges now inherit the name's colour** (`text-current`) instead of hardcoding `text-content-primary`.

The hardcoded tint is theme-dependent, which breaks down on any surface that fixes its own text colour. `CreatorTile`'s `name` slot is exactly that surface: it sits over a cover image with white text, so in light mode the name and tagline stayed white while the badges flipped to black.

On a default surface this is a no-op, because the colour inherited there is the same `text-content-primary` that was hardcoded. What does change: **a consumer rendering the name in a muted or branded colour now gets a badge in that colour** rather than `text-content-primary`. That is the point of the fix, but it ships to consumers, so shout if you would rather it were opt-in behind a prop.

The ambassador badge deliberately keeps its own tint, since its green is mode-aware by design rather than context-dependent. There is a test pinning that, so the inheritance change cannot leak into it.

## Known limitation: minimum width

The profile row is a fixed ~74px tall, so at 5:2 the tile becomes shorter than its own row below **185px** of width and clips the top of the row. Measured in Storybook:

| Width  | Tile height | Row clipped |
| ------ | ----------- | ----------- |
| 160px  | 64px        | 10px        |
| 180px  | 72px        | 2px         |
| 185px  | 74px        | none        |
| 200px+ | 80px+       | none        |

Documented in the `aspectRatio` JSDoc rather than fixed, because the only thing that actually fixes it is an explicit pixel `min-height` — `min-height: fit-content` and `max-content` are both ignored, since `aspect-ratio` wins over the intrinsic contribution. That would hardcode the row's height into the container, which then rots the moment the row changes. Happy to add it if you would rather have the guard than the note.

Worth separating from a second effect at narrow widths: below ~200px the name and tagline collapse to zero width, squeezed out by the fixed-width action button. That one is **not** specific to this ratio — it reproduces identically on `tall`, `medium` and `short`, so it is pre-existing and out of scope here.

## Verification

- `pnpm typecheck` clean
- `pnpm lint` — 36 warnings, 0 errors, **identical to `main`** (verified by stashing and re-running, so this branch adds nothing)
- `pnpm test` — 3,487 unit tests and 953 Storybook browser tests pass
- `pnpm build` succeeds
- No e2e specs exist for these components
- Visually verified in Storybook, both themes: the 5:2 tile sits correctly at the short end of the ratio scale, badges render white over the banner in light and dark, and both badges keep the right order and spacing in `UserItem`

New stories cover each addition, so Chromatic should show the diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
