### PR TITLE
fix(CyclingText): read reduced motion during render, split out the motion hook

### DIFF
--- a/src/components/CyclingText/CyclingText.test.tsx
+++ b/src/components/CyclingText/CyclingText.test.tsx
@@ -151,6 +151,54 @@ describe("CyclingText", () => {
     });
   });
 
+  describe("reduced motion", () => {
+    afterEach(() => {
+      Reflect.deleteProperty(window, "matchMedia");
+    });
+
+    const stubReducedMotion = (matches: boolean) => {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: vi.fn((query: string) => ({
+          matches,
+          media: query,
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        })),
+      });
+    };
+
+    it("drops the transition when the user prefers reduced motion", () => {
+      stubReducedMotion(true);
+      render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={200} />);
+
+      act(() => vi.advanceTimersByTime(500));
+      expect(getIncomingLabel()).toHaveStyle({ transition: "none" });
+    });
+
+    it("keeps the transition when the user has no preference", () => {
+      stubReducedMotion(false);
+      render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={200} />);
+
+      act(() => vi.advanceTimersByTime(500));
+      expect(getIncomingLabel()?.getAttribute("style")).toContain("200ms");
+    });
+
+    it("still advances the cycle with no transition to wait on", () => {
+      stubReducedMotion(true);
+      render(<CyclingText items={ITEMS} intervalMs={500} transitionMs={200} />);
+
+      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(200));
+      expect(getVisibleLabel().textContent).toBe("Beta");
+    });
+  });
+
   describe("onActiveIndexChange", () => {
     it("reports the initial index on mount", () => {
       const onActiveIndexChange = vi.fn();

--- a/src/components/CyclingText/CyclingText.tsx
+++ b/src/components/CyclingText/CyclingText.tsx
@@ -1,14 +1,12 @@
 import * as React from "react";
 import { cn } from "../../utils/cn";
-import { usePrefersReducedMotion } from "../../utils/usePrefersReducedMotion";
 import { useCyclingCycle } from "./useCyclingCycle";
+import { useCyclingMotion } from "./useCyclingMotion";
 import { useCyclingTextTrackWidth } from "./useCyclingTextTrackWidth";
 import { usePageVisibility } from "./usePageVisibility";
 
 const DEFAULT_INTERVAL_MS = 2100;
 const DEFAULT_TRANSITION_MS = 200;
-
-const SLIDE_OFFSET_PX = 18;
 
 /** How the wrapper should be sized to accommodate variable-length items. */
 export type CyclingTextSizing = "longest" | "current";
@@ -82,7 +80,6 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
     ref,
   ) => {
     const docVisible = usePageVisibility();
-    const reducedMotion = usePrefersReducedMotion();
     const { sizingLabelRef, trackWidth } = useCyclingTextTrackWidth();
     const {
       cycle,
@@ -106,33 +103,12 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
       onActiveIndexChangeRef.current?.(currentIndex);
     }, [currentIndex]);
 
-    const outgoingMotionStyle = React.useMemo((): React.CSSProperties => {
-      const durMs = reducedMotion ? 0 : transitionMs;
-      const exiting = cycle.transitioning;
-      const yExit = direction === "up" ? -SLIDE_OFFSET_PX : SLIDE_OFFSET_PX;
-      return {
-        opacity: exiting ? 0 : 1,
-        transform: exiting ? `translate3d(0, ${yExit}px, 0)` : "translate3d(0, 0, 0)",
-        transition:
-          exiting && durMs > 0
-            ? `opacity ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1), transform ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1)`
-            : "none",
-      };
-    }, [cycle.transitioning, direction, transitionMs, reducedMotion]);
-
-    const incomingMotionStyle = React.useMemo((): React.CSSProperties => {
-      const durMs = reducedMotion ? 0 : transitionMs;
-      const entered = cycle.incomingEntered;
-      const yEnter = direction === "up" ? SLIDE_OFFSET_PX : -SLIDE_OFFSET_PX;
-      return {
-        opacity: entered ? 1 : 0,
-        transform: entered ? "translate3d(0, 0, 0)" : `translate3d(0, ${yEnter}px, 0)`,
-        transition:
-          durMs > 0
-            ? `opacity ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1), transform ${durMs}ms cubic-bezier(0.4, 0, 0.2, 1)`
-            : "none",
-      };
-    }, [cycle.incomingEntered, direction, transitionMs, reducedMotion]);
+    const { outgoingStyle, incomingStyle } = useCyclingMotion({
+      transitioning: cycle.transitioning,
+      incomingEntered: cycle.incomingEntered,
+      direction,
+      transitionMs,
+    });
 
     if (itemCount === 0) {
       return null;
@@ -140,7 +116,6 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
 
     const wrapperStyle = {
       ...(trackWidth !== null ? { width: `${trackWidth}px` } : {}),
-      // paddingTop: SLIDE_OFFSET_PX,
     } as React.CSSProperties;
 
     const showIncoming = incomingLabel !== null && cycle.transitioning;
@@ -179,7 +154,7 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
             "absolute inset-0 flex items-center whitespace-nowrap leading-[inherit]",
             labelClassName,
           )}
-          style={outgoingMotionStyle}
+          style={outgoingStyle}
         >
           {currentLabel}
         </span>
@@ -193,7 +168,7 @@ export const CyclingText = React.forwardRef<HTMLSpanElement, CyclingTextProps>(
               "absolute inset-0 flex items-center whitespace-nowrap leading-[inherit]",
               labelClassName,
             )}
-            style={incomingMotionStyle}
+            style={incomingStyle}
           >
             {incomingLabel}
           </span>

--- a/src/components/CyclingText/useCyclingMotion.ts
+++ b/src/components/CyclingText/useCyclingMotion.ts
@@ -23,10 +23,9 @@ export interface CyclingMotion {
 /**
  * Inline styles driving the slide and cross-fade between two cycling items.
  *
- * Kept as inline styles rather than utility classes because `transitionMs` is a
- * runtime prop. Reduced motion collapses the duration to zero, which leaves the
- * end states intact so items still swap, just without the movement; the cycle
- * itself is advanced by the fallback timer in `useCyclingCycle`, not by
+ * Inline rather than utility classes because `transitionMs` is a runtime prop.
+ * Reduced motion collapses the duration to zero, leaving the end states intact;
+ * the cycle is advanced by the fallback timer in `useCyclingCycle`, not by
  * `transitionend`, so it keeps running when no transition fires.
  */
 export function useCyclingMotion({

--- a/src/components/CyclingText/useCyclingMotion.ts
+++ b/src/components/CyclingText/useCyclingMotion.ts
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { usePrefersReducedMotion } from "../../utils/usePrefersReducedMotion";
+
+const SLIDE_OFFSET_PX = 18;
+const EASING = "cubic-bezier(0.4, 0, 0.2, 1)";
+
+export interface CyclingMotionOptions {
+  /** True while the outgoing item is sliding out and the incoming one is sliding in. */
+  transitioning: boolean;
+  /** True once the incoming item has been moved to its resting position. */
+  incomingEntered: boolean;
+  /** Direction the outgoing item slides. */
+  direction: "up" | "down";
+  /** Slide and cross-fade duration in milliseconds. */
+  transitionMs: number;
+}
+
+export interface CyclingMotion {
+  outgoingStyle: React.CSSProperties;
+  incomingStyle: React.CSSProperties;
+}
+
+/**
+ * Inline styles driving the slide and cross-fade between two cycling items.
+ *
+ * Kept as inline styles rather than utility classes because `transitionMs` is a
+ * runtime prop. Reduced motion collapses the duration to zero, which leaves the
+ * end states intact so items still swap, just without the movement; the cycle
+ * itself is advanced by the fallback timer in `useCyclingCycle`, not by
+ * `transitionend`, so it keeps running when no transition fires.
+ */
+export function useCyclingMotion({
+  transitioning,
+  incomingEntered,
+  direction,
+  transitionMs,
+}: CyclingMotionOptions): CyclingMotion {
+  const reducedMotion = usePrefersReducedMotion();
+  const durMs = reducedMotion ? 0 : transitionMs;
+
+  const outgoingStyle = React.useMemo((): React.CSSProperties => {
+    const yExit = direction === "up" ? -SLIDE_OFFSET_PX : SLIDE_OFFSET_PX;
+    return {
+      opacity: transitioning ? 0 : 1,
+      transform: transitioning ? `translate3d(0, ${yExit}px, 0)` : "translate3d(0, 0, 0)",
+      // Only while exiting: returning to idle should snap, not animate back.
+      transition:
+        transitioning && durMs > 0
+          ? `opacity ${durMs}ms ${EASING}, transform ${durMs}ms ${EASING}`
+          : "none",
+    };
+  }, [transitioning, direction, durMs]);
+
+  const incomingStyle = React.useMemo((): React.CSSProperties => {
+    const yEnter = direction === "up" ? SLIDE_OFFSET_PX : -SLIDE_OFFSET_PX;
+    return {
+      opacity: incomingEntered ? 1 : 0,
+      transform: incomingEntered ? "translate3d(0, 0, 0)" : `translate3d(0, ${yEnter}px, 0)`,
+      transition:
+        durMs > 0 ? `opacity ${durMs}ms ${EASING}, transform ${durMs}ms ${EASING}` : "none",
+    };
+  }, [incomingEntered, direction, durMs]);
+
+  return { outgoingStyle, incomingStyle };
+}

--- a/src/utils/usePrefersReducedMotion.test.tsx
+++ b/src/utils/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,106 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
+
+type Listener = () => void;
+
+/**
+ * jsdom does not implement `matchMedia`, so every test that needs a value has to
+ * install one. `stub` returns a setter so a test can flip the query and fire the
+ * change event the same way a browser would.
+ */
+function stubMatchMedia(initialMatches: boolean) {
+  const listeners = new Set<Listener>();
+  let matches = initialMatches;
+
+  const matchMedia = vi.fn((query: string) => ({
+    // A real MediaQueryList updates `matches` in place, so this has to be a
+    // getter rather than a snapshot taken when the list was created.
+    get matches() {
+      return matches;
+    },
+    media: query,
+    onchange: null,
+    addEventListener: (_: string, listener: Listener) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_: string, listener: Listener) => {
+      listeners.delete(listener);
+    },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }));
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+
+  return {
+    matchMedia,
+    set(next: boolean) {
+      matches = next;
+      for (const listener of listeners) listener();
+    },
+  };
+}
+
+/** Records the hook's value on every render, so the first one can be asserted. */
+function renderHookValues() {
+  const values: boolean[] = [];
+  function Probe() {
+    values.push(usePrefersReducedMotion());
+    return null;
+  }
+  const result = render(<Probe />);
+  return { values, ...result };
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "matchMedia");
+  vi.restoreAllMocks();
+});
+
+describe("usePrefersReducedMotion", () => {
+  it("returns false when matchMedia is unavailable", () => {
+    expect(typeof window.matchMedia).toBe("undefined");
+    const { values } = renderHookValues();
+    expect(values.every((value) => value === false)).toBe(true);
+  });
+
+  it("reports the preference on the very first render, with no false frame", () => {
+    stubMatchMedia(true);
+    const { values } = renderHookValues();
+    // The effect-based version rendered `false` first and corrected itself, which
+    // let a reduced-motion user catch one animated frame.
+    expect(values[0]).toBe(true);
+  });
+
+  it("returns false on the first render when the query does not match", () => {
+    stubMatchMedia(false);
+    const { values } = renderHookValues();
+    expect(values[0]).toBe(false);
+  });
+
+  it("updates when the preference changes", () => {
+    const mq = stubMatchMedia(false);
+    const { values } = renderHookValues();
+    expect(values[0]).toBe(false);
+
+    act(() => mq.set(true));
+    expect(values.at(-1)).toBe(true);
+
+    act(() => mq.set(false));
+    expect(values.at(-1)).toBe(false);
+  });
+
+  it("unsubscribes on unmount", () => {
+    const mq = stubMatchMedia(false);
+    const { unmount } = renderHookValues();
+    unmount();
+    // A listener left attached would throw on setState after unmount.
+    expect(() => act(() => mq.set(true))).not.toThrow();
+  });
+});

--- a/src/utils/usePrefersReducedMotion.test.tsx
+++ b/src/utils/usePrefersReducedMotion.test.tsx
@@ -4,18 +4,11 @@ import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
 
 type Listener = () => void;
 
-/**
- * jsdom does not implement `matchMedia`, so every test that needs a value has to
- * install one. `stub` returns a setter so a test can flip the query and fire the
- * change event the same way a browser would.
- */
 function stubMatchMedia(initialMatches: boolean) {
   const listeners = new Set<Listener>();
   let matches = initialMatches;
 
   const matchMedia = vi.fn((query: string) => ({
-    // A real MediaQueryList updates `matches` in place, so this has to be a
-    // getter rather than a snapshot taken when the list was created.
     get matches() {
       return matches;
     },
@@ -47,7 +40,6 @@ function stubMatchMedia(initialMatches: boolean) {
   };
 }
 
-/** Records the hook's value on every render, so the first one can be asserted. */
 function renderHookValues() {
   const values: boolean[] = [];
   function Probe() {
@@ -73,8 +65,6 @@ describe("usePrefersReducedMotion", () => {
   it("reports the preference on the very first render, with no false frame", () => {
     stubMatchMedia(true);
     const { values } = renderHookValues();
-    // The effect-based version rendered `false` first and corrected itself, which
-    // let a reduced-motion user catch one animated frame.
     expect(values[0]).toBe(true);
   });
 
@@ -100,7 +90,6 @@ describe("usePrefersReducedMotion", () => {
     const mq = stubMatchMedia(false);
     const { unmount } = renderHookValues();
     unmount();
-    // A listener left attached would throw on setState after unmount.
     expect(() => act(() => mq.set(true))).not.toThrow();
   });
 });

--- a/src/utils/usePrefersReducedMotion.ts
+++ b/src/utils/usePrefersReducedMotion.ts
@@ -2,12 +2,8 @@ import * as React from "react";
 
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
-/**
- * jsdom does not implement `matchMedia`, and neither does a server render, so
- * both entry points below have to tolerate its absence rather than assume a
- * browser. `getSnapshot` runs during render, so an unguarded call would throw
- * rather than degrade.
- */
+// jsdom has no `matchMedia`, and `getSnapshot` runs during render, so an
+// unguarded call throws rather than degrades.
 const isSupported = () => typeof window !== "undefined" && typeof window.matchMedia === "function";
 
 const subscribe = (onStoreChange: () => void) => {
@@ -26,12 +22,9 @@ const getServerSnapshot = () => false;
 /**
  * Whether the user has asked for reduced motion.
  *
- * Reads the media query during render via `useSyncExternalStore` rather than
- * syncing it into state from an effect. The effect-based version always returned
- * `false` on the first render and corrected itself afterwards, so someone with
- * reduced motion on could catch one animated frame before it settled. This is
- * also the version that behaves correctly under concurrent rendering, where an
- * effect-based subscription can read a stale value.
+ * Read during render rather than synced into state from an effect: an effect
+ * returns `false` on the first render, which lets a reduced-motion user catch one
+ * animated frame, and can read a stale value under concurrent rendering.
  */
 export function usePrefersReducedMotion(): boolean {
   return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);

--- a/src/utils/usePrefersReducedMotion.ts
+++ b/src/utils/usePrefersReducedMotion.ts
@@ -1,20 +1,38 @@
 import * as React from "react";
 
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * jsdom does not implement `matchMedia`, and neither does a server render, so
+ * both entry points below have to tolerate its absence rather than assume a
+ * browser. `getSnapshot` runs during render, so an unguarded call would throw
+ * rather than degrade.
+ */
+const isSupported = () => typeof window !== "undefined" && typeof window.matchMedia === "function";
+
+const subscribe = (onStoreChange: () => void) => {
+  if (!isSupported()) {
+    return () => {};
+  }
+  const mq = window.matchMedia(REDUCED_MOTION_QUERY);
+  mq.addEventListener("change", onStoreChange);
+  return () => mq.removeEventListener("change", onStoreChange);
+};
+
+const getSnapshot = () => (isSupported() ? window.matchMedia(REDUCED_MOTION_QUERY).matches : false);
+
+const getServerSnapshot = () => false;
+
+/**
+ * Whether the user has asked for reduced motion.
+ *
+ * Reads the media query during render via `useSyncExternalStore` rather than
+ * syncing it into state from an effect. The effect-based version always returned
+ * `false` on the first render and corrected itself afterwards, so someone with
+ * reduced motion on could catch one animated frame before it settled. This is
+ * also the version that behaves correctly under concurrent rendering, where an
+ * effect-based subscription can read a stale value.
+ */
 export function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = React.useState(false);
-
-  React.useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
-    }
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const sync = () => {
-      setReduced(mq.matches);
-    };
-    sync();
-    mq.addEventListener("change", sync);
-    return () => mq.removeEventListener("change", sync);
-  }, []);
-
-  return reduced;
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
Follow-up to #621, which stayed a pure move. Two things Alfonso raised there, plus the animation split we discussed.

## Reduced motion is read during render

`usePrefersReducedMotion` now uses `useSyncExternalStore`, as sketched in [his comment](https://github.com/fanvue/fanv-ui/pull/621#discussion_r3689068851). The effect-based version returned `false` on the first render and corrected itself afterwards, so a reduced-motion user could catch one animated frame.

One deviation from the snippet: the `matchMedia` guard stays. `getSnapshot` runs during render, and jsdom does not implement `matchMedia` (`src/test/setup.ts` polyfills `ResizeObserver` but not this), so an unguarded call throws instead of degrading. Verified: `typeof window.matchMedia` is `undefined` in the unit project, which is also why `CyclingText` already had a test named "completes a transition step without relying on matchMedia".

The new test fails against the old implementation and passes against this one. With a faithful stub, where `matches` is a live getter rather than a snapshot, it is the only one of the five that changes verdict. The old hook handled preference changes correctly; the first render was its single defect.

## The slide and cross-fade moved out

Both motion `useMemo`s, `SLIDE_OFFSET_PX` and the easing now live in `useCyclingMotion`, alongside the existing `useCyclingCycle` / `useCyclingTextTrackWidth` / `usePageVisibility`. The hook also owns the reduced-motion read, so `CyclingText` no longer imports `usePrefersReducedMotion` and is left with layout and cycle wiring.

Behaviour is unchanged and the 20 existing `CyclingText` tests pass untouched. It stays inline styles rather than `motion-safe:` utilities because `transitionMs` is a runtime prop.

Adds three reduced-motion tests, a branch that was previously unreachable with no `matchMedia` to stub. Worth noting the cycle is advanced by the fallback timer in `useCyclingCycle`, not by `transitionend`, so it keeps running when no transition fires.

Also drops the commented-out `paddingTop: SLIDE_OFFSET_PX` in `wrapperStyle`, which referenced the constant that moved out.

No public API change; the hook is not exported from `src/index.ts` and `useCyclingMotion` has one internal consumer.

Based on `ds/move-prefers-reduced-motion` so the diff stays clean. GitHub retargets it to `main` once #621 merges.