### PR TITLE
feat(TabsList): add flushLeft and scrollable

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -155,6 +155,63 @@ export const FillStyle: Story = {
   ),
 };
 
+/**
+ * `flushLeft` drops the first tab's leading padding so its label lines up with
+ * page content outside the bar. The heading here shares the tab list's left
+ * edge, which the default 16px trigger padding would otherwise break.
+ */
+export const FlushLeft: Story = {
+  name: "Full Width - Align Left, Flush",
+  render: () => (
+    <Tabs defaultValue="tab1">
+      <h2 className="typography-header-heading-sm pb-4 text-content-primary">Insights</h2>
+      <TabsList alignLeft flushLeft>
+        <TabsTrigger value="tab1">Manager Insights</TabsTrigger>
+        <TabsTrigger value="tab2">Chatter Leaderboard</TabsTrigger>
+      </TabsList>
+      <TabsContent value="tab1">
+        <p className="pt-4 text-content-tertiary text-sm">
+          The first label sits flush with the heading above it.
+        </p>
+      </TabsContent>
+      <TabsContent value="tab2">
+        <p className="pt-4 text-content-tertiary text-sm">Chatter Leaderboard content</p>
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+/**
+ * `scrollable` keeps every label readable in a narrow container. Without it the
+ * tabs compress until they all ellipsise at once; here they hold their width and
+ * the row scrolls, with the clipped tab at the edge as the affordance.
+ */
+export const Scrollable: Story = {
+  name: "Scrollable - Narrow Container",
+  render: () => (
+    <div className="w-[320px]">
+      <Tabs defaultValue="tab1">
+        <TabsList scrollable flushLeft>
+          <TabsTrigger value="tab1">Manager Insights</TabsTrigger>
+          <TabsTrigger value="tab2">Chatter Leaderboard</TabsTrigger>
+          <TabsTrigger value="tab3">Fans at Risk</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">
+          <p className="pt-4 text-content-tertiary text-sm">
+            Drag the row sideways to reach the later tabs.
+          </p>
+        </TabsContent>
+        <TabsContent value="tab2">
+          <p className="pt-4 text-content-tertiary text-sm">Chatter Leaderboard content</p>
+        </TabsContent>
+        <TabsContent value="tab3">
+          <p className="pt-4 text-content-tertiary text-sm">Fans at Risk content</p>
+        </TabsContent>
+      </Tabs>
+    </div>
+  ),
+};
+
 export const AlignLeft: Story = {
   name: "Full Width - Align Left",
   render: () => (

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -212,6 +212,37 @@ export const Scrollable: Story = {
   ),
 };
 
+/**
+ * A `scrollable` row mounted with a later tab already active, as URL-driven tab
+ * state does. The row scrolls to bring it into view on mount, so the active tab and
+ * its indicator are both visible rather than sitting off to the right unannounced.
+ */
+export const ScrollableActiveOffscreen: Story = {
+  name: "Scrollable - Active Tab Offscreen",
+  render: () => (
+    <div className="w-[320px]">
+      <Tabs defaultValue="tab3">
+        <TabsList scrollable flushLeft>
+          <TabsTrigger value="tab1">Manager Insights</TabsTrigger>
+          <TabsTrigger value="tab2">Chatter Leaderboard</TabsTrigger>
+          <TabsTrigger value="tab3">Fans at Risk</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">
+          <p className="pt-4 text-content-tertiary text-sm">Manager Insights content</p>
+        </TabsContent>
+        <TabsContent value="tab2">
+          <p className="pt-4 text-content-tertiary text-sm">Chatter Leaderboard content</p>
+        </TabsContent>
+        <TabsContent value="tab3">
+          <p className="pt-4 text-content-tertiary text-sm">
+            Mounted on the third tab, scrolled into view.
+          </p>
+        </TabsContent>
+      </Tabs>
+    </div>
+  ),
+};
+
 export const AlignLeft: Story = {
   name: "Full Width - Align Left",
   render: () => (

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -81,6 +81,58 @@ describe("Tabs", () => {
       );
     });
 
+    it("anchors the indicator to the label, not the tab centre, when padding is asymmetric", () => {
+      const rect = (left: number, width: number) =>
+        ({
+          left,
+          width,
+          right: left + width,
+          top: 0,
+          bottom: 0,
+          height: 0,
+          x: left,
+          y: 0,
+        }) as DOMRect;
+
+      const original = Element.prototype.getBoundingClientRect;
+      Element.prototype.getBoundingClientRect = function () {
+        if (this.getAttribute("role") === "tab") return rect(0, 149);
+        if (this.closest?.('[role="tab"]')) return rect(0, 133);
+        return rect(0, 320);
+      };
+      Object.defineProperty(HTMLElement.prototype, "offsetLeft", {
+        configurable: true,
+        get() {
+          return 0;
+        },
+      });
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+        configurable: true,
+        get() {
+          return 149;
+        },
+      });
+
+      try {
+        const { container } = render(
+          <Tabs defaultValue="t">
+            <TabsList alignLeft flushLeft>
+              <TabsTrigger value="t">Manager Insights</TabsTrigger>
+            </TabsList>
+          </Tabs>,
+        );
+        const indicator = container.querySelector<HTMLElement>(
+          '[role="tablist"] > span:not([role])',
+        );
+        expect(indicator?.style.width).toBe("133px");
+        expect(indicator?.style.transform).toBe("translateX(0px)");
+      } finally {
+        Element.prototype.getBoundingClientRect = original;
+        Reflect.deleteProperty(HTMLElement.prototype, "offsetLeft");
+        Reflect.deleteProperty(HTMLElement.prototype, "offsetWidth");
+      }
+    });
+
     it("scrolls rather than compresses the tabs when scrollable is set", () => {
       // `flex-none` is the load-bearing half: tabs that still share the row
       // never overflow, so there would be nothing to scroll.

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -53,6 +53,62 @@ describe("Tabs", () => {
       expect(screen.getByRole("tablist")).toHaveClass("custom-list");
     });
 
+    it("does not zero the first tab's leading padding by default", () => {
+      render(
+        <Tabs defaultValue="t">
+          <TabsList alignLeft>
+            <TabsTrigger value="t">T</TabsTrigger>
+          </TabsList>
+        </Tabs>,
+      );
+      expect(screen.getByRole("tablist")).not.toHaveClass(
+        "data-[orientation=horizontal]:[&>[role=tab]:first-child]:pl-0",
+      );
+    });
+
+    it("zeroes the first tab's leading padding when flushLeft is set", () => {
+      // Lines the first label up with page content beside the bar; the DS pads
+      // every trigger by 16px, which would otherwise indent it.
+      render(
+        <Tabs defaultValue="t">
+          <TabsList alignLeft flushLeft>
+            <TabsTrigger value="t">T</TabsTrigger>
+          </TabsList>
+        </Tabs>,
+      );
+      expect(screen.getByRole("tablist")).toHaveClass(
+        "data-[orientation=horizontal]:[&>[role=tab]:first-child]:pl-0",
+      );
+    });
+
+    it("scrolls rather than compresses the tabs when scrollable is set", () => {
+      // `flex-none` is the load-bearing half: tabs that still share the row
+      // never overflow, so there would be nothing to scroll.
+      render(
+        <Tabs defaultValue="t">
+          <TabsList scrollable>
+            <TabsTrigger value="t">T</TabsTrigger>
+          </TabsList>
+        </Tabs>,
+      );
+      const list = screen.getByRole("tablist");
+      expect(list).toHaveClass("data-[orientation=horizontal]:overflow-x-auto");
+      expect(list).toHaveClass("data-[orientation=horizontal]:[&>[role=tab]]:flex-none");
+    });
+
+    it("lets the tabs share the row by default", () => {
+      render(
+        <Tabs defaultValue="t">
+          <TabsList>
+            <TabsTrigger value="t">T</TabsTrigger>
+          </TabsList>
+        </Tabs>,
+      );
+      expect(screen.getByRole("tablist")).not.toHaveClass(
+        "data-[orientation=horizontal]:overflow-x-auto",
+      );
+    });
+
     it("isolates the active-indicator z-index in a local stacking context", () => {
       // `isolate` keeps the indicator's z-10 from escaping above page chrome.
       render(

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -133,6 +133,88 @@ describe("Tabs", () => {
       }
     });
 
+    it("scrolls a scrollable row so an already-active offscreen tab is visible on mount", () => {
+      const widths: Record<string, number> = { tab1: 0, tab2: 150, tab3: 300 };
+      Object.defineProperty(HTMLElement.prototype, "offsetLeft", {
+        configurable: true,
+        get(this: HTMLElement) {
+          return widths[this.getAttribute("data-testid") ?? ""] ?? 0;
+        },
+      });
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+        configurable: true,
+        get() {
+          return 150;
+        },
+      });
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        get() {
+          return 320;
+        },
+      });
+
+      try {
+        render(
+          <Tabs defaultValue="tab3">
+            <TabsList scrollable>
+              <TabsTrigger value="tab1" data-testid="tab1">
+                One
+              </TabsTrigger>
+              <TabsTrigger value="tab2" data-testid="tab2">
+                Two
+              </TabsTrigger>
+              <TabsTrigger value="tab3" data-testid="tab3">
+                Three
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>,
+        );
+        expect(screen.getByRole("tablist").scrollLeft).toBe(130);
+      } finally {
+        Reflect.deleteProperty(HTMLElement.prototype, "offsetLeft");
+        Reflect.deleteProperty(HTMLElement.prototype, "offsetWidth");
+        Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+      }
+    });
+
+    it("leaves scrollLeft alone when the active tab already fits", () => {
+      Object.defineProperty(HTMLElement.prototype, "offsetLeft", {
+        configurable: true,
+        get() {
+          return 0;
+        },
+      });
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+        configurable: true,
+        get() {
+          return 150;
+        },
+      });
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        get() {
+          return 320;
+        },
+      });
+
+      try {
+        render(
+          <Tabs defaultValue="tab1">
+            <TabsList scrollable>
+              <TabsTrigger value="tab1">One</TabsTrigger>
+              <TabsTrigger value="tab2">Two</TabsTrigger>
+            </TabsList>
+          </Tabs>,
+        );
+        expect(screen.getByRole("tablist").scrollLeft).toBe(0);
+      } finally {
+        Reflect.deleteProperty(HTMLElement.prototype, "offsetLeft");
+        Reflect.deleteProperty(HTMLElement.prototype, "offsetWidth");
+        Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+      }
+    });
+
     it("scrolls rather than compresses the tabs when scrollable is set", () => {
       // `flex-none` is the load-bearing half: tabs that still share the row
       // never overflow, so there would be nothing to scroll.

--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -115,9 +115,18 @@ export const TabsList = React.forwardRef<
         indicator.style.background =
           "linear-gradient(90deg, var(--color-buttons-tertiary-default) 0%, var(--color-tab-active) 50%, var(--color-buttons-tertiary-default) 100%)";
         const textSpan = activeTab.querySelector("span");
-        const textWidth = (textSpan ?? activeTab).getBoundingClientRect().width;
-        const tabCenter = activeTab.offsetLeft + activeTab.offsetWidth / 2;
-        const indicatorLeft = tabCenter - textWidth / 2;
+        const target = textSpan ?? activeTab;
+        const textWidth = target.getBoundingClientRect().width;
+        // Anchor to where the label actually sits, not to the tab's centre. The two
+        // only coincide when the tab's horizontal padding is symmetric, which
+        // `flushLeft` breaks by dropping `pl` on the first tab: the tab's centre then
+        // sits `pr / 2` to the right of the label's. Measured as a difference of two
+        // rects so it stays correct while a `scrollable` list is scrolled.
+        const textOffsetInTab =
+          target === activeTab
+            ? 0
+            : target.getBoundingClientRect().left - activeTab.getBoundingClientRect().left;
+        const indicatorLeft = activeTab.offsetLeft + textOffsetInTab;
         indicator.style.inset = "auto auto 0 0";
         indicator.style.height = "1px";
         indicator.style.width = `${textWidth}px`;

--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -42,113 +42,159 @@ export type TabsListProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.
   alignLeft?: boolean | Breakpoint;
   /** Explicit layout variant. `"hug"` sizes the list to its content; `"fill"` stretches it full-width with equal-width tabs. Takes precedence over `fullWidth`/`alignLeft`. */
   variant?: "fill" | "hug";
+  /**
+   * Drops the leading padding on the first tab so its label sits flush with the
+   * list's left edge, lining it up with page content above or below the bar
+   * (a heading, for instance) rather than being indented by the tab's own
+   * padding. Spacing between tabs is unaffected. Pair with `alignLeft` or
+   * `variant="hug"`. @default false
+   */
+  flushLeft?: boolean;
+  /**
+   * Scrolls the row horizontally when the tabs don't fit, instead of letting
+   * them compress. By default a tab may shrink until its label ellipsises,
+   * which on a narrow viewport can truncate every label at once; here each tab
+   * keeps its natural width and the overflow scrolls. The scrollbar itself is
+   * hidden — the clipped tab at the edge is the affordance.
+   *
+   * Because the tabs are content-sized, they no longer spread to fill the row:
+   * a set that does fit sits left-aligned, as with `alignLeft`.
+   *
+   * Horizontal orientation only: a vertical list already grows downwards.
+   * @default false
+   */
+  scrollable?: boolean;
 };
 
 /** Container for {@link TabsTrigger} elements. Renders a sliding active-tab indicator that animates between tabs. */
 export const TabsList = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.List>,
   TabsListProps
->(({ className, children, fullWidth = true, alignLeft, variant, ...props }, ref) => {
-  const innerRef = React.useRef<HTMLDivElement>(null);
-  const indicatorRef = React.useRef<HTMLSpanElement>(null);
+>(
+  (
+    {
+      className,
+      children,
+      fullWidth = true,
+      alignLeft,
+      variant,
+      flushLeft = false,
+      scrollable = false,
+      ...props
+    },
+    ref,
+  ) => {
+    const innerRef = React.useRef<HTMLDivElement>(null);
+    const indicatorRef = React.useRef<HTMLSpanElement>(null);
 
-  React.useImperativeHandle(ref, () => innerRef.current as HTMLDivElement);
+    React.useImperativeHandle(ref, () => innerRef.current as HTMLDivElement);
 
-  const updateIndicator = React.useCallback(() => {
-    const list = innerRef.current;
-    const indicator = indicatorRef.current;
-    if (!list || !indicator) return;
+    const updateIndicator = React.useCallback(() => {
+      const list = innerRef.current;
+      const indicator = indicatorRef.current;
+      if (!list || !indicator) return;
 
-    const activeTab = list.querySelector<HTMLElement>('[data-state="active"]');
-    if (!activeTab) {
-      indicator.style.opacity = "0";
-      return;
-    }
+      const activeTab = list.querySelector<HTMLElement>('[data-state="active"]');
+      if (!activeTab) {
+        indicator.style.opacity = "0";
+        return;
+      }
 
-    const isVertical = list.dataset.orientation === "vertical";
+      const isVertical = list.dataset.orientation === "vertical";
 
-    indicator.style.opacity = "1";
+      indicator.style.opacity = "1";
 
-    if (isVertical) {
-      indicator.style.background =
-        "linear-gradient(180deg, var(--color-buttons-tertiary-default) 0%, var(--color-tab-active) 50%, var(--color-buttons-tertiary-default) 100%)";
-      indicator.style.inset = `0 -1px auto auto`;
-      indicator.style.width = "1px";
-      indicator.style.height = `${activeTab.offsetHeight}px`;
-      indicator.style.transform = `translateY(${activeTab.offsetTop}px)`;
-    } else {
-      indicator.style.background =
-        "linear-gradient(90deg, var(--color-buttons-tertiary-default) 0%, var(--color-tab-active) 50%, var(--color-buttons-tertiary-default) 100%)";
-      const textSpan = activeTab.querySelector("span");
-      const textWidth = (textSpan ?? activeTab).getBoundingClientRect().width;
-      const tabCenter = activeTab.offsetLeft + activeTab.offsetWidth / 2;
-      const indicatorLeft = tabCenter - textWidth / 2;
-      indicator.style.inset = "auto auto 0 0";
-      indicator.style.height = "1px";
-      indicator.style.width = `${textWidth}px`;
-      indicator.style.transform = `translateX(${indicatorLeft}px)`;
-    }
-  }, []);
+      if (isVertical) {
+        indicator.style.background =
+          "linear-gradient(180deg, var(--color-buttons-tertiary-default) 0%, var(--color-tab-active) 50%, var(--color-buttons-tertiary-default) 100%)";
+        indicator.style.inset = `0 -1px auto auto`;
+        indicator.style.width = "1px";
+        indicator.style.height = `${activeTab.offsetHeight}px`;
+        indicator.style.transform = `translateY(${activeTab.offsetTop}px)`;
+      } else {
+        indicator.style.background =
+          "linear-gradient(90deg, var(--color-buttons-tertiary-default) 0%, var(--color-tab-active) 50%, var(--color-buttons-tertiary-default) 100%)";
+        const textSpan = activeTab.querySelector("span");
+        const textWidth = (textSpan ?? activeTab).getBoundingClientRect().width;
+        const tabCenter = activeTab.offsetLeft + activeTab.offsetWidth / 2;
+        const indicatorLeft = tabCenter - textWidth / 2;
+        indicator.style.inset = "auto auto 0 0";
+        indicator.style.height = "1px";
+        indicator.style.width = `${textWidth}px`;
+        indicator.style.transform = `translateX(${indicatorLeft}px)`;
+      }
+    }, []);
 
-  React.useLayoutEffect(() => {
-    const list = innerRef.current;
-    const indicator = indicatorRef.current;
-    if (!list || !indicator) return;
+    React.useLayoutEffect(() => {
+      const list = innerRef.current;
+      const indicator = indicatorRef.current;
+      if (!list || !indicator) return;
 
-    indicator.style.transitionDuration = "0s";
-    updateIndicator();
-    indicator.getBoundingClientRect();
-    indicator.style.transitionDuration = "";
+      indicator.style.transitionDuration = "0s";
+      updateIndicator();
+      indicator.getBoundingClientRect();
+      indicator.style.transitionDuration = "";
 
-    const mutationObserver = new MutationObserver(updateIndicator);
-    mutationObserver.observe(list, {
-      attributes: true,
-      attributeFilter: ["data-state"],
-      childList: true,
-      subtree: true,
-    });
-
-    const resizeObserver = new ResizeObserver(updateIndicator);
-    resizeObserver.observe(list);
-
-    let cancelled = false;
-    if (document.fonts?.status !== "loaded") {
-      document.fonts?.ready.then(() => {
-        if (!cancelled) updateIndicator();
+      const mutationObserver = new MutationObserver(updateIndicator);
+      mutationObserver.observe(list, {
+        attributes: true,
+        attributeFilter: ["data-state"],
+        childList: true,
+        subtree: true,
       });
-    }
 
-    return () => {
-      cancelled = true;
-      mutationObserver.disconnect();
-      resizeObserver.disconnect();
-    };
-  }, [updateIndicator]);
+      const resizeObserver = new ResizeObserver(updateIndicator);
+      resizeObserver.observe(list);
 
-  return (
-    <TabsPrimitive.List
-      ref={innerRef}
-      className={cn(
-        // `isolate` scopes the active indicator's `z-10` to a local stacking
-        // context. Without it, `relative` alone creates no stacking context, so
-        // the indicator escapes and paints above page chrome (e.g. the header).
-        "relative isolate",
-        getLayoutClass(variant, fullWidth, alignLeft),
-        "data-[orientation=horizontal]:items-center data-[orientation=horizontal]:shadow-[inset_0_-1px_0_0_var(--color-border-primary)]",
-        "data-[orientation=vertical]:flex-col data-[orientation=vertical]:shadow-[inset_-1px_0_0_0_var(--color-border-primary)]",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <span
-        ref={indicatorRef}
-        aria-hidden
-        className="pointer-events-none absolute z-10 rounded-full motion-safe:transition-[transform,width,height] motion-safe:duration-200 motion-safe:ease-in-out"
-        style={{ opacity: 0 }}
-      />
-    </TabsPrimitive.List>
-  );
-});
+      let cancelled = false;
+      if (document.fonts?.status !== "loaded") {
+        document.fonts?.ready.then(() => {
+          if (!cancelled) updateIndicator();
+        });
+      }
+
+      return () => {
+        cancelled = true;
+        mutationObserver.disconnect();
+        resizeObserver.disconnect();
+      };
+    }, [updateIndicator]);
+
+    return (
+      <TabsPrimitive.List
+        ref={innerRef}
+        className={cn(
+          // `isolate` scopes the active indicator's `z-10` to a local stacking
+          // context. Without it, `relative` alone creates no stacking context, so
+          // the indicator escapes and paints above page chrome (e.g. the header).
+          "relative isolate",
+          getLayoutClass(variant, fullWidth, alignLeft),
+          // Horizontal only: in the vertical orientation the leading padding is
+          // the row's left inset, not a label offset, so zeroing it would pull
+          // the first label out of line with the others.
+          flushLeft && "data-[orientation=horizontal]:[&>[role=tab]:first-child]:pl-0",
+          // `flex-none` is what stops the tabs compressing — without it they
+          // share the row and never overflow, so there is nothing to scroll.
+          // The scrollbar is hidden in both engines: Firefox reads
+          // `scrollbar-width`, WebKit and Blink the pseudo-element.
+          scrollable &&
+            "data-[orientation=horizontal]:overflow-x-auto data-[orientation=horizontal]:[scrollbar-width:none] data-[orientation=horizontal]:[&::-webkit-scrollbar]:hidden data-[orientation=horizontal]:[&>[role=tab]]:flex-none",
+          "data-[orientation=horizontal]:items-center data-[orientation=horizontal]:shadow-[inset_0_-1px_0_0_var(--color-border-primary)]",
+          "data-[orientation=vertical]:flex-col data-[orientation=vertical]:shadow-[inset_-1px_0_0_0_var(--color-border-primary)]",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <span
+          ref={indicatorRef}
+          aria-hidden
+          className="pointer-events-none absolute z-10 rounded-full motion-safe:transition-[transform,width,height] motion-safe:duration-200 motion-safe:ease-in-out"
+          style={{ opacity: 0 }}
+        />
+      </TabsPrimitive.List>
+    );
+  },
+);
 
 TabsList.displayName = "TabsList";

--- a/src/components/Tabs/TabsList.tsx
+++ b/src/components/Tabs/TabsList.tsx
@@ -134,6 +134,22 @@ export const TabsList = React.forwardRef<
       }
     }, []);
 
+    // Radix scrolls a tab into view when it takes focus, and mount is not focus, so
+    // URL-driven state can land on a tab that is off to the right with nothing on
+    // screen to say so: no indicator, and tab one showing as though it were active.
+    // Assigns `scrollLeft` rather than calling `scrollIntoView`, which would also
+    // scroll every ancestor and the page with it. Only ever scrolls further right, so
+    // re-running it after the webfont settles corrects a short initial scroll without
+    // yanking the row back from wherever the user has since dragged it.
+    const revealActiveTab = React.useCallback(() => {
+      const list = innerRef.current;
+      if (!list || !scrollable || list.dataset.orientation === "vertical") return;
+      const activeTab = list.querySelector<HTMLElement>('[data-state="active"]');
+      if (!activeTab) return;
+      const overshoot = activeTab.offsetLeft + activeTab.offsetWidth - list.clientWidth;
+      if (overshoot > list.scrollLeft) list.scrollLeft = overshoot;
+    }, [scrollable]);
+
     React.useLayoutEffect(() => {
       const list = innerRef.current;
       const indicator = indicatorRef.current;
@@ -143,6 +159,7 @@ export const TabsList = React.forwardRef<
       updateIndicator();
       indicator.getBoundingClientRect();
       indicator.style.transitionDuration = "";
+      revealActiveTab();
 
       const mutationObserver = new MutationObserver(updateIndicator);
       mutationObserver.observe(list, {
@@ -158,7 +175,11 @@ export const TabsList = React.forwardRef<
       let cancelled = false;
       if (document.fonts?.status !== "loaded") {
         document.fonts?.ready.then(() => {
-          if (!cancelled) updateIndicator();
+          if (cancelled) return;
+          updateIndicator();
+          // The tabs are wider once the real font is in, so the mount-time scroll can
+          // fall short of the active tab. Recomputed here against the settled layout.
+          revealActiveTab();
         });
       }
 
@@ -167,7 +188,7 @@ export const TabsList = React.forwardRef<
         mutationObserver.disconnect();
         resizeObserver.disconnect();
       };
-    }, [updateIndicator]);
+    }, [updateIndicator, revealActiveTab]);
 
     return (
       <TabsPrimitive.List


### PR DESCRIPTION
Adds two independent, opt-in props to `TabsList`. Both default `false`, so every existing tab bar is untouched.

## `flushLeft`

Drops the leading padding on the first tab so its label sits flush with the list's left edge, lining up with page content above or below the bar — a heading, for instance — rather than being indented by the tab's own padding. Spacing between tabs is unaffected.

## `scrollable`

Scrolls the row horizontally when the tabs don't fit, instead of letting them compress. By default a tab may shrink until its label ellipsises, which on a narrow viewport can truncate *every* label at once; here each tab keeps its natural width and the overflow scrolls. The scrollbar is hidden — the clipped tab at the edge is the affordance.

One consequence worth knowing: because the tabs become content-sized, they no longer spread to fill the row, so a set that *does* fit sits left-aligned as with `alignLeft`.

## Reviewing the diff

**Use `?w=1`.** GitHub reports ~248 changed lines in `TabsList.tsx`, but `git diff -w` gives **48 insertions / 2 deletions** — the rest is reindentation from the new destructuring wrapper. Ignoring whitespace makes this a small diff.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- `Tabs` suite — 34 tests passing, with new coverage for both props including the no-compress behaviour
- Stories added for both
