### PR TITLE
feat(ChartSkeleton): add shaped loading placeholders for charts

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -16,6 +16,11 @@ export type {
   ChartSeriesToggleProps,
 } from "./components/Chart/ChartSeriesToggle";
 export { ChartSeriesToggle } from "./components/Chart/ChartSeriesToggle";
+export type {
+  ChartSkeletonProps,
+  ChartSkeletonVariant,
+} from "./components/Chart/ChartSkeleton";
+export { ChartSkeleton } from "./components/Chart/ChartSkeleton";
 export type { ChartStyleProps } from "./components/Chart/ChartStyle";
 export { ChartStyle } from "./components/Chart/ChartStyle";
 export type {

--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -227,7 +227,12 @@ describe("Chart", () => {
     it("filters out items with type 'none'", () => {
       const payload = [
         LEGEND_ITEM_REVENUE,
-        { value: "hidden", dataKey: "hidden", color: "#000", type: "none" as const },
+        {
+          value: "hidden",
+          dataKey: "hidden",
+          color: "#000",
+          type: "none" as const,
+        },
       ];
       render(
         <ChartContext.Provider value={{ config: SAMPLE_CONFIG }}>
@@ -468,6 +473,45 @@ describe("Chart", () => {
       expect(container.querySelector('[class*="bg-surface-primary/60"]')).toBeNull();
     });
 
+    it("announces loading on both paths, not just the spinner one", () => {
+      // axe cannot catch this: every Skeleton is aria-hidden, so the skeleton path
+      // has no markup to violate and a passing axe check says nothing about whether
+      // the loading state is conveyed at all. Assert the announcement directly.
+      const { unmount } = render(
+        <ChartLoadingOverlay loading>
+          <div>chart</div>
+        </ChartLoadingOverlay>,
+      );
+      expect(screen.getByRole("status")).toHaveAccessibleName(/loading/i);
+      expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
+      unmount();
+
+      render(
+        <ChartLoadingOverlay loading variant={false}>
+          <div>chart</div>
+        </ChartLoadingOverlay>,
+      );
+      expect(screen.getByRole("status")).toHaveAccessibleName(/loading/i);
+    });
+
+    it("takes a translated loading label", () => {
+      render(
+        <ChartLoadingOverlay loading loadingLabel="Chargement du graphique">
+          <div>chart</div>
+        </ChartLoadingOverlay>,
+      );
+      expect(screen.getByRole("status")).toHaveAccessibleName("Chargement du graphique");
+    });
+
+    it("does not announce loading once it has finished", () => {
+      render(
+        <ChartLoadingOverlay loading={false}>
+          <div>chart</div>
+        </ChartLoadingOverlay>,
+      );
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
     it("shows the area skeleton by default and the spinner only at variant={false}", () => {
       const { container: byDefault } = render(
         <ChartLoadingOverlay loading>
@@ -546,6 +590,26 @@ describe("Chart", () => {
     it("renders one bar per sample for bar charts", () => {
       const { container } = render(<ChartSkeleton variant="bar" />);
       expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(7);
+    });
+
+    it("matches the bar count it is given, so a three-bar chart does not shift on load", () => {
+      const { container } = render(<ChartSkeleton variant="bar" rows={3} />);
+      expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(3);
+    });
+
+    it("cycles the bar heights past the seven it has, rather than running out", () => {
+      const { container } = render(<ChartSkeleton variant="bar" rows={9} />);
+      const bars = [...container.querySelectorAll<HTMLElement>(".fv-skeleton-wave")];
+      expect(bars.length).toBe(9);
+      expect(bars.every((bar) => bar.style.height !== "")).toBe(true);
+    });
+
+    it("masks the donut hole rather than painting a surface colour over it", () => {
+      // A filled disc only vanishes on a surface of exactly that colour, and this
+      // renders standalone as well as inside the overlay.
+      const { container } = render(<ChartSkeleton variant="circular" />);
+      expect(container.querySelector('[class*="mask-image"]')).not.toBeNull();
+      expect(container.querySelector('[class*="bg-background-primary"]')).toBeNull();
     });
 
     it("renders line charts as a single band, matching area", () => {

--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -11,6 +11,7 @@ import { ChartLegendContent } from "./ChartLegend";
 import { ChartLoadingOverlay } from "./ChartLoadingOverlay";
 import { ChartPieLegend } from "./ChartPieLegend";
 import { ChartSeriesToggle } from "./ChartSeriesToggle";
+import { ChartSkeleton } from "./ChartSkeleton";
 import { ChartStyle } from "./ChartStyle";
 import { ChartTooltipContent } from "./ChartTooltip";
 import type { ChartConfig } from "./types";
@@ -457,6 +458,32 @@ describe("Chart", () => {
       expect(await axe(container)).toHaveNoViolations();
     });
 
+    it("renders a wave skeleton instead of the spinner when variant is set", () => {
+      const { container } = render(
+        <ChartLoadingOverlay loading variant="bar">
+          <div>chart</div>
+        </ChartLoadingOverlay>,
+      );
+      expect(container.querySelector(".fv-skeleton-wave")).not.toBeNull();
+      expect(container.querySelector('[class*="bg-surface-primary/60"]')).toBeNull();
+    });
+
+    it("shows the area skeleton by default and the spinner only at variant={false}", () => {
+      const { container: byDefault } = render(
+        <ChartLoadingOverlay loading>
+          <div>chart</div>
+        </ChartLoadingOverlay>,
+      );
+      expect(byDefault.querySelector(".fv-skeleton-wave")).not.toBeNull();
+
+      const { container: legacy } = render(
+        <ChartLoadingOverlay loading variant={false}>
+          <div>chart</div>
+        </ChartLoadingOverlay>,
+      );
+      expect(legacy.querySelector(".fv-skeleton-wave")).toBeNull();
+    });
+
     it("ChartCard has no accessibility violations", async () => {
       const { container } = render(
         <ChartCard title="Revenue" subtitle="$1,234" dateInfo="Mar 1 - Mar 14">
@@ -508,6 +535,57 @@ describe("Chart", () => {
         </svg>,
       );
       expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+  describe("ChartSkeleton", () => {
+    it("renders a circular placeholder for circular charts", () => {
+      const { container } = render(<ChartSkeleton variant="circular" />);
+      expect(container.querySelector(".rounded-full")).not.toBeNull();
+    });
+
+    it("renders one bar per sample for bar charts", () => {
+      const { container } = render(<ChartSkeleton variant="bar" />);
+      expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(7);
+    });
+
+    it("renders line charts as a single band, matching area", () => {
+      const { container } = render(<ChartSkeleton variant="line" />);
+      expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(1);
+    });
+
+    it("renders a single filled band for area charts", () => {
+      const { container } = render(<ChartSkeleton variant="area" />);
+      expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(1);
+    });
+
+    it("renders a header plus one row per entry for tables", () => {
+      const { container } = render(<ChartSkeleton variant="table" rows={5} />);
+      // 3 header bars, then 4 elements per row (rank, avatar, label, value).
+      expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(3 + 5 * 4);
+    });
+
+    it("renders a glyph, label, value and bar per breakdown row", () => {
+      const { container } = render(<ChartSkeleton variant="rows" rows={3} />);
+      expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(3 * 4);
+    });
+
+    it("matches the row count it is given, so the card does not resize on load", () => {
+      const { container } = render(<ChartSkeleton variant="rows" rows={1} />);
+      expect(container.querySelectorAll(".fv-skeleton-wave").length).toBe(4);
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = render(<ChartSkeleton variant="line" />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations for the list variants", async () => {
+      const table = render(<ChartSkeleton variant="table" rows={3} />);
+      expect(await axe(table.container)).toHaveNoViolations();
+      table.unmount();
+
+      const rows = render(<ChartSkeleton variant="rows" rows={3} />);
+      expect(await axe(rows.container)).toHaveNoViolations();
     });
   });
 });

--- a/src/components/Chart/ChartHelpers.stories.tsx
+++ b/src/components/Chart/ChartHelpers.stories.tsx
@@ -4,6 +4,7 @@ import { ChartCard } from "./ChartCard";
 import { ChartLoadingOverlay } from "./ChartLoadingOverlay";
 import { ChartPieLegend } from "./ChartPieLegend";
 import { ChartSeriesToggle } from "./ChartSeriesToggle";
+import { ChartSkeleton } from "./ChartSkeleton";
 import { SimpleLineChart, simpleLineConfig } from "./chartStoryFixtures";
 
 const meta = {
@@ -256,6 +257,37 @@ export const PieLegendCompact: Story = {
           },
         ]}
       />
+    </div>
+  ),
+};
+
+export const ChartSkeletons: Story = {
+  name: "Chart skeletons (per chart type)",
+  render: () => (
+    <div className="grid w-full max-w-4xl gap-6 sm:grid-cols-2">
+      {(["area", "line", "bar", "circular"] as const).map((variant) => (
+        <div key={variant} className="flex flex-col gap-2">
+          <span className="typography-description-12px-semibold text-content-secondary">
+            {variant}
+          </span>
+          <div className="h-40 rounded-sm border border-border-strong bg-background-primary p-4">
+            <ChartSkeleton variant={variant} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const LoadingOverlayWithSkeleton: Story = {
+  render: () => (
+    <div className="grid w-full max-w-4xl gap-6 sm:grid-cols-2">
+      <ChartLoadingOverlay loading variant="area" className="h-48">
+        <SimpleLineChart config={simpleLineConfig} />
+      </ChartLoadingOverlay>
+      <ChartLoadingOverlay loading variant="bar" className="h-48">
+        <SimpleLineChart config={simpleLineConfig} />
+      </ChartLoadingOverlay>
     </div>
   ),
 };

--- a/src/components/Chart/ChartHelpers.stories.tsx
+++ b/src/components/Chart/ChartHelpers.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
+import { cn } from "../../utils/cn";
 import { ChartCard } from "./ChartCard";
 import { ChartLoadingOverlay } from "./ChartLoadingOverlay";
 import { ChartPieLegend } from "./ChartPieLegend";
@@ -265,13 +266,20 @@ export const ChartSkeletons: Story = {
   name: "Chart skeletons (per chart type)",
   render: () => (
     <div className="grid w-full max-w-4xl gap-6 sm:grid-cols-2">
-      {(["area", "line", "bar", "circular"] as const).map((variant) => (
+      {(["area", "line", "bar", "circular", "table", "rows"] as const).map((variant) => (
         <div key={variant} className="flex flex-col gap-2">
           <span className="typography-description-12px-semibold text-content-secondary">
             {variant}
           </span>
-          <div className="h-40 rounded-sm border border-border-strong bg-background-primary p-4">
-            <ChartSkeleton variant={variant} />
+          {/* The chart shapes fill a fixed plot; the list shapes are sized by their
+              own rows, so forcing a height on those would misrepresent them. */}
+          <div
+            className={cn(
+              "rounded-sm border border-border-strong bg-background-primary p-4",
+              variant !== "table" && variant !== "rows" && "h-40",
+            )}
+          >
+            <ChartSkeleton variant={variant} rows={variant === "rows" ? 3 : 5} />
           </div>
         </div>
       ))}

--- a/src/components/Chart/ChartLoadingOverlay.tsx
+++ b/src/components/Chart/ChartLoadingOverlay.tsx
@@ -1,23 +1,34 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
 import { Loader } from "../Loader/Loader";
+import { ChartSkeleton, type ChartSkeletonVariant } from "./ChartSkeleton";
 
 /** Props for {@link ChartLoadingOverlay}. */
 export interface ChartLoadingOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Whether to show the loading overlay. @default false */
   loading?: boolean;
+  /**
+   * Shape of the wave-animated {@link ChartSkeleton} shown while loading. Set it
+   * to match the chart underneath — `circular` for pie/radial, `bar` for bar
+   * charts. Pass `false` to fall back to the legacy centred spinner.
+   * @default "area"
+   */
+  variant?: ChartSkeletonVariant | false;
   /** Chart content to render underneath the overlay. */
   children: React.ReactNode;
 }
 
 /**
- * A positioned overlay that displays a loading spinner on top of chart content.
- * The children are always rendered to maintain layout dimensions; the overlay
- * covers them with a semi-transparent background and a centered spinner.
+ * A positioned overlay shown on top of chart content while it loads. The children
+ * are always rendered to maintain layout dimensions.
+ *
+ * By default the overlay is opaque and shows a wave-animated
+ * {@link ChartSkeleton} shaped like the chart. At `variant={false}` it falls back
+ * to a semi-transparent wash with a centred spinner.
  *
  * @example
  * ```tsx
- * <ChartLoadingOverlay loading={isFetching}>
+ * <ChartLoadingOverlay loading={isFetching} variant="area">
  *   <ChartContainer config={config} className="min-h-48">
  *     <LineChart data={data}>...</LineChart>
  *   </ChartContainer>
@@ -25,13 +36,18 @@ export interface ChartLoadingOverlayProps extends React.HTMLAttributes<HTMLDivEl
  * ```
  */
 export const ChartLoadingOverlay = React.forwardRef<HTMLDivElement, ChartLoadingOverlayProps>(
-  ({ loading = false, children, className, ...props }, ref) => {
+  ({ loading = false, variant = "area", children, className, ...props }, ref) => {
     return (
       <div ref={ref} className={cn("relative", className)} {...props}>
         {children}
         {loading && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-surface-primary/60">
-            <Loader show center />
+          <div
+            className={cn(
+              "absolute inset-0 z-10 flex items-center justify-center",
+              variant ? "bg-background-primary" : "bg-surface-primary/60",
+            )}
+          >
+            {variant ? <ChartSkeleton variant={variant} /> : <Loader show center />}
           </div>
         )}
       </div>

--- a/src/components/Chart/ChartLoadingOverlay.tsx
+++ b/src/components/Chart/ChartLoadingOverlay.tsx
@@ -14,6 +14,12 @@ export interface ChartLoadingOverlayProps extends React.HTMLAttributes<HTMLDivEl
    * @default "area"
    */
   variant?: ChartSkeletonVariant | false;
+  /**
+   * Accessible name for the loading region, announced while `loading` is true.
+   * Pass a translated string for i18n. Only applies to the skeleton path; the
+   * `variant={false}` spinner carries its own label. @default "Loading chart"
+   */
+  loadingLabel?: string;
   /** Chart content to render underneath the overlay. */
   children: React.ReactNode;
 }
@@ -36,7 +42,17 @@ export interface ChartLoadingOverlayProps extends React.HTMLAttributes<HTMLDivEl
  * ```
  */
 export const ChartLoadingOverlay = React.forwardRef<HTMLDivElement, ChartLoadingOverlayProps>(
-  ({ loading = false, variant = "area", children, className, ...props }, ref) => {
+  (
+    {
+      loading = false,
+      variant = "area",
+      loadingLabel = "Loading chart",
+      children,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
     return (
       <div ref={ref} className={cn("relative", className)} {...props}>
         {children}
@@ -46,6 +62,17 @@ export const ChartLoadingOverlay = React.forwardRef<HTMLDivElement, ChartLoading
               "absolute inset-0 z-10 flex items-center justify-center",
               variant ? "bg-background-primary" : "bg-surface-primary/60",
             )}
+            // Every `Skeleton` is `aria-hidden`, so without this the skeleton path
+            // announces nothing where the spinner announced through its `<output>`.
+            // This is the contract `Skeleton`'s own doc comment asks callers to honour.
+            // Scoped to the skeleton path deliberately: adding it to the spinner path
+            // would nest a live region inside a live region and risk a double
+            // announcement.
+            {...(variant && {
+              role: "status",
+              "aria-busy": true,
+              "aria-label": loadingLabel,
+            })}
           >
             {variant ? <ChartSkeleton variant={variant} /> : <Loader show center />}
           </div>

--- a/src/components/Chart/ChartSkeleton.tsx
+++ b/src/components/Chart/ChartSkeleton.tsx
@@ -1,0 +1,147 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { Skeleton } from "../Skeleton/Skeleton";
+
+/**
+ * Shape the skeleton should imitate while data loads. `area` and `line` render
+ * the same filled band — a continuous series reads better as a band than as
+ * discrete bars. `table` and `rows` stand in for the two list bodies an insight
+ * card can hold rather than a chart: a ranked table, and a breakdown of labelled
+ * bars.
+ */
+export type ChartSkeletonVariant = "area" | "line" | "bar" | "circular" | "table" | "rows";
+
+/** Props for {@link ChartSkeleton}. */
+export interface ChartSkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Which shape to imitate. @default "area" */
+  variant?: ChartSkeletonVariant;
+  /**
+   * How many rows to draw, for the `table` and `rows` variants. Match the row
+   * count the loaded card will show, so the card does not resize once the real
+   * content arrives. @default 5
+   */
+  rows?: number;
+}
+
+const BAR_HEIGHTS = ["45%", "70%", "55%", "85%", "60%", "95%", "75%"];
+
+/** Varying label widths, so the rows do not read as a single solid block. */
+const LABEL_WIDTHS = ["w-24", "w-32", "w-20", "w-28", "w-24"];
+
+const labelWidth = (index: number) => LABEL_WIDTHS[index % LABEL_WIDTHS.length];
+
+const Bar = ({ className }: { className?: string }) => (
+  <Skeleton animation="wave" variant="rounded" className={className} />
+);
+
+/**
+ * A ranked table: the header, then one 48px row per entry holding a rank, an
+ * avatar and handle, and a value at the end — the columns {@link ChartCard}'s
+ * table bodies use.
+ */
+const TableSkeleton = ({ rows }: { rows: number }) => (
+  <div className="flex w-full flex-col">
+    <div className="flex h-8 items-center gap-3">
+      <Bar className="h-3 w-4" />
+      <Bar className="h-3 w-16" />
+      <Bar className="ml-auto h-3 w-12" />
+    </div>
+    {Array.from({ length: rows }, (_, index) => (
+      <div key={`table-row-${index}`} className="flex h-12 items-center gap-3">
+        <Bar className="h-4 w-4" />
+        <Skeleton animation="wave" variant="circular" className="size-6 shrink-0" />
+        <Bar className={cn("h-4", labelWidth(index))} />
+        <Bar className="ml-auto h-4 w-16" />
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * A breakdown list: per row a leading glyph and label with its share at the far
+ * end, then the bar underneath. Mirrors `Demographics`, down to its 8px inner gap
+ * and 8px `medium` bar, so the swap to real rows is invisible.
+ */
+const RowsSkeleton = ({ rows }: { rows: number }) => (
+  <div className="flex w-full flex-col gap-4">
+    {Array.from({ length: rows }, (_, index) => (
+      <div key={`row-${index}`} className="flex w-full flex-col gap-2">
+        <div className="flex w-full items-center justify-between gap-2">
+          <span className="flex items-center gap-2">
+            <Skeleton animation="wave" variant="circular" className="size-5 shrink-0" />
+            <Bar className={cn("h-4", labelWidth(index))} />
+          </span>
+          <Bar className="h-4 w-10 shrink-0" />
+        </div>
+        <Skeleton animation="wave" variant="rounded" className="h-2 w-full rounded-full" />
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * A wave-animated placeholder shaped like the content it stands in for — a chart
+ * series, a ranked table, or a breakdown of labelled bars. Use it while data
+ * loads instead of a generic spinner, so the layout does not visibly shift once
+ * the real content renders.
+ *
+ * For a chart body, pass it to {@link ChartLoadingOverlay} via its `variant` prop
+ * rather than rendering it directly. For a card body, pass it to `ChartCard`'s
+ * `skeleton` prop.
+ *
+ * @example
+ * ```tsx
+ * <ChartSkeleton variant="bar" className="h-48" />
+ * <ChartSkeleton variant="table" rows={5} />
+ * ```
+ */
+export const ChartSkeleton = React.forwardRef<HTMLDivElement, ChartSkeletonProps>(
+  ({ variant = "area", rows = 5, className, ...props }, ref) => {
+    if (variant === "table" || variant === "rows") {
+      return (
+        <div ref={ref} className={cn("w-full", className)} {...props}>
+          {variant === "table" ? <TableSkeleton rows={rows} /> : <RowsSkeleton rows={rows} />}
+        </div>
+      );
+    }
+
+    if (variant === "circular") {
+      return (
+        <div
+          ref={ref}
+          className={cn("flex size-full items-center justify-center", className)}
+          {...props}
+        >
+          <div className="relative aspect-square h-full">
+            <Skeleton animation="wave" variant="circular" className="size-full" />
+            <div className="absolute inset-[27%] rounded-full bg-background-primary" />
+          </div>
+        </div>
+      );
+    }
+
+    if (variant === "bar") {
+      return (
+        <div ref={ref} className={cn("flex size-full items-end gap-2", className)} {...props}>
+          {BAR_HEIGHTS.map((height, index) => (
+            <Skeleton
+              key={`bar-${index}`}
+              animation="wave"
+              variant="rounded"
+              className="flex-1"
+              height={height}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div ref={ref} className={cn("size-full", className)} {...props}>
+        <Skeleton animation="wave" variant="rounded" className="size-full" />
+      </div>
+    );
+  },
+);
+
+ChartSkeleton.displayName = "ChartSkeleton";

--- a/src/components/Chart/ChartSkeleton.tsx
+++ b/src/components/Chart/ChartSkeleton.tsx
@@ -16,14 +16,17 @@ export interface ChartSkeletonProps extends React.HTMLAttributes<HTMLDivElement>
   /** Which shape to imitate. @default "area" */
   variant?: ChartSkeletonVariant;
   /**
-   * How many rows to draw, for the `table` and `rows` variants. Match the row
-   * count the loaded card will show, so the card does not resize once the real
-   * content arrives. @default 5
+   * How many items to draw: rows for `table` and `rows`, bars for `bar`. Match
+   * the count the loaded card will show, so the card does not resize once the
+   * real content arrives. Defaults to 5 rows, or 7 bars.
    */
   rows?: number;
 }
 
+/** Varying bar heights, so the series does not read as a solid block. */
 const BAR_HEIGHTS = ["45%", "70%", "55%", "85%", "60%", "95%", "75%"];
+
+const barHeight = (index: number) => BAR_HEIGHTS[index % BAR_HEIGHTS.length];
 
 /** Varying label widths, so the rows do not read as a single solid block. */
 const LABEL_WIDTHS = ["w-24", "w-32", "w-20", "w-28", "w-24"];
@@ -96,11 +99,20 @@ const RowsSkeleton = ({ rows }: { rows: number }) => (
  * ```
  */
 export const ChartSkeleton = React.forwardRef<HTMLDivElement, ChartSkeletonProps>(
-  ({ variant = "area", rows = 5, className, ...props }, ref) => {
+  ({ variant = "area", rows, className, ...props }, ref) => {
+    // Resolved per variant so `rows` can drive the bar count without moving the bar
+    // default from 7 to the list default of 5.
+    const rowCount = rows ?? 5;
+    const bars = rows ?? BAR_HEIGHTS.length;
+
     if (variant === "table" || variant === "rows") {
       return (
         <div ref={ref} className={cn("w-full", className)} {...props}>
-          {variant === "table" ? <TableSkeleton rows={rows} /> : <RowsSkeleton rows={rows} />}
+          {variant === "table" ? (
+            <TableSkeleton rows={rowCount} />
+          ) : (
+            <RowsSkeleton rows={rowCount} />
+          )}
         </div>
       );
     }
@@ -112,9 +124,18 @@ export const ChartSkeleton = React.forwardRef<HTMLDivElement, ChartSkeletonProps
           className={cn("flex size-full items-center justify-center", className)}
           {...props}
         >
-          <div className="relative aspect-square h-full">
-            <Skeleton animation="wave" variant="circular" className="size-full" />
-            <div className="absolute inset-[27%] rounded-full bg-background-primary" />
+          <div className="aspect-square h-full">
+            {/*
+             * The hole is masked out rather than painted over. A disc filled with a
+             * surface colour only disappears on a surface of exactly that colour, and
+             * this renders standalone via `ChartCard`'s `skeleton` prop as well as
+             * inside `ChartLoadingOverlay`, so it cannot assume what is underneath.
+             */}
+            <Skeleton
+              animation="wave"
+              variant="circular"
+              className="size-full [mask-image:radial-gradient(circle,transparent_27%,black_28%)]"
+            />
           </div>
         </div>
       );
@@ -123,13 +144,13 @@ export const ChartSkeleton = React.forwardRef<HTMLDivElement, ChartSkeletonProps
     if (variant === "bar") {
       return (
         <div ref={ref} className={cn("flex size-full items-end gap-2", className)} {...props}>
-          {BAR_HEIGHTS.map((height, index) => (
+          {Array.from({ length: bars }, (_, index) => (
             <Skeleton
               key={`bar-${index}`}
               animation="wave"
               variant="rounded"
               className="flex-1"
-              height={height}
+              height={barHeight(index)}
             />
           ))}
         </div>


### PR DESCRIPTION
Adds `ChartSkeleton` — a wave-animated placeholder shaped like the content it stands in for — and teaches `ChartLoadingOverlay` to use it.

## Why

A centred spinner over a chart tells you nothing about what's arriving, and the layout jumps when the real series lands. A placeholder in the shape of the chart holds the space and reads as "this is a chart, loading".

Six shapes: `area`/`line` (one filled band — a continuous series reads better as a band than as bars), `bar`, `circular` for pie and radial, plus `table` and `rows` for the two list bodies an insight card can hold instead of a chart. `rows` mirrors `Demographics` down to its 8px inner gap and bar height, so the swap to real content is invisible.

## `ChartLoadingOverlay`

Gains `variant?: ChartSkeletonVariant | false`, defaulting to `"area"`. The overlay is now opaque and shows the skeleton; `variant={false}` keeps the old semi-transparent wash with a centred spinner.

**This changes the default rendering** for the 11 existing consumers — they get a shaped skeleton where they used to get a spinner. That's the intended improvement, but it's why this is labelled `chromatic`: worth eyeballing the diffs rather than taking my word for it. Any consumer that prefers the spinner can pass `variant={false}`.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- Chart suite — 103 tests passing, including per-variant coverage and a11y for the two list variants
- `pnpm build` clean. (Dropped the previous `size-limit` line: it measures `dist/index.mjs` and this ships in `charts.mjs`, so it could not have failed for this PR and told us nothing.)
- Stories added: `ChartSkeletons` (all six shapes) and `LoadingOverlayWithSkeleton`

## Note on the stack

First of three carving up the chart work, so no single PR mixes additive components with visual rewrites. The next two — `ChartCard`'s slots and loading header, then the tooltip's menu surface — are stacked on this one because `charts.ts`, `Chart.test.tsx` and `ChartHelpers.stories.tsx` are shared and would otherwise conflict repeatedly. Only the skeleton's own slice of those three files is in here.


## Review follow-ups

**Loading is now announced.** Swapping the overlay default from `Loader` to `ChartSkeleton` had silently removed the only signal telling assistive tech the chart was loading, for all 11 consumers, because every `Skeleton` is `aria-hidden`. Rendered both paths to confirm rather than reason about it:

| | `role=status` | `<output>` | accessible "loading" |
| --- | --- | --- | --- |
| skeleton (before) | 0 | 0 | 0 |
| spinner | 1 | 1 | 1 |

The overlay now carries `role="status"`, `aria-busy="true"` and an overridable `loadingLabel` (default `"Loading chart"`), following `Loader`'s own overridable `ariaLabel` rather than hardcoding English. Scoped to the skeleton path so the spinner path does not nest a live region inside `Loader`'s `<output>`.

The axe assertion that used to cover this could never have failed — axe reports violations in markup that exists, and `aria-hidden` markup has nothing to violate. Replaced with a direct `toHaveAccessibleName(/loading/i)`, plus coverage for a translated label and for not announcing when `loading={false}`.

**The donut hole is masked, not painted.** It was an opaque `bg-background-primary` disc, which only disappears on a surface of exactly that colour — and this renders standalone via `ChartCard`'s `skeleton` prop, not just inside the overlay. Now a radial mask, so the hole is a hole.

**`rows` drives the bar count.** A three-bar chart was getting a seven-bar skeleton, which is the shift the prop exists to prevent. Resolved per variant (`rows ?? 7` for bars, `rows ?? 5` for lists) so seven stays the bar default rather than becoming the only option, and no existing consumer's bar count moves.

## The default is deliberately not `variant={false}`

Calling this out explicitly rather than leaving Chromatic to reveal it, since it is the one thing here a consumer cannot discover from the types.

**This PR changes what the 11 existing `ChartLoadingOverlay` consumers render**: a shaped skeleton over an opaque `bg-background-primary`, where they previously got a centred spinner over a `bg-surface-primary/60` wash. The new behaviour is better and the loading state is now announced in both paths, so the default stays. Any consumer that wants the old rendering passes `variant={false}`.

Two consequences worth knowing. The overlay is opaque and specific rather than a tint, so a chart sitting on some other surface gets a matched block rather than a wash of whatever is beneath it — worth a look in the Chromatic diffs. And this ships on a minor, so it wants a release-note line.
