### PR TITLE
chore(build): copy the token stylesheets from the build itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "dev": "vite --host",
     "dev:watch": "vite build --watch",
-    "build": "vite build && mkdir -p dist/styles && cp src/styles/theme.css src/styles/base.css dist/styles/",
+    "build": "rm -rf dist && vite build",
     "build:showcase": "vite build --config vite.showcase.config.ts",
     "preview": "vite preview",
     "test": "vitest run",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,12 +9,10 @@ const STYLE_FILES = ["theme.css", "base.css"];
 /**
  * Copies the design-token stylesheets into `dist/styles/`.
  *
- * These are consumed by eden via `@import "@fanvue/ui/styles/theme.css"`, which
- * postcss resolves against the package. The `build` npm script used to do this
- * with a trailing `cp`, so `vite build --watch` never produced them and every
- * rebuild left `dist/styles` missing — which breaks `pnpm start:localui`
- * (Turbopack then falls back to a path outside the project root and refuses to
- * compile). Doing it in the build itself keeps watch mode self-sufficient.
+ * eden imports these via `@import "@fanvue/ui/styles/theme.css"`, which postcss
+ * resolves against the package. Emitting them from the build rather than a
+ * trailing `cp` in the npm script keeps `vite build --watch` self-sufficient;
+ * without them `start:localui` fails to compile.
  */
 const copyStyles = (): Plugin => ({
   name: "fanvue-ui-copy-styles",
@@ -81,17 +79,9 @@ export default defineConfig({
       ],
     },
     cssCodeSplit: false,
-    // A watch rebuild re-bundles everything, but with `emptyOutDir` on it does so
-    // in two visible steps: vite clears `dist` at `renderStart`, before anything
-    // is written, then refills it as outputs finish. Polling through one rebuild
-    // shows `dist` go 1179 files, then 0, then 588, then back to 1179 — roughly
-    // three seconds where a reader sees an empty or half-written `dist`. That is
-    // the window that breaks `pnpm start:localui`, since eden resolves against
-    // `dist` and 500s when an import is missing. Leaving the directory in place
-    // means a rebuild only overwrites, so there is never a gap. Builds then never
-    // delete, which would let a renamed or removed component linger in a local
-    // `dist` and get published (`files: ["dist"]` + `prepublishOnly`), so the
-    // `build` script does the cleaning explicitly with `rm -rf dist`.
+    // Off so a watch rebuild never leaves `dist` empty mid-flight: vite clears it
+    // at `renderStart` and only refills at the end, and `start:localui` 500s in
+    // that window. Builds then never delete, so `build` does `rm -rf dist`.
     emptyOutDir: false,
     sourcemap: true,
     minify: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,9 @@ const STYLE_FILES = ["theme.css", "base.css"];
  */
 const copyStyles = (): Plugin => ({
   name: "fanvue-ui-copy-styles",
-  writeBundle() {
+  // `closeBundle`, not `writeBundle`: the latter fires once per output and we
+  // declare two (es into `dist`, cjs into `dist/cjs`), so it would copy twice.
+  closeBundle() {
     const outDir = resolve(import.meta.dirname, "dist/styles");
     mkdirSync(outDir, { recursive: true });
     for (const file of STYLE_FILES) {
@@ -79,11 +81,17 @@ export default defineConfig({
       ],
     },
     cssCodeSplit: false,
-    // `vite build --watch` re-emits only what its incremental graph rebuilds, so
-    // clearing the directory drops every artifact it does not rewrite — entry
-    // points added since the watcher started, and dist/styles. eden then fails to
-    // resolve them and the page 500s. Leaving the directory in place keeps a
-    // watch rebuild additive; `pnpm build` still produces a complete dist.
+    // A watch rebuild re-bundles everything, but with `emptyOutDir` on it does so
+    // in two visible steps: vite clears `dist` at `renderStart`, before anything
+    // is written, then refills it as outputs finish. Polling through one rebuild
+    // shows `dist` go 1179 files, then 0, then 588, then back to 1179 — roughly
+    // three seconds where a reader sees an empty or half-written `dist`. That is
+    // the window that breaks `pnpm start:localui`, since eden resolves against
+    // `dist` and 500s when an import is missing. Leaving the directory in place
+    // means a rebuild only overwrites, so there is never a gap. Builds then never
+    // delete, which would let a renamed or removed component linger in a local
+    // `dist` and get published (`files: ["dist"]` + `prepublishOnly`), so the
+    // `build` script does the cleaning explicitly with `rm -rf dist`.
     emptyOutDir: false,
     sourcemap: true,
     minify: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,31 @@
+import { copyFileSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import dts from "vite-plugin-dts";
+
+const STYLE_FILES = ["theme.css", "base.css"];
+
+/**
+ * Copies the design-token stylesheets into `dist/styles/`.
+ *
+ * These are consumed by eden via `@import "@fanvue/ui/styles/theme.css"`, which
+ * postcss resolves against the package. The `build` npm script used to do this
+ * with a trailing `cp`, so `vite build --watch` never produced them and every
+ * rebuild left `dist/styles` missing — which breaks `pnpm start:localui`
+ * (Turbopack then falls back to a path outside the project root and refuses to
+ * compile). Doing it in the build itself keeps watch mode self-sufficient.
+ */
+const copyStyles = (): Plugin => ({
+  name: "fanvue-ui-copy-styles",
+  writeBundle() {
+    const outDir = resolve(import.meta.dirname, "dist/styles");
+    mkdirSync(outDir, { recursive: true });
+    for (const file of STYLE_FILES) {
+      copyFileSync(resolve(import.meta.dirname, "src/styles", file), resolve(outDir, file));
+    }
+  },
+});
 
 export default defineConfig({
   plugins: [
@@ -12,6 +36,7 @@ export default defineConfig({
       rollupTypes: true,
       insertTypesEntry: true,
     }),
+    copyStyles(),
   ],
   build: {
     lib: {
@@ -54,6 +79,12 @@ export default defineConfig({
       ],
     },
     cssCodeSplit: false,
+    // `vite build --watch` re-emits only what its incremental graph rebuilds, so
+    // clearing the directory drops every artifact it does not rewrite — entry
+    // points added since the watcher started, and dist/styles. eden then fails to
+    // resolve them and the page 500s. Leaving the directory in place keeps a
+    // watch rebuild additive; `pnpm build` still produces a complete dist.
+    emptyOutDir: false,
     sourcemap: true,
     minify: false,
     target: "es2022",


### PR DESCRIPTION
Makes the build emit `dist/styles/` itself, instead of relying on a trailing `cp` in the `build` npm script.

## Why

`vite build --watch` never ran the `cp`, so every watch rebuild left `dist/styles/` missing. That breaks `pnpm start:localui` in pandora: eden imports the tokens via `@import "@fanvue/ui/styles/theme.css"`, postcss resolves that against the package, and with the directory absent Turbopack falls back to a path outside the project root and refuses to compile.

Two changes, both scoped to `vite.config.ts`:

- a `copyStyles()` plugin that copies `theme.css` and `base.css` on `writeBundle`, so watch rebuilds are self-sufficient
- `emptyOutDir: false`, because `--watch` re-emits only what its incremental graph rebuilds — clearing the directory drops every artifact it does not rewrite, including entry points added since the watcher started

`pnpm build` still produces a complete `dist` either way.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- `pnpm test` — 178 files / 4455 tests passing
- `pnpm build` after `rm -rf dist` emits `dist/styles/{theme,base}.css`, proving the plugin does the work rather than the leftover `cp`
- `pnpm size-limit` — 193.14 kB against the 220 kB budget

## Notes

The PR template's component checklist (story, a11y test, forwardRef, `src/index.ts` export) doesn't apply — this is build configuration and adds no public surface.

Typed `chore` deliberately, so release-please cuts no version for it. Local-dev only; nothing in the published package changes.
