### PR TITLE
feat(TooltipLabel): add the underlined label trigger and two-row tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { InfoCircleIcon } from "../Icons/InfoCircleIcon";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./Tooltip";
+import { TooltipLabel } from "./TooltipLabel";
 
 const meta: Meta<typeof TooltipContent> = {
   title: "Components/Tooltip",
@@ -154,4 +155,21 @@ export const AllPlacements: Story = {
   parameters: {
     layout: "padded",
   },
+};
+
+export const LabelAsTrigger: Story = {
+  name: "Label as trigger (dashed underline)",
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/23x2vofTPkLpbcJyRdDa55/Creator---Management%E2%80%A8--Teams?node-id=8279-35515",
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-1">
+      <TooltipLabel tooltip="Total earnings for the selected period.">Total Earnings</TooltipLabel>
+      <span className="typography-header-heading-xl text-content-primary">$128,046.73</span>
+    </div>
+  ),
 };

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -40,45 +40,65 @@ export type TooltipPlacement =
   | "right-end";
 
 export interface TooltipContentProps
-  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
+  extends Omit<React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>, "title"> {
   /**
    * Position of the tooltip relative to the trigger. Takes precedence over `side` and `align`.
    * @default "top"
    */
   placement?: TooltipPlacement;
+  /**
+   * Optional heading above the body, for the two-row tooltip: a bold label
+   * naming the thing, then a plain-weight description of it. Without it the
+   * tooltip is a single bold line.
+   */
+  title?: React.ReactNode;
 }
 
 export const TooltipContent = React.forwardRef<
   React.ComponentRef<typeof TooltipPrimitive.Content>,
   TooltipContentProps
->(({ className, sideOffset = 8, style, placement, side, align, ...props }, ref) => {
-  let resolvedSide = side;
-  let resolvedAlign: "start" | "center" | "end" = align ?? "center";
-  if (placement) {
-    const [parsedSide, parsedAlign] = placement.split("-") as [
-      "top" | "right" | "bottom" | "left",
-      "start" | "end" | undefined,
-    ];
-    resolvedSide = parsedSide;
-    resolvedAlign = parsedAlign ?? "center";
-  }
+>(
+  (
+    { className, sideOffset = 8, style, placement, side, align, title, children, ...props },
+    ref,
+  ) => {
+    let resolvedSide = side;
+    let resolvedAlign: "start" | "center" | "end" = align ?? "center";
+    if (placement) {
+      const [parsedSide, parsedAlign] = placement.split("-") as [
+        "top" | "right" | "bottom" | "left",
+        "start" | "end" | undefined,
+      ];
+      resolvedSide = parsedSide;
+      resolvedAlign = parsedAlign ?? "center";
+    }
 
-  return (
-    <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
-        ref={ref}
-        side={resolvedSide}
-        align={resolvedAlign}
-        sideOffset={sideOffset}
-        collisionPadding={8}
-        style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
-        className={cn(
-          "typography-description-12px-semibold max-w-[320px] rounded-sm bg-surface-primary-inverted px-4 py-2 text-content-primary-inverted shadow-[0px_1px_4px_0px_rgba(0,0,0,0.06),0px_1px_3px_0px_rgba(0,0,0,0.05)]",
-          className,
-        )}
-        {...props}
-      />
-    </TooltipPrimitive.Portal>
-  );
-});
+    return (
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          ref={ref}
+          side={resolvedSide}
+          align={resolvedAlign}
+          sideOffset={sideOffset}
+          collisionPadding={8}
+          style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
+          className={cn(
+            "typography-description-12px-semibold max-w-[320px] rounded-sm bg-surface-primary-inverted px-4 py-2 text-content-primary-inverted shadow-[0px_1px_4px_0px_rgba(0,0,0,0.06),0px_1px_3px_0px_rgba(0,0,0,0.05)]",
+            className,
+          )}
+          {...props}
+        >
+          {title ? (
+            <span className="flex flex-col gap-1">
+              <span>{title}</span>
+              <span className="typography-description-12px-regular">{children}</span>
+            </span>
+          ) : (
+            children
+          )}
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    );
+  },
+);
 TooltipContent.displayName = "TooltipContent";

