### PR TITLE
feat(tokens): add the missing yellow, lime and red chart colours

### DIFF
--- a/src/styles/styleTokens.json
+++ b/src/styles/styleTokens.json
@@ -2531,6 +2531,21 @@
                   "exportKey": "variables"
                 }
               }
+            },
+            "yellow": {
+              "type": "color",
+              "value": "#f5d90aff",
+              "blendMode": "normal"
+            },
+            "lime": {
+              "type": "color",
+              "value": "#8fcb3aff",
+              "blendMode": "normal"
+            },
+            "red": {
+              "type": "color",
+              "value": "#ff4d4dff",
+              "blendMode": "normal"
             }
           },
           "default": {
@@ -6172,6 +6187,21 @@
                   "exportKey": "variables"
                 }
               }
+            },
+            "yellow": {
+              "type": "color",
+              "value": "#f5d90aff",
+              "blendMode": "normal"
+            },
+            "lime": {
+              "type": "color",
+              "value": "#8fcb3aff",
+              "blendMode": "normal"
+            },
+            "red": {
+              "type": "color",
+              "value": "#ff4d4dff",
+              "blendMode": "normal"
             }
           },
           "default": {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -133,6 +133,9 @@
   --color-special-chart-gray: #c6c6c6ff;
   --color-special-chart-pink: #ff59acff;
   --color-special-chart-purple: #785dffff;
+  --color-special-chart-yellow: #f5d90aff;
+  --color-special-chart-lime: #8fcb3aff;
+  --color-special-chart-red: #ff4d4dff;
   --color-special-default: #9c27b0ff;
   --color-special-background: #fdf1ffff;
   --color-brand-primary-default: var(--primitives-color-green-500);
@@ -524,6 +527,9 @@
   --color-special-chart-gray: #c6c6c6ff;
   --color-special-chart-pink: #ff59acff;
   --color-special-chart-purple: #785dffff;
+  --color-special-chart-yellow: #f5d90aff;
+  --color-special-chart-lime: #8fcb3aff;
+  --color-special-chart-red: #ff4d4dff;
   --color-special-default: #9c27b0ff;
   --color-special-background: #fdf1ffff;
   --color-brand-primary-default: var(--primitives-color-green-500);
@@ -738,6 +744,9 @@
   --color-special-chart-gray: #c6c6c6ff;
   --color-special-chart-pink: #ff59acff;
   --color-special-chart-purple: #785dffff;
+  --color-special-chart-yellow: #f5d90aff;
+  --color-special-chart-lime: #8fcb3aff;
+  --color-special-chart-red: #ff4d4dff;
   --color-special-default: #ed81ffff;
   --color-special-background: #4f1259ff;
   --color-brand-primary-default: var(--primitives-color-green-500);


### PR DESCRIPTION
Adds the three chart colours the V2 insights frames use but the token set was missing: `special/chart/yellow`, `special/chart/lime` and `special/chart/red`.

## Why

The agency earnings chart plots nine categories. Six had tokens; three were absent, so those series had no legitimate colour to reach for.

Values come straight from the Figma frame's bound variables:

| Token | Value |
|---|---|
| `special/chart/yellow` | `#f5d90a` |
| `special/chart/lime` | `#8fcb3a` |
| `special/chart/red` | `#ff4d4d` |

`lime` and `red` are also what `ChartMetricTrend` reaches for later, which is why they land ahead of it.

## Blast radius

**None.** Purely additive — three new custom properties with no existing consumer, defined identically across the light, `:root` and `.dark` blocks as the rest of the chart ramp is.

## Note on `theme.css`

That file carries an `AUTO-GENERATED — do not edit` header. The change is made in `src/styles/styleTokens.json` and the CSS regenerated with `node src/styles/buildStyles.js`. I re-ran the generator on this branch and it produced no diff, which confirms the committed CSS matches the tokens rather than having been hand-edited.

## Verification

- `pnpm lint`, `pnpm typecheck` clean
- Full suite — 178 files / 4455 tests passing
- Generator re-run produces no diff
