### PR TITLE
fix(tooltip): default TooltipProvider delayDuration to 200ms

### DIFF
--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./Tooltip";
 
@@ -17,6 +17,41 @@ function renderTooltip(contentProps?: React.ComponentPropsWithoutRef<typeof Tool
 }
 
 describe("Tooltip", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("delayDuration", () => {
+    function hoverWithFakeTimers() {
+      vi.useFakeTimers();
+      render(
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>Hover me</TooltipTrigger>
+            <TooltipContent>Tooltip text</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>,
+      );
+      fireEvent.pointerMove(screen.getByRole("button", { name: "Hover me" }));
+    }
+
+    it("keeps the tooltip closed until 200ms after hover", () => {
+      hoverWithFakeTimers();
+      act(() => {
+        vi.advanceTimersByTime(199);
+      });
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    it("opens at 200ms without waiting for Radix's 700ms default", () => {
+      hoverWithFakeTimers();
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Tooltip text");
+    });
+  });
+
   describe("API", () => {
     it("renders tooltip content on hover", async () => {
       const user = userEvent.setup();

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -5,8 +5,23 @@ import { cn } from "../../utils/cn";
 /** Props for the {@link TooltipProvider}. Wraps Radix `Tooltip.Provider`. */
 export type TooltipProviderProps = React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Provider>;
 
-/** Provides tooltip delay and skip-delay context. Wrap your app or a subtree. */
-export const TooltipProvider = TooltipPrimitive.Provider;
+const DEFAULT_DELAY_DURATION = 200;
+
+/**
+ * Provides tooltip delay and skip-delay context. Wrap your app or a subtree.
+ *
+ * Defaults `delayDuration` to 200ms rather than inheriting Radix's 700ms, which
+ * reads as unresponsive on the short hint labels this library uses tooltips for.
+ * Pass `delayDuration` to override.
+ *
+ * Note that `TooltipLabel`, `ChartCard` and `SwitchField` each mount their own
+ * provider internally, so they take this default but not an app-level override.
+ */
+export const TooltipProvider = ({
+  delayDuration = DEFAULT_DELAY_DURATION,
+  ...props
+}: TooltipProviderProps) => <TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />;
+TooltipProvider.displayName = "TooltipProvider";
 
 /** Props for the {@link Tooltip} root component. */
 export interface TooltipProps extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root> {


### PR DESCRIPTION
Follow-up to the `delayDuration` thread on #628.

Radix's `Tooltip.Provider` defaults to 700ms. On the short hint labels this library uses tooltips for (`TooltipLabel`, the `ChartCard` info icon, `SwitchField`), that reads as the tooltip not working rather than as a deliberate delay. This sets our `TooltipProvider` to 200ms by default, still overridable per provider.

## Scope

Deliberately one file. `TooltipLabel`, `ChartCard` and `SwitchField` each mount their own `<TooltipProvider>` internally, and they import ours rather than Radix's, so they pick up the new default for free. No component, story or test needed a change.

## What this does not do

A nested provider still shadows the root one, so an app that sets its own `delayDuration` at the root will not reach those three components. Fixing that means removing the nested providers, which makes a root `TooltipProvider` a hard requirement (Radix throws `Tooltip must be used within TooltipProvider` without one) and touches every test and story that renders them. That is a separate change and not needed to fix the delay.

## Verification

Two tests, both driving the real Radix timer: closed at 199ms, open at 200ms. The 200ms case fails against the previous bare re-export and passes with the change. Full suite 4502/4502, `tsc --noEmit` clean, biome clean.