### PR TITLE
feat(Drawer): add the menu variant

### DIFF
--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -175,6 +175,31 @@ export const BottomSheet: Story = {
   ),
 };
 
+/**
+ * `variant="menu"` is for a dropdown that becomes a bottom overlay on a narrow
+ * viewport. Unlike `"sheet"` it floats clear of the edges and keeps the dropdown
+ * surface, so the menu reads as the same object it is on desktop.
+ */
+export const BottomMenu: Story = {
+  args: { position: "bottom", variant: "menu" },
+  play: openDrawer,
+  render: (args) => (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button>Open Bottom Menu</Button>
+      </DrawerTrigger>
+      <DrawerContent {...args}>
+        <DrawerHeader>
+          <DrawerTitle className="typography-header-heading-xs">Revenue View</DrawerTitle>
+        </DrawerHeader>
+        <div className="p-4 pt-0">
+          <p>Inset from all three edges, rounded on every corner.</p>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ),
+};
+
 export const WithoutOverlay: Story = {
   args: { overlay: false },
   play: openDrawer,

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -247,8 +247,87 @@ describe("Drawer", () => {
         "inset-x-4",
         "bottom-4",
         "rounded-lg",
+        // Same blur as a sheet: the docs promise the two share the modal surface.
+        "backdrop-blur-[4px]",
       );
-      expect(content).not.toHaveClass("rounded-t-xl");
+      // `rounded-t-xs` is the class that is genuinely in the running: `SLIDE_CLASSES.bottom`
+      // emits it for `position="bottom"`, and `rounded-lg` only wins by being merged
+      // over it. A negative on `rounded-t-xl` would pass whatever happened here, since
+      // only `SHEET_CLASSES` emits that and this is not a sheet.
+      expect(content).not.toHaveClass("rounded-t-xs");
+      expect(content).not.toHaveClass("w-full");
+      expect(content).not.toHaveClass("inset-x-0");
+    });
+
+    it("emits the classes the menu variant overrides, on a plain bottom drawer", async () => {
+      // Proves the negatives above are live rather than decorative: these are the
+      // classes `position="bottom"` really does add, so if the merge ever stopped
+      // stripping them for `menu` the assertions above would start failing.
+      const user = userEvent.setup();
+      render(
+        <Drawer>
+          <DrawerTrigger>Open plain</DrawerTrigger>
+          <DrawerContent position="bottom" aria-describedby={undefined}>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </Drawer>,
+      );
+      await user.click(screen.getByRole("button", { name: "Open plain" }));
+      const content = screen.getByRole("dialog");
+      expect(content).toHaveClass("rounded-t-xs");
+      expect(content).toHaveClass("w-full");
+      expect(content).toHaveClass("inset-x-0");
+    });
+
+    it("lets the variant shadow win instead of the base shadow-lg", async () => {
+      // tailwind-merge does not treat `shadow-blur-menu` as a box-shadow utility, so
+      // it never deduped it against the base `shadow-lg` and `shadow-lg` won on
+      // stylesheet order. Measured in a browser: the menu panel was painting
+      // shadow-lg's `0 4px 8px -1px / 0 8px 22px -1px` rather than the menu token's
+      // `0 6px 12px 0`. `shadow-lg` is now scoped to `panel`.
+      const user = userEvent.setup();
+      const { unmount } = render(
+        <Drawer>
+          <DrawerTrigger>Open menu</DrawerTrigger>
+          <DrawerContent position="bottom" variant="menu" aria-describedby={undefined}>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </Drawer>,
+      );
+      await user.click(screen.getByRole("button", { name: "Open menu" }));
+      expect(screen.getByRole("dialog")).toHaveClass("shadow-blur-menu");
+      expect(screen.getByRole("dialog")).not.toHaveClass("shadow-lg");
+      unmount();
+
+      renderDrawer();
+      await user.click(screen.getByRole("button", { name: "Open drawer" }));
+      expect(screen.getByRole("dialog")).toHaveClass("shadow-lg");
+    });
+
+    it("gives menu and sheet the same blur, since only their shape differs", async () => {
+      const user = userEvent.setup();
+      const { unmount } = render(
+        <Drawer>
+          <DrawerTrigger>Open sheet</DrawerTrigger>
+          <DrawerContent position="bottom" variant="sheet" aria-describedby={undefined}>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </Drawer>,
+      );
+      await user.click(screen.getByRole("button", { name: "Open sheet" }));
+      expect(screen.getByRole("dialog")).toHaveClass("backdrop-blur-[4px]");
+      unmount();
+
+      render(
+        <Drawer>
+          <DrawerTrigger>Open menu</DrawerTrigger>
+          <DrawerContent position="bottom" variant="menu" aria-describedby={undefined}>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </Drawer>,
+      );
+      await user.click(screen.getByRole("button", { name: "Open menu" }));
+      expect(screen.getByRole("dialog")).toHaveClass("backdrop-blur-[4px]");
     });
   });
 

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -225,6 +225,33 @@ describe("Drawer", () => {
     });
   });
 
