### PR TITLE
feat(SegmentedControl): allow icon and text

### DIFF
--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
+import { AIIcon } from "../Icons/AIIcon";
 import { GridViewIcon } from "../Icons/GridViewIcon";
+import { HomeIcon } from "../Icons/HomeIcon";
 import { ListViewIcon } from "../Icons/ListViewIcon";
 import type { SegmentedControlSize, SegmentedControlVariant } from "./SegmentedControl";
 import { SegmentedControl } from "./SegmentedControl";
@@ -27,7 +29,7 @@ const meta = {
     },
     appearance: {
       control: "inline-radio",
-      options: ["pill", "plain"],
+      options: ["pill", "plain", "brand"],
     },
     disabled: {
       control: "boolean",
@@ -147,6 +149,30 @@ export const IconOnly: Story = {
     design: {
       type: "figma",
       url: "https://www.figma.com/design/LB9q4XzCNlbOaeW3xN6tQo/Creator---Content---Creation?node-id=4506-17416",
+    },
+  },
+};
+
+const brandOptions = [
+  { label: "Home", value: "home", icon: <HomeIcon size={16} aria-hidden="true" /> },
+  { label: "Agent", value: "agent", icon: <AIIcon size={16} aria-hidden="true" /> },
+];
+
+/**
+ * Icon + visible label with the brand-green selected pill — the Home/Agent navigation switch.
+ * Colours are approximated with existing tokens pending dedicated navigation tokens.
+ */
+export const Brand: Story = {
+  args: {
+    appearance: "brand",
+    options: brandOptions,
+    defaultValue: "agent",
+    "aria-label": "Navigation mode",
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/fDlJj7bf7KXQlibPoujgaC/Creator---AI-Features?node-id=6470-48376",
     },
   },
 };

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -23,6 +23,11 @@ const iconOptions = [
   { label: "Grid view", value: "grid", icon: <GridViewIcon size={16} aria-hidden="true" /> },
 ];
 
