### PR TITLE
fix(Chip): stop a dotted chip resizing when it is selected

### DIFF
--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -218,6 +218,33 @@ describe("Chip", () => {
       expect(rect).toHaveAttribute("stroke-dasharray", "8 8");
     });
 
+    it("keeps a border in both states", () => {
+      const { rerender } = render(<Chip dotted>New folder</Chip>);
+      expect(screen.getByTestId("chip")).toHaveClass(
+        "border",
+        "border-solid",
+        "border-transparent",
+      );
+
+      rerender(
+        <Chip dotted selected>
+          New folder
+        </Chip>,
+      );
+      expect(screen.getByTestId("chip")).toHaveClass("border", "border-solid");
+    });
+
+    it("does not reserve a border on the asChild path, which draws a real one", () => {
+      render(
+        <Chip dotted asChild>
+          <a href="/x">New folder</a>
+        </Chip>,
+      );
+      const chip = screen.getByRole("link");
+      expect(chip).toHaveClass("border-dashed");
+      expect(chip).not.toHaveClass("border-transparent");
+    });
+
     it("does not render a dashed border by default", () => {
       render(<Chip>Chip</Chip>);
       const chip = screen.getByTestId("chip");

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -108,7 +108,10 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
       <svg
         aria-hidden="true"
         className={cn(
-          "pointer-events-none absolute inset-0 size-full overflow-visible",
+          // `-1px` spans the reserved transparent border rather than the padding box
+          // inside it, so the dash lands on the same ring as the solid border it
+          // becomes when selected.
+          "pointer-events-none absolute -top-px -left-px h-[calc(100%+2px)] w-[calc(100%+2px)] overflow-visible",
           disabled ? "text-buttons-chip-disabled" : "text-buttons-chip-dotted-default",
           isInteractive &&
             !disabled &&
@@ -165,6 +168,11 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
           // border fallback since the SVG is only rendered in the default path.
           isDotted && !selected && "bg-transparent text-content-primary",
           isDotted && !selected && !asChild && "group",
+          // The SVG path draws no CSS border, so selecting one used to add 1px and
+          // widen the chip by 2px, shifting the row on every toggle. Reserving a
+          // transparent border also puts the dash on the same ring as the solid
+          // border it becomes. The `asChild` path already has a real border below.
+          isDotted && !selected && !asChild && "border border-transparent border-solid",
           isDotted &&
             !selected &&
             asChild &&


### PR DESCRIPTION
Follow-up from [Alfonso's review on #622](https://github.com/fanvue/fanv-ui/pull/622), where he spotted that `dotted` has the same bug the `outlined` variant was fixing.

## Confirmed in a browser first

jsdom cannot do layout, so I measured the real thing in Storybook rather than reasoning about it:

| state | before | after |
| --- | --- | --- |
| dotted unselected | 87.30px | 89.30px |
| dotted selected | 89.30px | 89.30px |

So toggling shifted the row by 2px. Height was 32px throughout, because `h-8` is explicit and `border-box` absorbs the border on a sized axis; only the intrinsic width was affected. Same mechanism as #622.

## The fix

The dashed ring is an SVG, so the unselected chip had no CSS border while the selected one adds 1px. It now reserves a transparent border while unselected, matching the approach in #622.

One extra step that measuring caught: with the border reserved, the SVG was still sized to the padding box, which put the dash 1.5px in from the outer edge while the selected border sits at 0.5px. So they were not on the same ring and toggling would have visibly nudged the outline. The SVG now spans the border box, and the dash lands at 0.5px in both states. The `rx` values were already written for a ring at the outer edge, so they needed no change.

Verified visually in Storybook at both dash patterns (6/6 rounded, 8/8 for the 40px square) and the disabled state. Dash renders cleanly with no clipping from the overhang.

The `asChild` path already draws a real dashed CSS border, so it has no shift and is deliberately untouched. Added a test pinning that.

Based on `ds/chip-outlined` since both touch the same class list; GitHub retargets it to `main` once #622 merges.