--- a/src/components/Tooltip/TooltipLabel.test.tsx
+++ b/src/components/Tooltip/TooltipLabel.test.tsx
@@ -45,17 +45,31 @@ describe("TooltipLabel", () => {
   it("marks the label with a dashed underline rather than an icon", () => {
     render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
     const trigger = screen.getByRole("button", { name: "Revenue" });
-    expect(trigger.className).toContain("bg-repeat-x");
+    expect(trigger.querySelector("span")?.className).toContain("bg-repeat-x");
     expect(trigger.querySelector("svg")).toBeNull();
+  });
+
+  it("draws the dash on the label text, not the trigger box", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+    const label = trigger.querySelector("span");
+    // The button is block-level and stretches to its container, so a dash painted
+    // on it runs the width of the row instead of the word. It belongs on the
+    // inline span, which is only ever as wide as the text.
+    expect(label?.textContent).toBe("Revenue");
+    expect(label?.className).toContain("bg-repeat-x");
+    expect(trigger.className).not.toContain("bg-repeat-x");
+    // And the trigger itself hugs the label, so hover does not answer across the row.
+    expect(trigger.className).toContain("w-fit");
   });
 
   it("anchors the dash pattern to the left edge so it does not clip mid-dash", () => {
     render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
-    const trigger = screen.getByRole("button", { name: "Revenue" });
-    expect(trigger.className).toContain("bg-bottom-left");
+    const label = screen.getByRole("button", { name: "Revenue" }).querySelector("span");
+    expect(label?.className).toContain("bg-bottom-left");
     // Not the bare `bg-bottom`, which centres the tile and lays the pattern out
     // from the middle outward.
-    expect(trigger.className).not.toMatch(/\bbg-bottom(?![\w-])/);
+    expect(label?.className).not.toMatch(/\bbg-bottom(?![\w-])/);
   });
 
   it("stays open after a tap, rather than flashing", () => {

--- a/src/components/Tooltip/TooltipLabel.test.tsx
+++ b/src/components/Tooltip/TooltipLabel.test.tsx
@@ -72,6 +72,25 @@ describe("TooltipLabel", () => {
     expect(label?.className).not.toMatch(/\bbg-bottom(?![\w-])/);
   });
 
+  it("does not repeat the label in the trigger's description", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+    tap(trigger);
+    // Radix wires the whole tooltip as the trigger's `aria-describedby`, and the
+    // trigger's name is already this label, so an exposed heading described the
+    // button as "RevenueExplains it". Assert the computed description rather than
+    // textContent, which ignores `aria-hidden` and would pass either way.
+    expect(trigger).toHaveAccessibleName("Revenue");
+    expect(trigger).toHaveAccessibleDescription("Explains it");
+  });
+
+  it("still shows the label as the tooltip's visible heading", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    tap(screen.getByRole("button", { name: "Revenue" }));
+    // Hidden from assistive tech, still on screen: the two-row block is the design.
+    expect(screen.getAllByText("Revenue").length).toBeGreaterThan(1);
+  });
+
   it("stays open after a tap, rather than flashing", () => {
     render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
     tap(screen.getByRole("button", { name: "Revenue" }));

--- a/src/components/Tooltip/TooltipLabel.test.tsx
+++ b/src/components/Tooltip/TooltipLabel.test.tsx
@@ -1,0 +1,127 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { TooltipLabel } from "./TooltipLabel";
+
+/**
+ * A tap, as the browser sequences it. `focused` reflects whether the label
+ * already has focus: after the first tap it does, so no further focus event
+ * fires and the tap alone has to drive the tooltip.
+ */
+const tap = (trigger: HTMLElement, { focused = false }: { focused?: boolean } = {}) => {
+  fireEvent.pointerDown(trigger, { pointerType: "touch" });
+  fireEvent.pointerUp(trigger, { pointerType: "touch" });
+  if (!focused) fireEvent.focus(trigger);
+  fireEvent.click(trigger, { detail: 1 });
+};
+
+/**
+ * Dismissing by tapping the page, which leaves the label focused. Radix attaches
+ * its outside-pointerdown listener in a deferred task so the tap that opened the
+ * tooltip cannot immediately dismiss it, so wait for that before tapping.
+ */
+const tapOutside = async () => {
+  await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+  fireEvent.pointerDown(document.body, { pointerType: "touch" });
+  fireEvent.pointerUp(document.body, { pointerType: "touch" });
+  // For touch, Radix holds the outside dismissal back until the click that
+  // follows the pointerdown, so the tooltip is not dismissed without it.
+  fireEvent.click(document.body, { detail: 1 });
+};
+
+const isTooltipVisible = () => screen.queryAllByText("Explains it").length > 0;
+
+describe("TooltipLabel", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("takes its accessible name from the visible label", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    expect(screen.getByRole("button", { name: "Revenue" })).toBeInTheDocument();
+  });
+
+  it("marks the label with a dashed underline rather than an icon", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+    expect(trigger.className).toContain("bg-repeat-x");
+    expect(trigger.querySelector("svg")).toBeNull();
+  });
+
+  it("anchors the dash pattern to the left edge so it does not clip mid-dash", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+    expect(trigger.className).toContain("bg-bottom-left");
+    // Not the bare `bg-bottom`, which centres the tile and lays the pattern out
+    // from the middle outward.
+    expect(trigger.className).not.toMatch(/\bbg-bottom(?![\w-])/);
+  });
+
+  it("stays open after a tap, rather than flashing", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    tap(screen.getByRole("button", { name: "Revenue" }));
+    expect(isTooltipVisible()).toBe(true);
+  });
+
+  it("reopens on a second tap after being dismissed", async () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+
+    tap(trigger);
+    expect(isTooltipVisible()).toBe(true);
+
+    await tapOutside();
+    expect(isTooltipVisible()).toBe(false);
+
+    // The label still holds focus here, so there is no focus event left to open
+    // the tooltip — the tap has to do it.
+    tap(trigger, { focused: true });
+    expect(isTooltipVisible()).toBe(true);
+  });
+
+  it("closes when the open tooltip's label is tapped again", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+
+    tap(trigger);
+    expect(isTooltipVisible()).toBe(true);
+
+    tap(trigger, { focused: true });
+    expect(isTooltipVisible()).toBe(false);
+  });
+
+  it("still lets a mouse click dismiss the tooltip", () => {
+    render(<TooltipLabel tooltip="Explains it">Revenue</TooltipLabel>);
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+    fireEvent.pointerDown(trigger, { pointerType: "mouse" });
+    fireEvent.pointerUp(trigger, { pointerType: "mouse" });
+    fireEvent.focus(trigger);
+    fireEvent.click(trigger, { detail: 1 });
+    expect(screen.queryByText("Explains it")).not.toBeInTheDocument();
+  });
+
+  it("still calls a caller's own click and pointerdown handlers", () => {
+    const onClick = vi.fn();
+    const onPointerDown = vi.fn();
+    render(
+      <TooltipLabel tooltip="Explains it" onClick={onClick} onPointerDown={onPointerDown}>
+        Revenue
+      </TooltipLabel>,
+    );
+    tap(screen.getByRole("button", { name: "Revenue" }));
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(onPointerDown).toHaveBeenCalledOnce();
+  });
+
+  it("forwards className and button attributes", () => {
+    render(
+      <TooltipLabel tooltip="Explains it" className="w-full" data-testid="label">
+        Revenue
+      </TooltipLabel>,
+    );
+    const trigger = screen.getByRole("button", { name: "Revenue" });
+    expect(trigger.className).toContain("w-full");
+    expect(trigger).toHaveAttribute("data-testid", "label");
+  });
+});

