### PR TITLE
feat(IconButton): add the field variant

### DIFF
--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -153,6 +153,7 @@ const meta = {
         "tertiaryDestructive",
         "stop",
         "microphone",
+        "field",
       ],
     },
     size: {
@@ -695,5 +696,22 @@ export const AllIcons: Story = {
   ),
   parameters: {
     layout: "fullscreen",
+  },
+};
+
+/**
+ * Carries the input surface rather than a button one, so an icon-only action can sit
+ * flush in a row of fields — Figma draws these as a `V2 Input Fields` instance with
+ * only an icon inside. Its border and hover match the Select trigger it lines up
+ * with, so the row reads as one control group.
+ *
+ * The only variant that is never circular: it takes the inputs' `rounded-sm` at
+ * every size, where the other variants are shaped by size.
+ */
+export const Field: Story = {
+  args: {
+    variant: "field",
+    size: "40",
+    icon: <HomeIcon />,
   },
 };

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -53,7 +53,8 @@ describe("IconButton", () => {
         );
         const button = screen.getByTestId("icon-button");
         expect(button).toHaveClass("rounded-sm");
-        expect(button).not.toHaveClass("rounded-full", "rounded-xs");
+        expect(button).not.toHaveClass("rounded-full");
+        expect(button).not.toHaveClass("rounded-xs");
         unmount();
       }
     });

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -46,6 +46,27 @@ describe("IconButton", () => {
       expect(button).not.toHaveClass("rounded-xs");
     });
 
+    it("gives the field variant the inputs' radius at every size, never circular", () => {
+      for (const size of ["24", "40"] as const) {
+        const { unmount } = render(
+          <IconButton icon={<HomeIcon />} variant="field" size={size} aria-label="Download" />,
+        );
+        const button = screen.getByTestId("icon-button");
+        expect(button).toHaveClass("rounded-sm");
+        expect(button).not.toHaveClass("rounded-full", "rounded-xs");
+        unmount();
+      }
+    });
+
+    it("gives the field variant the input surface and border", () => {
+      render(<IconButton icon={<HomeIcon />} variant="field" size="40" aria-label="Download" />);
+      expect(screen.getByTestId("icon-button")).toHaveClass(
+        "bg-inputs-inputs-primary",
+        "border",
+        "border-border-primary",
+      );
+    });
+
     it("keeps bespoke variants circular at every size", () => {
       render(<IconButton icon={<HomeIcon />} variant="microphone" size="24" aria-label="Mic" />);
       expect(screen.getByTestId("icon-button")).toHaveClass("rounded-full");

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -230,7 +230,8 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  * `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`,
  * `microphone`) stay circular at all sizes. `field` is the exception that is
  * never circular — it takes the inputs' `rounded-sm` so it matches the fields it
- * sits beside.
+ * sits beside. Use it at `32`, `40` or `48`: those are the sizes `Select` offers,
+ * and the variant only earns its surface when it lines up with one.
  *
  * @example
  * ```tsx

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -27,7 +27,8 @@ export type IconButtonVariant =
   | "navTray"
   | "tertiaryDestructive"
   | "stop"
-  | "microphone";
+  | "microphone"
+  | "field";
 
 /** Icon button size in pixels. */
 export type IconButtonSize = "24" | "32" | "40" | "48" | "52" | "72";
@@ -184,6 +185,15 @@ const VARIANT_CLASSES: Record<IconButtonVariant, VariantClasses> = {
       "bg-buttons-primary-default text-content-primary-inverted hover:bg-buttons-brand-default hover:text-content-always-black not-disabled:active:bg-buttons-brand-default not-disabled:active:text-content-always-black",
     disabled: DISABLED_OPACITY,
   },
+  // Carries the input surface rather than a button one, so an icon-only action can
+  // sit flush in a row of fields (Figma draws these as a `V2 Input Fields` instance
+  // with only an icon inside). Border and hover match the Select trigger it lines up
+  // with, so the row reads as one control group.
+  field: {
+    default:
+      "border border-border-primary bg-inputs-inputs-primary text-content-primary not-disabled:hover:border-neutral-alphas-400",
+    disabled: DISABLED_TRANSPARENT,
+  },
 };
 
 function getVariantClasses(variant: IconButtonVariant, negative: boolean): string {
@@ -218,7 +228,9 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  * Shape is size-driven for the standard variants: the `24` size is squared
  * (`rounded-xs`), every larger size is circular. Bespoke variants (`brand`,
  * `contrast`, `messaging`, `navTray`, `tertiaryDestructive`, `stop`,
- * `microphone`) stay circular at all sizes.
+ * `microphone`) stay circular at all sizes. `field` is the exception that is
+ * never circular — it takes the inputs' `rounded-sm` so it matches the fields it
+ * sits beside.
  *
  * @example
  * ```tsx
@@ -257,7 +269,13 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           "relative inline-flex shrink-0 items-center justify-center focus-visible:outline-none",
           "cursor-pointer transition-all duration-150 ease-in-out disabled:cursor-default",
           "focus-visible:shadow-focus-ring",
-          SIZE_DRIVEN_SHAPE_VARIANTS.has(variant) && size === "24" ? "rounded-xs" : "rounded-full",
+          // `field` takes the inputs' radius at every size so it lines up with the
+          // fields around it; everything else keeps the existing size-driven shape.
+          variant === "field"
+            ? "rounded-sm"
+            : SIZE_DRIVEN_SHAPE_VARIANTS.has(variant) && size === "24"
+              ? "rounded-xs"
+              : "rounded-full",
           sizeVariants[size],
           getVariantClasses(variant, negative),
           className,


### PR DESCRIPTION
Adds a `field` variant to `IconButton`, carrying the input surface rather than a button one.

## Why

Figma draws an icon-only action inside a row of fields as a `V2 Input Fields` instance with just an icon in it — not as a button. On the agency insights toolbar, the download control sits immediately beside a Select and a date-range field, and a button-surfaced icon broke the row into two visual groups.

`field` takes the same border, background and hover as the Select trigger it lines up with, so the row reads as one control group.

## The one thing that isn't like the others

`field` is the **only variant that is never circular**. Every other variant is shaped by size (`rounded-xs` at 24, circular above); `field` takes the inputs' `rounded-sm` at every size, because it has to match the fields either side of it rather than the buttons elsewhere.

That asymmetry is deliberate and called out in the type's doc comment, so it isn't mistaken for an oversight later.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- `IconButton` suite — 55 tests passing, including coverage for the variant's surface and its non-circular shape at every size
- `Field` story added and the variant registered in the Storybook `variant` control
- `e2e/iconButton.spec.ts` doesn't reference variants, so the Playwright suite is unaffected

Additive — every existing variant is untouched, so nothing renders differently.
