### PR TITLE
feat(UserHandle): add a tone prop

### DIFF
--- a/src/components/UserHandle/UserHandle.stories.tsx
+++ b/src/components/UserHandle/UserHandle.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   tags: ["autodocs"],
   argTypes: {
     children: { control: "text" },
+    tone: { control: "select", options: ["secondary", "primary"] },
   },
   args: {
     children: "fit_aitana",
@@ -29,5 +30,16 @@ export const Default: Story = {};
 export const LongHandle: Story = {
   args: {
     children: "an_extremely_long_handle_that_should_truncate_with_an_ellipsis",
+  },
+};
+
+/**
+ * `primary` is for rows where the handle *is* the identity line, with no display
+ * name above it to carry the emphasis — Figma's table rows do this. The default
+ * `secondary` stays muted, for a handle sitting beneath a name.
+ */
+export const PrimaryTone: Story = {
+  args: {
+    tone: "primary",
   },
 };

--- a/src/components/UserHandle/UserHandle.test.tsx
+++ b/src/components/UserHandle/UserHandle.test.tsx
@@ -24,6 +24,17 @@ describe("UserHandle", () => {
       );
     });
 
+    it("renders the handle as the identity line at tone=primary", () => {
+      render(
+        <UserHandle data-testid="handle" tone="primary">
+          fit_aitana
+        </UserHandle>,
+      );
+      const el = screen.getByTestId("handle");
+      expect(el).toHaveClass("text-content-primary");
+      expect(el).not.toHaveClass("text-content-secondary");
+    });
+
     it("applies custom className", () => {
       render(
         <UserHandle data-testid="handle" className="custom">

--- a/src/components/UserHandle/UserHandle.tsx
+++ b/src/components/UserHandle/UserHandle.tsx
@@ -3,11 +3,18 @@ import { cn } from "../../utils/cn";
 
 const HANDLE_SYMBOL = "@";
 
-export interface UserHandleProps extends React.HTMLAttributes<HTMLSpanElement> {}
+export interface UserHandleProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /**
+   * `"secondary"` (default) is the muted handle sitting beneath a display name.
+   * Use `"primary"` where the handle *is* the identity line and there is no name
+   * above it to carry the emphasis — Figma's table rows do this.
+   */
+  tone?: "secondary" | "primary";
+}
 
 /**
- * Renders a user handle prefixed with the `@` symbol as muted, truncated
- * secondary text.
+ * Renders a user handle prefixed with the `@` symbol as truncated text, muted by
+ * default. Owns the `@` so callers never concatenate it themselves.
  *
  * @example
  * ```tsx
@@ -15,12 +22,13 @@ export interface UserHandleProps extends React.HTMLAttributes<HTMLSpanElement> {
  * ```
  */
 export const UserHandle = React.forwardRef<HTMLSpanElement, UserHandleProps>(
-  ({ children, className, ...props }, ref) => {
+  ({ children, className, tone = "secondary", ...props }, ref) => {
     return (
       <span
         ref={ref}
         className={cn(
-          "typography-body-small-14px-regular block max-w-full truncate text-content-secondary",
+          "typography-body-small-14px-regular block max-w-full truncate",
+          tone === "primary" ? "text-content-primary" : "text-content-secondary",
           className,
         )}
         {...props}


### PR DESCRIPTION
Adds a `tone` prop to `UserHandle`, defaulting to the existing muted `secondary`.

## Why

`secondary` assumes the handle sits *beneath* a display name, which carries the emphasis. Figma's V2 table rows identify a row by handle alone — there's no name above it — so the handle needs to be the primary text rather than muted supporting text.

## Blast radius

Defaulted to `secondary`, so the one existing consumer and every future one renders exactly as before. `UserHandleProps` was previously an empty interface extending `HTMLAttributes`, so this is its first real prop.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- `UserHandle` suite — 9 tests passing, with coverage for both tones
- `PrimaryTone` story added and `tone` wired into the Storybook controls
