### PR TITLE
feat(TrendPill): add the filled trend pill from the V2 design

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -260,6 +260,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
   TrashBinIcon,
+  TrendPill,
   TrophyIcon,
   TwitterIcon,
   UploadIcon,
@@ -2499,6 +2500,18 @@ function UserItemTrailingDemo() {
           showHandle={false}
           trailing={<UserItemTrailing value="$980.00" meta="3 purchases" />}
         />
+      </div>
+    </section>
+  );
+}
+
+function TrendPillDemo() {
+  return (
+    <section>
+      <h2 className="typography-header-heading-sm mb-4">TrendPill</h2>
+      <div className="flex flex-wrap items-center gap-2">
+        <TrendPill label="$240 vs Jun" trend="positive" />
+        <TrendPill label="$85 vs Jun" trend="negative" />
       </div>
     </section>
   );
@@ -5832,6 +5845,7 @@ function App() {
             {/* Pill */}
             <PillDemo />
             <UserItemTrailingDemo />
+            <TrendPillDemo />
 
             {/* Checkbox */}
             <CheckboxDemo />

--- a/src/components/TrendPill/TrendPill.stories.tsx
+++ b/src/components/TrendPill/TrendPill.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TrendPill } from "./TrendPill";
+
+const meta = {
+  title: "Components/TrendPill",
+  component: TrendPill,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    trend: {
+      control: "inline-radio",
+      options: ["positive", "negative"],
+    },
+  },
+  args: {
+    label: "$240 vs Jun",
+    trend: "positive",
+  },
+} satisfies Meta<typeof TrendPill>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Positive: Story = {};
+
+export const Negative: Story = {
+  args: { label: "$120 vs Jun", trend: "negative" },
+};
+
+export const BothDirections: Story = {
+  name: "Both directions",
+  render: () => (
+    <div className="flex items-center gap-2">
+      <TrendPill label="$240 vs Jun" trend="positive" />
+      <TrendPill label="$120 vs Jun" trend="negative" />
+    </div>
+  ),
+};