--- a/src/components/Tooltip/TooltipLabel.tsx
+++ b/src/components/Tooltip/TooltipLabel.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./Tooltip";
+
+/** Props for {@link TooltipLabel}. */
+export interface TooltipLabelProps extends React.ComponentPropsWithoutRef<"button"> {
+  /** Tooltip content. Pass a translated string for i18n. */
+  tooltip: React.ReactNode;
+  /** The label text, which doubles as the trigger. */
+  children: React.ReactNode;
+}
+
+/**
+ * A text label that is itself the tooltip trigger, marked by a dashed
+ * underline. Use this instead of pairing a label with a separate info glyph:
+ * the visible text becomes the trigger's accessible name, and the row stays at
+ * text height rather than being stretched by an icon button.
+ *
+ * The label is repeated as the tooltip's heading, so the tooltip reads as the
+ * two-row block the design specifies — the term, then what it means.
+ *
+ * Tapping the label toggles the tooltip on touch devices, where there is no
+ * hover to trigger it. Tapping elsewhere, scrolling, or opening another tooltip
+ * dismisses it.
+ *
+ * @example
+ * ```tsx
+ * <TooltipLabel tooltip="Total earnings for the selected period.">Total Earnings</TooltipLabel>
+ * ```
+ */
+export const TooltipLabel = React.forwardRef<HTMLButtonElement, TooltipLabelProps>(
+  ({ tooltip, children, className, onClick, onPointerDown, onBlur, ...props }, ref) => {
+    /*
+     * Touch has to drive the tooltip from the tap itself, not from focus.
+     *
+     * Radix's trigger ignores pointer events whose `pointerType` is "touch", so
+     * hover never opens the tooltip on a phone; focus is the only thing that
+     * does. That is not enough on its own for two reasons, and both need the
+     * open state controlled here:
+     *
+     *   - The trigger closes on click. Since the tap that focuses the label is
+     *     also a click, focus opens the tooltip and the click immediately shuts
+     *     it, so it only flashes.
+     *   - After the first tap the label keeps focus. Dismissing the tooltip by
+     *     tapping elsewhere leaves it focused, so a second tap fires no focus
+     *     event and nothing would reopen it.
+     *
+     * Radix composes trigger handlers with `checkForDefaultPrevented`, so
+     * calling `preventDefault` makes it skip its own open/close and leaves the
+     * toggle below in charge. Dismissal still comes from Radix: `TooltipContent`
+     * closes on outside pointerdown, Escape, scroll, and when another tooltip
+     * opens.
+     *
+     * All of this is scoped to touch, so mouse and keyboard behave as before.
+     */
+    const [open, setOpen] = React.useState(false);
+    const pointerTypeRef = React.useRef<string>("");
+    /**
+     * The open state as it was when the tap began. The trigger's own pointerdown
+     * close lands between pointerdown and click, so toggling against the live
+     * state would read the value Radix just reset and reopen on every tap.
+     */
+    const openAtTapStartRef = React.useRef(false);
+
+    const isTouch = () => pointerTypeRef.current === "touch";
+
+    return (
+      <TooltipProvider>
+        <Tooltip open={open} onOpenChange={setOpen}>
+          <TooltipTrigger asChild>
+            <button
+              ref={ref}
+              type="button"
+              className={cn(
+                "typography-body-small-14px-regular cursor-help rounded-2xs text-left text-content-secondary outline-none",
+                // Anchor the 4-on/4-off tile to the left edge. A centred position (the
+                // `bg-bottom` default) lays the pattern out from the middle outward and
+                // clips mid-dash at the start of the label as well as the end.
+                //
+                // No bottom padding: the dash sits in the descender space the 18px
+                // line-height already leaves under the 14px text. Padding it out made
+                // the label 20px, and since this label is the entire header of a
+                // title-only insight card, that put the card over its designed height.
+                "bg-[length:8px_1px] bg-[linear-gradient(to_right,var(--color-icons-tertiary)_0_4px,transparent_4px_8px)] bg-bottom-left bg-repeat-x",
+                "hover:text-content-primary focus-visible:shadow-focus-ring",
+                className,
+              )}
+              onPointerDown={(event) => {
+                pointerTypeRef.current = event.pointerType;
+                openAtTapStartRef.current = open;
+                onPointerDown?.(event);
+              }}
+              onClick={(event) => {
+                onClick?.(event);
+                if (!isTouch()) return;
+                event.preventDefault();
+                setOpen(!openAtTapStartRef.current);
+              }}
+              onBlur={(event) => {
+                // Forget the pointer type once the label loses focus, so a later
+                // keyboard focus still opens the tooltip on a device that has
+                // both a touchscreen and a keyboard.
+                pointerTypeRef.current = "";
+                onBlur?.(event);
+              }}
+              {...props}
+            >
+              {children}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent title={children}>{tooltip}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  },
+);
+
+TooltipLabel.displayName = "TooltipLabel";

--- a/src/components/Tooltip/TooltipLabel.tsx
+++ b/src/components/Tooltip/TooltipLabel.tsx
@@ -72,16 +72,11 @@ export const TooltipLabel = React.forwardRef<HTMLButtonElement, TooltipLabelProp
               ref={ref}
               type="button"
               className={cn(
-                "typography-body-small-14px-regular cursor-help rounded-2xs text-left text-content-secondary outline-none",
-                // Anchor the 4-on/4-off tile to the left edge. A centred position (the
-                // `bg-bottom` default) lays the pattern out from the middle outward and
-                // clips mid-dash at the start of the label as well as the end.
-                //
-                // No bottom padding: the dash sits in the descender space the 18px
-                // line-height already leaves under the 14px text. Padding it out made
-                // the label 20px, and since this label is the entire header of a
-                // title-only insight card, that put the card over its designed height.
-                "bg-[length:8px_1px] bg-[linear-gradient(to_right,var(--color-icons-tertiary)_0_4px,transparent_4px_8px)] bg-bottom-left bg-repeat-x",
+                // `w-fit` keeps the trigger the size of its label. The button is
+                // block-level, so a column flex or grid cell would otherwise stretch it
+                // and the whole row would answer to hover with a help cursor, opening
+                // this label's tooltip from a long way away from the label.
+                "typography-body-small-14px-regular w-fit cursor-help rounded-2xs text-left text-content-secondary outline-none",
                 "hover:text-content-primary focus-visible:shadow-focus-ring",
                 className,
               )}
@@ -105,7 +100,24 @@ export const TooltipLabel = React.forwardRef<HTMLButtonElement, TooltipLabelProp
               }}
               {...props}
             >