+  describe("variants", () => {
+    it("floats the menu variant clear of the edges on the modal surface", async () => {
+      // The variant differs from `sheet` in shape only — inset and rounded on every
+      // corner — so it keeps the modal background and stroke rather than the
+      // lighter surface the trigger-anchored dropdown paints.
+      const user = userEvent.setup();
+      render(
+        <Drawer>
+          <DrawerTrigger>Open menu</DrawerTrigger>
+          <DrawerContent position="bottom" variant="menu" aria-describedby={undefined}>
+            <DrawerTitle>Revenue View</DrawerTitle>
+          </DrawerContent>
+        </Drawer>,
+      );
+      await user.click(screen.getByRole("button", { name: "Open menu" }));
+      const content = screen.getByRole("dialog");
+      expect(content).toHaveClass(
+        "bg-modal-background",
+        "border-modal-stroke",
+        "inset-x-4",
+        "bottom-4",
+        "rounded-lg",
+      );
+      expect(content).not.toHaveClass("rounded-t-xl");
+    });
+  });
+
   describe("ref forwarding", () => {
     it("forwards ref to DrawerContent", async () => {
       const ref = React.createRef<HTMLDivElement>();

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -18,8 +18,12 @@ export type DrawerSize = "sm" | "md" | "lg" | "full";
  * - `"sheet"` — a bottom-sheet treatment matching the modal surface: large
  *   top-only radius (32px), modal background/stroke, and menu blur+shadow.
  *   Intended for `position="bottom"`.
+ * - `"menu"` — a floating menu near the bottom edge rather than a sheet fixed to
+ *   it: inset from all three sides and rounded on every corner. Shares the modal
+ *   surface with `"sheet"`; only the shape differs. Intended for
+ *   `position="bottom"`.
  */
-export type DrawerVariant = "panel" | "sheet";
+export type DrawerVariant = "panel" | "sheet" | "menu";
 
 /**
  * Shared surface classes for the `"sheet"` variant. Mirrors the mobile sheet
@@ -27,6 +31,18 @@ export type DrawerVariant = "panel" | "sheet";
  */
 const SHEET_CLASSES =
   "rounded-t-xl border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[4px]";
+
+/**
+ * Surface and inset for the `"menu"` variant. Same modal background and stroke as
+ * a sheet — the design puts this panel on `background/secondary` with
+ * `border/strong`, not on the lighter surface the trigger-anchored dropdown uses.
+ * The 24px radius is the design's `rounded-lg`.
+ *
+ * The insets restate position on purpose — they override `SLIDE_CLASSES.bottom`,
+ * which pins a sheet flush to the bottom edge at full width.
+ */
+const MENU_CLASSES =
+  "inset-x-4 bottom-4 w-auto rounded-lg border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[8px]";
 
 /**
  * Props for the {@link Drawer} root component.
@@ -174,7 +190,8 @@ export interface DrawerContentProps
   size?: DrawerSize;
   /**
    * Visual treatment of the panel. Use `"sheet"` (with `position="bottom"`) for
-   * a bottom sheet with the modal surface treatment. @default "panel"
+   * a bottom sheet with the modal surface treatment, or `"menu"` for a floating
+   * inset menu carrying the dropdown surface. @default "panel"
    */
   variant?: DrawerVariant;
   /**
@@ -253,6 +270,7 @@ export const DrawerContent = React.forwardRef<
             SLIDE_CLASSES[position],
             sizeClass,
             variant === "sheet" && SHEET_CLASSES,
+            variant === "menu" && MENU_CLASSES,
             className,
           )}
           {...props}

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -42,7 +42,7 @@ const SHEET_CLASSES =
  * which pins a sheet flush to the bottom edge at full width.
  */
 const MENU_CLASSES =
-  "inset-x-4 bottom-4 w-auto rounded-lg border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[8px]";
+  "inset-x-4 bottom-4 w-auto rounded-lg border border-modal-stroke bg-modal-background shadow-blur-menu backdrop-blur-[4px]";
 
 /**
  * Props for the {@link Drawer} root component.
@@ -263,7 +263,13 @@ export const DrawerContent = React.forwardRef<
             ...style,
           }}
           className={cn(
-            "fixed flex flex-col bg-surface-secondary shadow-lg outline-none backdrop-blur-lg",
+            "fixed flex flex-col bg-surface-secondary outline-none backdrop-blur-lg",
+            // `shadow-lg` is scoped to `panel` rather than sitting in the base classes.
+            // tailwind-merge does not recognise `shadow-blur-menu` as a box-shadow
+            // utility, so it never deduped the two and `shadow-lg` won on stylesheet
+            // order — meaning the sheet and menu surfaces silently rendered `shadow-lg`
+            // instead of the menu shadow their tokens name.
+            variant === "panel" && "shadow-lg",
             "data-[state=closed]:animate-out data-[state=open]:animate-in",
             "data-[state=closed]:duration-150 data-[state=closed]:ease-in",
             "data-[state=open]:duration-200 data-[state=open]:ease-out",


### PR DESCRIPTION
Adds a `menu` variant to `DrawerContent`: an inset floating panel, rounded on every corner and held off all three edges, rather than a sheet flush to the bottom of the viewport.

## Why

It's the mobile form of the Figma `V2 Menu Dropdown`. On a phone a dropdown becomes a bottom sheet, but the V2 menu is drawn as a floating panel with its own margins — not the edge-to-edge sheet `variant="sheet"` produces.

Landing it on its own, ahead of anything that opts in, so the DropdownMenu work that needs it isn't carrying an unrelated Drawer change.

## Blast radius

**Nothing renders differently.** `menu` is a new member of an existing union with no consumers yet — all 12 current `Drawer` call sites keep whatever variant they already pass. `DrawerVariant` is already exported, so `src/index.ts` is untouched and there's no new public surface beyond the union member.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- `Drawer` suite — 40 tests passing, including coverage for the variant's insets and radius
- Story added

Labelled `chromatic` even though existing variants are untouched, because the variant map is shared and I'd rather have the baseline than assume.