--- a/src/components/TrendPill/TrendPill.test.tsx
+++ b/src/components/TrendPill/TrendPill.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { TrendPill } from "./TrendPill";
+
+describe("TrendPill", () => {
+  describe("API", () => {
+    it("renders the label", () => {
+      render(<TrendPill label="$240 vs Jun" trend="positive" />);
+      expect(screen.getByText("$240 vs Jun")).toBeInTheDocument();
+    });
+
+    it("uses the success surface when positive", () => {
+      render(<TrendPill label="up" trend="positive" />);
+      expect(screen.getByTestId("pill")).toHaveClass("bg-success-surface", "text-success-content");
+    });
+
+    it("uses the error surface when negative", () => {
+      render(<TrendPill label="down" trend="negative" />);
+      expect(screen.getByTestId("pill")).toHaveClass("bg-error-surface", "text-error-content");
+    });
+
+    it("swaps the glyph with the direction", () => {
+      const { container, rerender } = render(<TrendPill label="up" trend="positive" />);
+      const positiveGlyph = container.querySelector("svg")?.outerHTML;
+
+      rerender(<TrendPill label="down" trend="negative" />);
+      expect(container.querySelector("svg")?.outerHTML).not.toBe(positiveGlyph);
+    });
+
+    it("forwards ref and spreads HTML attributes", () => {
+      const ref = React.createRef<HTMLSpanElement>();
+      render(<TrendPill ref={ref} label="up" trend="positive" data-x="y" />);
+      expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+      expect(screen.getByTestId("pill")).toHaveAttribute("data-x", "y");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(<TrendPill label="$240 vs Jun" trend="positive" />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/TrendPill/TrendPill.test.tsx
+++ b/src/components/TrendPill/TrendPill.test.tsx
@@ -42,5 +42,20 @@ describe("TrendPill", () => {
       const { container } = render(<TrendPill label="$240 vs Jun" trend="positive" />);
       expect(await axe(container)).toHaveNoViolations();
     });
+
+    // axe passes either way here: nothing in the markup is invalid, the direction
+    // was simply absent. These assert the text channel exists at all.
+    it("announces the direction, which colour and glyph alone do not carry", () => {
+      const { rerender } = render(<TrendPill label="$240 vs Jun" trend="positive" />);
+      expect(screen.getByText("Increase")).toBeInTheDocument();
+      rerender(<TrendPill label="$85 vs Jun" trend="negative" />);
+      expect(screen.getByText("Decrease")).toBeInTheDocument();
+    });
+
+    it("lets the host translate the direction", () => {
+      render(<TrendPill label="$240 vs Jun" trend="negative" decreaseLabel="Baisse" />);
+      expect(screen.getByText("Baisse")).toBeInTheDocument();
+      expect(screen.queryByText("Decrease")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/TrendPill/TrendPill.tsx
+++ b/src/components/TrendPill/TrendPill.tsx
@@ -12,6 +12,13 @@ export interface TrendPillProps extends Omit<React.HTMLAttributes<HTMLSpanElemen
   label: React.ReactNode;
   /** Drives the colour and the leading glyph. */
   trend: TrendDirection;
+  /**
+   * Announced before {@link label} when `trend` is `"positive"`. Overridable
+   * because the component cannot translate it. @default "Increase"
+   */
+  increaseLabel?: string;
+  /** As {@link increaseLabel}, for `"negative"`. @default "Decrease" */
+  decreaseLabel?: string;
 }
 
 /**
@@ -29,7 +36,7 @@ export interface TrendPillProps extends Omit<React.HTMLAttributes<HTMLSpanElemen
  * ```
  */
 export const TrendPill = React.forwardRef<HTMLSpanElement, TrendPillProps>(
-  ({ label, trend, ...props }, ref) => {
+  ({ label, trend, increaseLabel = "Increase", decreaseLabel = "Decrease", ...props }, ref) => {
     const isPositive = trend === "positive";
 
     return (
@@ -39,6 +46,13 @@ export const TrendPill = React.forwardRef<HTMLSpanElement, TrendPillProps>(
         leftIcon={isPositive ? <PlusIcon /> : <MinusIcon />}
         {...props}
       >
+        {/*
+         * `Pill` renders `leftIcon` inside `aria-hidden`, so without this the only
+         * channel carrying the direction is the green/red fill and the label itself
+         * says nothing about which way it went — WCAG 1.4.1, and the direction is
+         * the point of a trend.
+         */}
+        <span className="sr-only">{isPositive ? increaseLabel : decreaseLabel}</span>
         {label}
       </Pill>
     );

--- a/src/components/TrendPill/TrendPill.tsx
+++ b/src/components/TrendPill/TrendPill.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { MinusIcon } from "../Icons/MinusIcon";
+import { PlusIcon } from "../Icons/PlusIcon";
+import { Pill } from "../Pill/Pill";
+
+/** Whether a change is an improvement or a decline. */
+export type TrendDirection = "positive" | "negative";
+
+/** Props for {@link TrendPill}. */
+export interface TrendPillProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** The change itself, already formatted (e.g. "$240 vs Jun"). */
+  label: React.ReactNode;
+  /** Drives the colour and the leading glyph. */
+  trend: TrendDirection;
+}
+
+/**
+ * A filled pill stating a change, green for positive and red for negative
+ * (Figma `V2 Trend Pill`).
+ *
+ * Distinct from {@link ChartCard}'s `trendChip`, which is Figma's `V2 Trend`: an
+ * unfilled arrow and label sitting beside a headline. Use this one where the
+ * change needs to hold its own against surrounding content rather than trail a
+ * number, such as inside a list row.
+ *
+ * @example
+ * ```tsx
+ * <TrendPill label="$240 vs Jun" trend="positive" />
+ * ```
+ */
+export const TrendPill = React.forwardRef<HTMLSpanElement, TrendPillProps>(
+  ({ label, trend, ...props }, ref) => {
+    const isPositive = trend === "positive";
+
+    return (
+      <Pill
+        ref={ref}
+        variant={isPositive ? "green" : "red"}
+        leftIcon={isPositive ? <PlusIcon /> : <MinusIcon />}
+        {...props}
+      >
+        {label}
+      </Pill>
+    );
+  },
+);
+
+TrendPill.displayName = "TrendPill";

--- a/src/index.ts
+++ b/src/index.ts
@@ -842,6 +842,11 @@ export {
 } from "./components/Tooltip/Tooltip";
 export type { TooltipLabelProps } from "./components/Tooltip/TooltipLabel";
 export { TooltipLabel } from "./components/Tooltip/TooltipLabel";
+export type {
+  TrendDirection,
+  TrendPillProps,
+} from "./components/TrendPill/TrendPill";
+export { TrendPill } from "./components/TrendPill/TrendPill";
 export type { UserDisplayNameProps } from "./components/UserDisplayName/UserDisplayName";
 export { UserDisplayName } from "./components/UserDisplayName/UserDisplayName";
 export type { UserHandleProps } from "./components/UserHandle/UserHandle";


### PR DESCRIPTION
First of six extracted from the `insights-components` batch. Each one is independent and can be reviewed in any order.

`TrendPill` is Figma's `V2 Trend Pill`: a filled pill stating a change, green with a plus for positive, red with a minus for negative. Agency insights uses it inside list rows.

It is deliberately not the same thing as `ChartCard`'s `trendChip`, which is Figma's `V2 Trend` (unfilled arrow beside a headline). The doc comment says so, because the two are easy to reach for interchangeably and they are not interchangeable: this one has to hold its own against surrounding content rather than trail a number.

Built on the existing `Pill` and the existing `PlusIcon` / `MinusIcon`, so there is no new primitive here.

Also adds the `App.tsx` demo per `AGENTS.md`. The batch branch had skipped that for the new components.

9 tests including axe, `tsc --noEmit` clean, biome clean.