-              {children}
+              {/*
+               * The dash lives on this inline span, not the button. The button is a
+               * block-level trigger and stretches to whatever its container gives it —
+               * a column flex or grid cell makes it full width — which dragged the
+               * underline across the whole row instead of the label.
+               *
+               * Anchor the 4-on/4-off tile to the left edge. A centred position (the
+               * `bg-bottom` default) lays the pattern out from the middle outward and
+               * clips mid-dash at the start of the label as well as the end.
+               *
+               * No bottom padding: the dash sits in the descender space the 18px
+               * line-height already leaves under the 14px text. Padding it out made
+               * the label 20px, and since this label is the entire header of a
+               * title-only insight card, that put the card over its designed height.
+               */}
+              <span className="bg-[length:8px_1px] bg-[linear-gradient(to_right,var(--color-icons-tertiary)_0_4px,transparent_4px_8px)] bg-bottom-left bg-repeat-x">
+                {children}
+              </span>
             </button>
           </TooltipTrigger>
           <TooltipContent title={children}>{tooltip}</TooltipContent>

--- a/src/components/Tooltip/TooltipLabel.tsx
+++ b/src/components/Tooltip/TooltipLabel.tsx
@@ -3,7 +3,10 @@ import { cn } from "../../utils/cn";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./Tooltip";
 
 /** Props for {@link TooltipLabel}. */