+const brandOptions = [
+  { label: "Home", value: "home", icon: <ListViewIcon size={16} aria-hidden="true" /> },
+  { label: "Agent", value: "agent", icon: <GridViewIcon size={16} aria-hidden="true" /> },
+];
+
 describe("SegmentedControl", () => {
   describe("API", () => {
     it("applies custom className", () => {
@@ -216,6 +221,64 @@ describe("SegmentedControl", () => {
         <SegmentedControl appearance="plain" options={iconOptions} aria-label="View" />,
       );
       expect(container.firstChild).not.toHaveClass("bg-surface-tertiary");
+    });
+  });
+
+  describe("brand appearance", () => {
+    it("renders both the icon and the visible label for each segment", () => {
+      render(<SegmentedControl appearance="brand" options={brandOptions} aria-label="Mode" />);
+      expect(screen.getByText("Home")).toBeInTheDocument();
+      expect(screen.getByText("Agent")).toBeInTheDocument();
+      // Accessible name comes from the visible text, not an aria-label override.
+      expect(screen.getByRole("radio", { name: "Home" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Agent" })).toBeInTheDocument();
+    });
+
+    it("does not override the accessible name with aria-label when the label is visible", () => {
+      render(<SegmentedControl appearance="brand" options={brandOptions} aria-label="Mode" />);
+      expect(screen.getByRole("radio", { name: "Home" })).not.toHaveAttribute("aria-label");
+    });
+
+    it("applies the brand-green pill to the selected segment", () => {
+      render(
+        <SegmentedControl
+          appearance="brand"
+          options={brandOptions}
+          defaultValue="agent"
+          aria-label="Mode"
+        />,
+      );
+      expect(screen.getByRole("radio", { name: "Agent" })).toHaveClass("bg-brand-primary-muted");
+    });
+
+    it("keeps the pill container background", () => {
+      const { container } = render(
+        <SegmentedControl appearance="brand" options={brandOptions} aria-label="Mode" />,
+      );
+      expect(container.firstChild).toHaveClass("bg-surface-tertiary");
+    });
+
+    it("selects via click and reports the value", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <SegmentedControl
+          appearance="brand"
+          options={brandOptions}
+          onChange={handleChange}
+          aria-label="Mode"
+        />,
+      );
+      await user.click(screen.getByRole("radio", { name: "Agent" }));
+      expect(handleChange).toHaveBeenCalledWith("agent");
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = render(
+        <SegmentedControl appearance="brand" options={brandOptions} aria-label="Mode" />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
     });
   });
 

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -16,22 +16,27 @@ export type SegmentedControlVariant = "hug" | "fill";
  * - `"pill"`: the container has a muted background and the selected segment shows a filled pill (default).
  * - `"plain"`: no container or selected-pill background; segments are bare content and selection is
  *   communicated by color alone. Designed for icon-only toggles (e.g. a list/grid view switch).
+ * - `"brand"`: like `"pill"`, but segments render their `icon` alongside the visible `label` and the
+ *   selected segment uses the brand-green pill. Designed for prominent toggles such as the
+ *   Home/Agent navigation switch.
  */
-export type SegmentedControlAppearance = "pill" | "plain";
+export type SegmentedControlAppearance = "pill" | "plain" | "brand";
 
 /** Describes one selectable segment. */
 export interface SegmentedControlOption {
   /**
-   * Display label for the segment. When `icon` is provided, the segment renders icon-only and
-   * this value is used as its accessible name (applied as `aria-label`) instead of visible text.
+   * Display label for the segment. In `pill`/`plain` appearances, when `icon` is provided the
+   * segment renders icon-only and this value becomes its accessible name (applied as `aria-label`)
+   * instead of visible text. In the `brand` appearance the label is always rendered as visible text
+   * (alongside the icon when present).
    */
   label: string;
   /** Value identifier returned via `onChange`. */
   value: string;
   /**
-   * Icon to render instead of the visible label. When set, the segment renders icon-only and
-   * `label` becomes required as its accessible name — it is applied as `aria-label` and no
-   * visible text is rendered.
+   * Icon to render for the segment. In `pill`/`plain` appearances the segment renders icon-only and
+   * `label` becomes required as its accessible name (applied as `aria-label`, no visible text). In
+   * the `brand` appearance the icon renders alongside the visible `label`.
    */
   icon?: React.ReactNode;
 }
@@ -112,8 +117,14 @@ function getSegmentClassName({
         )
       : cn(
           sizeClasses[size],
+          // brand renders icon + label together, so space them.
+          appearance === "brand" && "gap-1.5",
           isSelected
-            ? "bg-buttons-primary-default text-content-primary-inverted shadow-sm"
+            ? appearance === "brand"
+              ? // Approximate brand-green pill using existing tokens; exact colours pending
+                // dedicated navigation tokens (see ENG follow-up).
+                "bg-brand-primary-muted text-content-always-black shadow-sm ring-1 ring-brand-primary-default"
+              : "bg-buttons-primary-default text-content-primary-inverted shadow-sm"
             : "text-content-primary hover:bg-buttons-switch-hover",
         ),
     disabled && "pointer-events-none",
@@ -153,6 +164,20 @@ function getSegmentClassName({
  *   value={view}
  *   onChange={setView}
  *   aria-label="View"
+ * />
+ * ```
+ *
+ * @example Icon + label with the brand-green pill (e.g. the Home/Agent nav switch)
+ * ```tsx
+ * <SegmentedControl
+ *   appearance="brand"
+ *   options={[
+ *     { label: "Home", value: "home", icon: <HomeIcon size={16} /> },
+ *     { label: "Agent", value: "agent", icon: <AIIcon size={16} /> },
+ *   ]}
+ *   value={mode}
+ *   onChange={setMode}
+ *   aria-label="Navigation mode"
  * />
  * ```
  */
@@ -219,6 +244,9 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedContro
       >
         {options.map((option, index) => {
           const isSelected = currentValue === option.value;
+          // `brand` shows the label as visible text (with the icon); `pill`/`plain` render
+          // icon-only when an icon is given, falling back to the label otherwise.
+          const showLabelText = appearance === "brand" || !option.icon;
           return (
             // biome-ignore lint/a11y/useSemanticElements: native radio inputs only allow Tab-focus on the checked item; buttons with roving tabindex give full keyboard navigation
             <button
@@ -231,18 +259,17 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedContro
               aria-checked={isSelected}
               tabIndex={isSelected || (!anySelected && index === 0) ? 0 : -1}
               disabled={disabled}
-              aria-label={option.icon ? option.label : undefined}
+              aria-label={showLabelText ? undefined : option.label}
               onClick={() => handleSelect(option.value)}
               onKeyDown={(e) => handleKeyDown(e, index)}
               className={getSegmentClassName({ appearance, size, variant, isSelected, disabled })}
             >
-              {option.icon ? (
+              {option.icon && (
                 <span className="flex shrink-0 items-center justify-center" aria-hidden="true">
                   {option.icon}
                 </span>
-              ) : (
-                <span className="min-w-0 truncate">{option.label}</span>
               )}
+              {showLabelText && <span className="min-w-0 truncate">{option.label}</span>}
             </button>
           );
         })}


### PR DESCRIPTION
## Summary

Allows both icon and text in a segmentedbutton

## Changes

<img width="340" height="149" alt="image" src="https://github.com/user-attachments/assets/421c5995-9014-4ead-9078-90bfb102eb4a" />

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

<!-- Paste screenshots or a link to the Chromatic/Storybook build. -->
