### PR TITLE
feat(Chip): add an outlined variant

### DIFF
--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -158,6 +158,14 @@ export const OutlinedSelected: Story = {
   },
 };
 
+export const OutlinedInteractive: Story = {
+  args: {
+    outlined: true,
+    children: "Chip",
+    onClick: () => {},
+  },
+};
+
 export const Size32: Story = {
   args: {
     size: "32",

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -38,6 +38,7 @@ const meta = {
     disabled: { control: "boolean" },
     leftDot: { control: "boolean" },
     dotted: { control: "boolean" },
+    outlined: { control: "boolean" },
     notificationVariant: {
       control: "select",
       options: ["default", "contrast", "brand", "alert", "pink", "info", "success", "warning"],
@@ -132,6 +133,27 @@ export const Square: Story = {
 export const Dark: Story = {
   args: {
     variant: "dark",
+    children: "Chip",
+  },
+};
+
+/**
+ * The Figma `V2 Insights Chips` treatment: the unselected chip is a 1px outline
+ * over a transparent background rather than a fill. Used where a row of chips sits
+ * over a chart, and solid fills would compete with the plotted series. Selecting
+ * one still fills it, so the selected chip reads as the odd one out either way.
+ */
+export const Outlined: Story = {
+  args: {
+    outlined: true,
+    children: "Chip",
+  },
+};
+
+export const OutlinedSelected: Story = {
+  args: {
+    outlined: true,
+    selected: true,
     children: "Chip",
   },
 };

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -119,6 +119,59 @@ describe("Chip", () => {
     });
   });
 
+  describe("outlined", () => {
+    it("strokes the unselected chip instead of filling it", () => {
+      render(<Chip outlined>Subs</Chip>);
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("border-buttons-chip-default", "bg-transparent");
+      expect(chip).not.toHaveClass("bg-buttons-chip-default");
+    });
+
+    it("still fills when selected, so the selected state is unchanged", () => {
+      render(
+        <Chip outlined selected>
+          Subs
+        </Chip>,
+      );
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("bg-buttons-chip-active");
+      expect(chip).not.toHaveClass("border-buttons-chip-default");
+    });
+
+    it("keeps a border in both states so toggling cannot resize the chip", () => {
+      // A chip's width is intrinsic, so `border-box` does not absorb the border on
+      // that axis: dropping it when selected would shrink the chip and shift the row.
+      const { rerender } = render(<Chip outlined>Subs</Chip>);
+      expect(screen.getByTestId("chip")).toHaveClass("border", "border-solid");
+
+      rerender(
+        <Chip outlined selected>
+          Subs
+        </Chip>,
+      );
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("border", "border-solid", "border-transparent");
+    });
+
+    it("fills by default, leaving every existing chip untouched", () => {
+      render(<Chip>Subs</Chip>);
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("bg-buttons-chip-default");
+      expect(chip).not.toHaveClass("bg-transparent");
+    });
+
+    it("greys only its stroke when disabled", () => {
+      render(
+        <Chip outlined disabled onClick={() => {}}>
+          Subs
+        </Chip>,
+      );
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("border-buttons-chip-disabled");
+      expect(chip).not.toHaveClass("bg-buttons-chip-disabled");
+    });
+  });
+
   describe("dotted", () => {
     it("renders a dashed svg border when dotted is true", () => {
       render(<Chip dotted>New folder</Chip>);

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -176,7 +176,7 @@ describe("Chip", () => {
         </Chip>,
       );
       const chip = screen.getByTestId("chip");
-      expect(chip).toHaveClass("hover:border-buttons-chip-hover", "hover:bg-neutral-alphas-50");
+      expect(chip).toHaveClass("hover:border-buttons-chip-hover", "hover:bg-interaction-hover");
       expect(chip).not.toHaveClass("hover:bg-buttons-chip-hover");
     });
 

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -138,9 +138,7 @@ describe("Chip", () => {
       expect(chip).not.toHaveClass("border-buttons-chip-default");
     });
 
-    it("keeps a border in both states so toggling cannot resize the chip", () => {
-      // A chip's width is intrinsic, so `border-box` does not absorb the border on
-      // that axis: dropping it when selected would shrink the chip and shift the row.
+    it("keeps a border in both states", () => {
       const { rerender } = render(<Chip outlined>Subs</Chip>);
       expect(screen.getByTestId("chip")).toHaveClass("border", "border-solid");
 
@@ -160,7 +158,7 @@ describe("Chip", () => {
       expect(chip).not.toHaveClass("bg-transparent");
     });
 
-    it("greys only its stroke when disabled", () => {
+    it("greys only its stroke when disabled and unselected", () => {
       render(
         <Chip outlined disabled onClick={() => {}}>
           Subs
@@ -169,6 +167,18 @@ describe("Chip", () => {
       const chip = screen.getByTestId("chip");
       expect(chip).toHaveClass("border-buttons-chip-disabled");
       expect(chip).not.toHaveClass("bg-buttons-chip-disabled");
+    });
+
+    it("takes the muted fill when disabled and selected", () => {
+      render(
+        <Chip outlined selected disabled onClick={() => {}}>
+          Subs
+        </Chip>,
+      );
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("bg-buttons-chip-disabled");
+      expect(chip).not.toHaveClass("bg-buttons-chip-active");
+      expect(chip).toHaveClass("border-transparent");
     });
   });
 

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -169,6 +169,24 @@ describe("Chip", () => {
       expect(chip).not.toHaveClass("bg-buttons-chip-disabled");
     });
 
+    it("darkens its stroke on hover instead of inheriting the filled chip's hover", () => {
+      render(
+        <Chip outlined onClick={() => {}}>
+          Subs
+        </Chip>,
+      );
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("hover:border-buttons-chip-hover", "hover:bg-neutral-alphas-50");
+      expect(chip).not.toHaveClass("hover:bg-buttons-chip-hover");
+    });
+
+    it("leaves the filled chip's hover untouched", () => {
+      render(<Chip onClick={() => {}}>Subs</Chip>);
+      const chip = screen.getByTestId("chip");
+      expect(chip).toHaveClass("hover:bg-buttons-chip-hover");
+      expect(chip).not.toHaveClass("hover:border-buttons-chip-hover");
+    });
+
     it("takes the muted fill when disabled and selected", () => {
       render(
         <Chip outlined selected disabled onClick={() => {}}>

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -183,14 +183,14 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           // Outlined darkens its stroke rather than filling. `buttons-chip-hover` is
           // the one-step darkening for chips, but as a fill it is 20% over a 10%
           // stroke, so it swallows the outline the variant exists to show. Moved onto
-          // the border, with the same 5% fill `dotted` uses under its darkened stroke.
+          // the border, over `interaction-hover`, the atomic hover surface.
           isInteractive &&
             !disabled &&
             !isDark &&
             !selected &&
             !dotted &&
             outlined &&
-            "hover:border-buttons-chip-hover hover:bg-neutral-alphas-50",
+            "hover:border-buttons-chip-hover hover:bg-interaction-hover",
           isInteractive &&
             !disabled &&
             !isDark &&

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -26,6 +26,15 @@ export interface ChipProps extends React.HTMLAttributes<HTMLElement> {
    * @default false
    */
   dotted?: boolean;
+  /**
+   * Draws the unselected state as a 1px `buttons-chip-default` outline over a
+   * transparent background instead of filling with that same token. This is the
+   * Figma `V2 Insights Chips` treatment, used where chips sit over a chart and a
+   * row of solid fills would compete with the plotted series. The selected state
+   * is unaffected — it stays filled — as are the `dark` and `dotted` variants.
+   * @default false
+   */
+  outlined?: boolean;
   /** Icon element displayed before the label. */
   leftIcon?: React.ReactNode;
   /** Icon element displayed after the label. */
@@ -64,6 +73,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
       disabled = false,
       leftDot = false,
       dotted = false,
+      outlined = false,
       leftIcon,
       rightIcon,
       notificationLabel,
@@ -131,7 +141,24 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             selected &&
             dotted &&
             "border border-border-primary border-solid bg-inputs-inputs-primary text-content-primary",
-          !isDark && !selected && !dotted && "bg-buttons-chip-default text-content-primary",
+          !isDark &&
+            !selected &&
+            !dotted &&
+            !outlined &&
+            "bg-buttons-chip-default text-content-primary",
+          // Outlined: the same token as a 1px stroke rather than a fill. The border
+          // is declared in BOTH states and only changes colour, going transparent
+          // once selected. It cannot be dropped on selection: `border-box` constrains
+          // only explicitly sized axes, and a chip's width is intrinsic, so losing the
+          // border would narrow the chip by 2px and reflow the whole row on every
+          // click. Height is safe either way because `h-8` is explicit.
+          !isDark && !dotted && outlined && "border border-solid",
+          !isDark &&
+            !selected &&
+            !dotted &&
+            outlined &&
+            "border-buttons-chip-default bg-transparent text-content-primary",
+          !isDark && selected && !dotted && outlined && "border-transparent",
           // Dotted (non-selected): the dashed border is drawn via SVG (`dottedBorder`).
           // `group` lets that SVG react to hover/active. `asChild` keeps a CSS dashed
           // border fallback since the SVG is only rendered in the default path.
@@ -165,7 +192,9 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           disabled && !isDark && "pointer-events-none text-content-disabled",
           // Solid (non-dotted) disabled chips get a muted fill; dotted ones stay
           // transparent with their dashed border (drawn via SVG).
-          disabled && !isDark && !dotted && "bg-buttons-chip-disabled",
+          disabled && !isDark && !dotted && !outlined && "bg-buttons-chip-disabled",
+          // Outlined stays unfilled when disabled; only its stroke greys out.
+          disabled && !isDark && !dotted && outlined && "border-buttons-chip-disabled",
           className,
         )}
         {...(isInteractive && {

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -178,7 +178,19 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
             !isDark &&
             !selected &&
             !dotted &&
+            !outlined &&
             "hover:bg-buttons-chip-hover",
+          // Outlined darkens its stroke rather than filling. `buttons-chip-hover` is
+          // the one-step darkening for chips, but as a fill it is 20% over a 10%
+          // stroke, so it swallows the outline the variant exists to show. Moved onto
+          // the border, with the same 5% fill `dotted` uses under its darkened stroke.
+          isInteractive &&
+            !disabled &&
+            !isDark &&
+            !selected &&
+            !dotted &&
+            outlined &&
+            "hover:border-buttons-chip-hover hover:bg-neutral-alphas-50",
           isInteractive &&
             !disabled &&
             !isDark &&

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -91,13 +91,19 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
     const isInteractive = !!onClick && !asChild;
     const Comp = asChild ? Slot : isInteractive ? "button" : "span";
     const isDark = variant === "dark";
+    // Precedence between the three treatments, named once rather than re-derived per
+    // rule: `dark` owns its own palette, `dotted` wins over `outlined`, and what is
+    // left is the normal chip, either filled or outlined.
+    const isDotted = !isDark && dotted;
+    const isSolid = !isDark && !dotted && !outlined;
+    const isOutlined = !isDark && !dotted && outlined;
 
     // The dashed border is drawn as an SVG so the dash length matches the design
     // spec (8/8 for the 40px square, 6/6 otherwise). CSS `border-dashed` only
     // renders browser-default dash lengths, which are too short. The stroke colour
     // is driven by `currentColor`, and `group-hover`/`group-active` react to the
     // chip's interactive states. Rendered only in the default (non-`asChild`) path.
-    const showDottedBorder = !isDark && dotted && !selected && !asChild;
+    const showDottedBorder = isDotted && !selected && !asChild;
     const dottedBorder = showDottedBorder ? (
       <svg
         aria-hidden="true"
@@ -135,67 +141,52 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           size === "40" && "typography-body-small-14px-semibold h-10 py-2.5",
           // Variant colors
           isDark && "bg-neutral-alphas-600 text-content-always-white",
-          !isDark && selected && !dotted && "bg-buttons-chip-active text-content-primary-inverted",
-          // Active + dotted is a subtle filled state with a solid (non-dashed) border.
-          !isDark &&
+          (isSolid || isOutlined) &&
             selected &&
-            dotted &&
+            "bg-buttons-chip-active text-content-primary-inverted",
+          // Active + dotted is a subtle filled state with a solid (non-dashed) border.
+          isDotted &&
+            selected &&
             "border border-border-primary border-solid bg-inputs-inputs-primary text-content-primary",
-          !isDark &&
-            !selected &&
-            !dotted &&
-            !outlined &&
-            "bg-buttons-chip-default text-content-primary",
+          isSolid && !selected && "bg-buttons-chip-default text-content-primary",
           // Outlined: the same token as a 1px stroke rather than a fill. The border
           // is declared in BOTH states and only changes colour, going transparent
           // once selected. It cannot be dropped on selection: `border-box` constrains
           // only explicitly sized axes, and a chip's width is intrinsic, so losing the
           // border would narrow the chip by 2px and reflow the whole row on every
           // click. Height is safe either way because `h-8` is explicit.
-          !isDark && !dotted && outlined && "border border-solid",
-          !isDark &&
+          isOutlined && "border border-solid",
+          isOutlined &&
             !selected &&
-            !dotted &&
-            outlined &&
             "border-buttons-chip-default bg-transparent text-content-primary",
-          !isDark && selected && !dotted && outlined && "border-transparent",
+          isOutlined && selected && "border-transparent",
           // Dotted (non-selected): the dashed border is drawn via SVG (`dottedBorder`).
           // `group` lets that SVG react to hover/active. `asChild` keeps a CSS dashed
           // border fallback since the SVG is only rendered in the default path.
-          !isDark && !selected && dotted && "bg-transparent text-content-primary",
-          !isDark && !selected && dotted && !asChild && "group",
-          asChild &&
-            !isDark &&
+          isDotted && !selected && "bg-transparent text-content-primary",
+          isDotted && !selected && !asChild && "group",
+          isDotted &&
             !selected &&
-            dotted &&
+            asChild &&
             (disabled
               ? "border border-buttons-chip-disabled border-dashed"
               : "border border-buttons-chip-dotted-default border-dashed"),
           // Interactive
           isInteractive && !disabled && "cursor-pointer",
-          isInteractive &&
-            !disabled &&
-            !isDark &&
-            !selected &&
-            !dotted &&
-            !outlined &&
-            "hover:bg-buttons-chip-hover",
+          isInteractive && !disabled && isSolid && !selected && "hover:bg-buttons-chip-hover",
           // Outlined darkens its stroke rather than filling. `buttons-chip-hover` is
           // the one-step darkening for chips, but as a fill it is 20% over a 10%
           // stroke, so it swallows the outline the variant exists to show. Moved onto
           // the border, over `interaction-hover`, the atomic hover surface.
           isInteractive &&
             !disabled &&
-            !isDark &&
+            isOutlined &&
             !selected &&
-            !dotted &&
-            outlined &&
             "hover:border-buttons-chip-hover hover:bg-interaction-hover",
           isInteractive &&
             !disabled &&
-            !isDark &&
+            isDotted &&
             !selected &&
-            dotted &&
             "hover:bg-neutral-alphas-50 active:bg-neutral-alphas-50",
           // Focus
           "focus-visible:shadow-focus-ring focus-visible:outline-none",
@@ -204,10 +195,10 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           disabled && !isDark && "pointer-events-none text-content-disabled",
           // Solid (non-dotted) disabled chips get a muted fill; dotted ones stay
           // transparent with their dashed border (drawn via SVG).
-          disabled && !isDark && !dotted && (!outlined || selected) && "bg-buttons-chip-disabled",
+          disabled && (isSolid || (isOutlined && selected)) && "bg-buttons-chip-disabled",
           // Unselected outlined greys only its stroke. Selected is already filled, so
           // it takes the muted fill above and keeps `border-transparent` for its width.
-          disabled && !isDark && !dotted && outlined && !selected && "border-buttons-chip-disabled",
+          disabled && isOutlined && !selected && "border-buttons-chip-disabled",
           className,
         )}
         {...(isInteractive && {

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -192,9 +192,10 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           disabled && !isDark && "pointer-events-none text-content-disabled",
           // Solid (non-dotted) disabled chips get a muted fill; dotted ones stay
           // transparent with their dashed border (drawn via SVG).
-          disabled && !isDark && !dotted && !outlined && "bg-buttons-chip-disabled",
-          // Outlined stays unfilled when disabled; only its stroke greys out.
-          disabled && !isDark && !dotted && outlined && "border-buttons-chip-disabled",
+          disabled && !isDark && !dotted && (!outlined || selected) && "bg-buttons-chip-disabled",
+          // Unselected outlined greys only its stroke. Selected is already filled, so
+          // it takes the muted fill above and keeps `border-transparent` for its width.
+          disabled && !isDark && !dotted && outlined && !selected && "border-buttons-chip-disabled",
           className,
         )}
         {...(isInteractive && {


### PR DESCRIPTION
Adds an `outlined` prop to `Chip`: the unselected state draws a 1px `buttons-chip-default` stroke over a transparent background instead of filling with that same token.

## Why

The Figma `V2 Insights Chips` treatment. It's used where a row of chips sits directly over a chart — a row of solid fills competes with the plotted series for attention, while outlines recede and let the selected chip read as the odd one out.

Additive and defaulted `false`, so every existing chip renders byte-identically. The selected state is untouched (still filled), as are the `dark` and `dotted` variants.

## One detail worth reviewing

The border is declared in **both** the selected and unselected states, changing only its colour — going transparent once selected — rather than being dropped on selection.

It can't be dropped: `border-box` constrains only explicitly sized axes, and a chip's width is intrinsic. Removing the border on selection would narrow the chip by 2px and reflow the whole row on every click. Height is safe either way, because `h-8` is explicit.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- `Chip` suite — 83 tests passing, including new coverage for the variant and for the no-reflow behaviour above
- Two stories added, `Outlined` and `OutlinedSelected`, plus the prop wired into the Storybook controls


## Hover, and where its values come from

Raised in review: the hover rule never excluded `outlined`, so it inherited the filled chip's `hover:bg-buttons-chip-hover`. Against the real Figma values that is a **20% fill sitting over a 10% stroke**, so the outline disappeared into the fill at the moment of interaction, which works against the reason the variant exists.

Both hover values are existing **atomics** — no new tokens, and no raw primitives:

| | token | resolves to |
| --- | --- | --- |
| resting stroke | `buttons-chip-default` | `#1515151a` (10%) |
| hover stroke | `buttons-chip-hover` | `#15151533` (20%) |
| hover surface | `interaction-hover` | `#1515150d` (5%) |

`buttons-chip-hover` is design's one-step darkening for chips. As a *fill* it swallows a 10% stroke; moved onto the *border* it is the same step applied where the variant actually reads. `interaction-hover` is the atomic hover surface, and at 5% it cannot compete with a 20% stroke — the same relationship `dotted` already relies on.

**On design provenance, stated plainly:** the resting state is confirmed against Figma. The chips live in the Insights designs under `V2 Insight Card` (stable ancestor `8279:35573`; the chip instances themselves have non-persistent component-internal IDs), and they use `Buttons/Chip/Default` for the outline and `Buttons/Chip/Active` when selected, which is what this PR does. **Hover is not drawn anywhere reachable** — static product frames carry no hover state, and `V2 Insights Chips` in the library has no hover variant. So the hover values are derived from the atomics rather than read from a spec. Flagging that rather than implying parity.

Follow-up for design (Casp): draw hover, pressed and disabled on `V2 Insights Chips` and add the hover-stroke token to the atomics, so this stops being inferred.

## Verification

- Rendered the awkward combinations and dumped the real class strings rather than reading the conditions. `outlined selected disabled` did come out `bg-buttons-chip-active` + `text-content-disabled`; it now takes the muted fill and keeps `border-transparent` to hold width.
- Confirmed Tailwind actually emits `hover:border-buttons-chip-hover` — this token had never been used as a border anywhere, and an ungenerated utility fails silently.
- Real mouse hover in a browser: border 10% → 20%, background 0 → 5%, width unchanged at 52.8px so hover cannot reflow the row.
- Added `OutlinedInteractive`. Without it the hover was unreachable in Storybook, since both existing outlined stories pass no `onClick` — which is why this was never caught visually.
- 42 `Chip` tests, `typecheck` and `biome` clean.

## Split out

The `dotted` variant had the same 2px reflow bug (measured: 87.30px → 89.30px on toggle). Fixed separately in #631 rather than widening this PR.