-export interface TooltipLabelProps extends React.ComponentPropsWithoutRef<"button"> {
+export interface TooltipLabelProps
+  // `title` is omitted so a native browser tooltip cannot appear alongside the
+  // Radix one on the same element. `TooltipContentProps` omits it too.
+  extends Omit<React.ComponentPropsWithoutRef<"button">, "title"> {
   /** Tooltip content. Pass a translated string for i18n. */
   tooltip: React.ReactNode;
   /** The label text, which doubles as the trigger. */
@@ -120,7 +123,14 @@ export const TooltipLabel = React.forwardRef<HTMLButtonElement, TooltipLabelProp
               </span>
             </button>
           </TooltipTrigger>
-          <TooltipContent title={children}>{tooltip}</TooltipContent>
+          {/*
+           * The heading is hidden from assistive tech. Radix wires the whole content
+           * as the trigger's `aria-describedby`, and the trigger's name is already
+           * this same label, so leaving it exposed described the button as
+           * "Total EarningsTotal earnings for the selected period." It stays visible,
+           * since the two-row block is the point of the design.
+           */}
+          <TooltipContent title={<span aria-hidden>{children}</span>}>{tooltip}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -838,6 +838,8 @@ export {
   TooltipProvider,
   TooltipTrigger,
 } from "./components/Tooltip/Tooltip";
+export type { TooltipLabelProps } from "./components/Tooltip/TooltipLabel";
+export { TooltipLabel } from "./components/Tooltip/TooltipLabel";
 export type { UserDisplayNameProps } from "./components/UserDisplayName/UserDisplayName";
 export { UserDisplayName } from "./components/UserDisplayName/UserDisplayName";
 export type { UserHandleProps } from "./components/UserHandle/UserHandle";


### PR DESCRIPTION
Adds `TooltipLabel` — a text label that is itself the tooltip trigger, marked by a dashed underline — plus the `title` prop on `TooltipContent` that it needs.

## Why

The pattern this replaces is a label beside a separate info glyph. That has two problems: the glyph is an icon button, so it stretches the row past text height, and the accessible name ends up on the glyph rather than the words the user is reading.

Here the visible text *is* the trigger, so it carries its own accessible name and the row stays at text height. The label is repeated as the tooltip's heading, giving the two-row block the design specifies — the term, then what it means.

## `TooltipContent.title`

Optional heading above the body: bold label, plain-weight description. Without it the tooltip is a single bold line exactly as before, so **all 62 existing consumers are unchanged**.

One type detail: `TooltipContentProps` now `Omit`s `title` from the underlying HTML attributes, because `HTMLAttributes` already declares it as `string` and we need `ReactNode`. That's a narrowing on a prop nobody was passing as a native tooltip attribute.

## Touch behaviour

Radix tooltips don't open on touch — its trigger ignores pointer events whose `pointerType` is `"touch"`, so focus is the only thing that opens them, and the trigger closes on click. A tap therefore made the tooltip flash and vanish. Worse, once the label had focus, dismissing and tapping again fired no focus event at all, so it couldn't be reopened.

`TooltipLabel` controls its own open state on touch and toggles from the tap, snapshotting the state at `pointerdown` because Radix's own close lands between `pointerdown` and `click`. Dismissal still comes from Radix — outside tap, Escape, scroll, another tooltip opening. Mouse and keyboard paths are untouched.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- Tooltip suite — 25 tests passing, including the tap-to-open, tap-to-reopen-after-dismiss and toggle-closed sequences, and one asserting a **mouse** click still dismisses, which is what proves the change is scoped to touch
- `pnpm build` clean, `TooltipLabel` present in `dist/index.d.ts`
- Story added

## Deliberately not in here

`Tooltip.tsx` on the insights branch also carries a 700ms → 200ms provider-delay default and fade animations. Both are left out: the delay change affects every tooltip in the product and needs to stay independently revertable, especially since `ChartCard` will depend on `TooltipLabel` landing.
