### PR TITLE
feat(AnimatedNumber): add the roll and count value animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   AIIcon,
   Alert,
   AlertIcon,
+  AnimatedNumber,
   ArrowDownIcon,
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -2512,6 +2513,22 @@ function TrendPillDemo() {
       <div className="flex flex-wrap items-center gap-2">
         <TrendPill label="$240 vs Jun" trend="positive" />
         <TrendPill label="$85 vs Jun" trend="negative" />
+      </div>
+    </section>
+  );
+}
+
+function AnimatedNumberDemo() {
+  const [value, setValue] = React.useState(1240);
+  return (
+    <section>
+      <h2 className="typography-header-heading-sm mb-4">AnimatedNumber</h2>
+      <div className="flex flex-wrap items-center gap-4">
+        <AnimatedNumber value={value} variant="roll" />
+        <AnimatedNumber value={value} variant="count" />
+        <Button size="32" onClick={() => setValue((v) => v + 310)}>
+          Increase
+        </Button>
       </div>
     </section>
   );
@@ -5846,6 +5863,7 @@ function App() {
             <PillDemo />
             <UserItemTrailingDemo />
             <TrendPillDemo />
+            <AnimatedNumberDemo />
 
             {/* Checkbox */}
             <CheckboxDemo />

--- a/src/components/AnimatedNumber/AnimatedNumber.stories.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as React from "react";
+import { Button } from "../Button/Button";
+import { AnimatedNumber } from "./AnimatedNumber";
+
+const formatPrice = (value: number) =>
+  `$${(Math.round(value) / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+
+const meta: Meta<typeof AnimatedNumber> = {
+  title: "Components/AnimatedNumber",
+  component: AnimatedNumber,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: { control: "inline-radio", options: ["count", "roll"] },
+    durationMs: { control: { type: "number", min: 0, step: 50 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The two gross values the insights earnings toggle switches between. */
+const GROSS = 12_804_673;
+const NET = 10_243_738;
+
+export const Default: Story = {
+  args: { value: 1234, variant: "count" },
+};
+
+/**
+ * Both variants against the same value change, so the difference is directly
+ * comparable: `roll` moves each digit column and eases the box width when the
+ * digit count changes, while `count` interpolates the value itself.
+ */
+export const Comparison: Story = {
+  render: () => {
+    const [value, setValue] = React.useState(GROSS);
+
+    return (
+      <div className="flex w-96 flex-col items-start gap-6">
+        <Button
+          variant="secondary"
+          size="40"
+          onClick={() => setValue((current) => (current === GROSS ? NET : GROSS))}
+        >
+          Toggle net / gross
+        </Button>
+
+        <div className="flex flex-col gap-1">
+          <span className="typography-description-12px-regular text-content-secondary">
+            roll — headline figure
+          </span>
+          <span className="typography-header-heading-lg text-content-primary">
+            <AnimatedNumber value={value} format={formatPrice} variant="roll" />
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <span className="typography-description-12px-regular text-content-secondary">
+            count — supporting figure
+          </span>
+          <span className="typography-body-default-16px-semibold text-content-primary">
+            <AnimatedNumber value={value} format={formatPrice} variant="count" />
+          </span>
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * A change that drops a digit, which is where the box width eases rather than
+ * snapping. Toggle repeatedly to see the separators shift.
+ */
+export const DigitCountChange: Story = {
+  render: () => {
+    const [value, setValue] = React.useState(999_99);
+
+    return (
+      <div className="flex w-96 flex-col items-start gap-6">
+        <Button
+          variant="secondary"
+          size="40"
+          onClick={() => setValue((current) => (current === 999_99 ? 1_000_00 : 999_99))}
+        >
+          Cross the thousand
+        </Button>
+        <span className="typography-header-heading-lg text-content-primary">
+          <AnimatedNumber value={value} format={formatPrice} variant="roll" />
+        </span>
+      </div>
+    );
+  },
+};

--- a/src/components/AnimatedNumber/AnimatedNumber.test.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { AnimatedNumber } from "./AnimatedNumber";
 
 const formatPrice = (value: number) => `$${Math.round(value).toLocaleString("en-US")}`;
@@ -100,6 +101,23 @@ describe("AnimatedNumber", () => {
       );
       // 4 digits roll; "$" and "," do not.
       expect(container.querySelectorAll('[style*="translateY"]')).toHaveLength(4);
+    });
+  });
+  describe("accessibility", () => {
+    it("has no accessibility violations in the count variant", async () => {
+      const { container } = render(<AnimatedNumber value={1234} format={formatPrice} />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    // The roll variant stacks ten digits per column, so the run is hidden and the
+    // value exposed once as text. axe cannot see that distinction — it is covered
+    // by "exposes the formatted value once as text" above — but it does catch the
+    // markup being invalid.
+    it("has no accessibility violations in the roll variant", async () => {
+      const { container } = render(
+        <AnimatedNumber value={1234} format={formatPrice} variant="roll" />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
     });
   });
 });

--- a/src/components/AnimatedNumber/AnimatedNumber.test.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.test.tsx
@@ -7,20 +7,15 @@ const formatPrice = (value: number) => `$${Math.round(value).toLocaleString("en-
 describe("AnimatedNumber", () => {
   describe("count variant", () => {
     beforeEach(() => {
-      // Drive requestAnimationFrame off fake timers so the tween can be stepped
-      // deterministically instead of waiting on real frames.
+      // Vitest fakes requestAnimationFrame itself, so the tween can be stepped
+      // deterministically. Hand-stubbing it over setTimeout instead would create
+      // timers that `cancelAnimationFrame` cannot clear, which only shows up once
+      // a test interrupts a tween while a frame is still pending.
       vi.useFakeTimers();
-      vi.stubGlobal(
-        "requestAnimationFrame",
-        (cb: FrameRequestCallback) =>
-          setTimeout(() => cb(performance.now()), 16) as unknown as number,
-      );
-      vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
     });
 
     afterEach(() => {
       vi.useRealTimers();
-      vi.unstubAllGlobals();
     });
 
     it("renders the formatted value on first paint without animating in", () => {
@@ -37,6 +32,31 @@ describe("AnimatedNumber", () => {
       });
 
       expect(screen.getByText("$200")).toBeInTheDocument();
+    });
+
+    it("resumes an interrupted tween from what is on screen, not the abandoned target", () => {
+      const plain = (value: number) => String(Math.round(value));
+      const read = () => Number(screen.getByTestId("n").textContent);
+
+      const { rerender } = render(<AnimatedNumber value={0} format={plain} data-testid="n" />);
+      rerender(<AnimatedNumber value={100} format={plain} data-testid="n" />);
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      const mid = read();
+      expect(mid).toBeGreaterThan(0);
+      expect(mid).toBeLessThan(100);
+
+      // Retarget mid-flight, as a refetch or filter change would.
+      rerender(<AnimatedNumber value={200} format={plain} data-testid="n" />);
+      act(() => {
+        vi.advanceTimersByTime(16);
+      });
+
+      // Carries on from `mid`. Resuming from the abandoned 100 would overshoot it.
+      expect(read()).toBeGreaterThanOrEqual(mid);
+      expect(read()).toBeLessThan(100);
     });
 
     it("swaps instantly when the duration is zero", () => {

--- a/src/components/AnimatedNumber/AnimatedNumber.test.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.test.tsx
@@ -1,0 +1,85 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AnimatedNumber } from "./AnimatedNumber";
+
+const formatPrice = (value: number) => `$${Math.round(value).toLocaleString("en-US")}`;
+
+describe("AnimatedNumber", () => {
+  describe("count variant", () => {
+    beforeEach(() => {
+      // Drive requestAnimationFrame off fake timers so the tween can be stepped
+      // deterministically instead of waiting on real frames.
+      vi.useFakeTimers();
+      vi.stubGlobal(
+        "requestAnimationFrame",
+        (cb: FrameRequestCallback) =>
+          setTimeout(() => cb(performance.now()), 16) as unknown as number,
+      );
+      vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it("renders the formatted value on first paint without animating in", () => {
+      render(<AnimatedNumber value={1234} format={formatPrice} />);
+      expect(screen.getByText("$1,234")).toBeInTheDocument();
+    });
+
+    it("settles on the new value once the tween completes", () => {
+      const { rerender } = render(<AnimatedNumber value={100} format={formatPrice} />);
+      rerender(<AnimatedNumber value={200} format={formatPrice} />);
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(screen.getByText("$200")).toBeInTheDocument();
+    });
+
+    it("swaps instantly when the duration is zero", () => {
+      const { rerender } = render(
+        <AnimatedNumber value={100} format={formatPrice} durationMs={0} />,
+      );
+      rerender(<AnimatedNumber value={200} format={formatPrice} durationMs={0} />);
+      expect(screen.getByText("$200")).toBeInTheDocument();
+    });
+  });
+
+  describe("roll variant", () => {
+    it("exposes the formatted value once as text", () => {
+      render(<AnimatedNumber value={1234} format={formatPrice} variant="roll" />);
+      expect(screen.getByText("$1,234")).toBeInTheDocument();
+    });
+
+    it("hides the digit columns from assistive technology", () => {
+      const { container } = render(<AnimatedNumber value={12} format={String} variant="roll" />);
+      // Without this the ten stacked digits in every column would be read out.
+      expect(container.querySelector("[aria-hidden]")).toBeInTheDocument();
+    });
+
+    it("renders one column per digit, each listing all ten digits", () => {
+      const { container } = render(<AnimatedNumber value={12} format={String} variant="roll" />);
+      const strips = container.querySelectorAll('[style*="translateY"]');
+      expect(strips).toHaveLength(2);
+      expect(strips[0]).toHaveTextContent("0123456789");
+    });
+
+    it("offsets each column to its own digit", () => {
+      const { container } = render(<AnimatedNumber value={12} format={String} variant="roll" />);
+      const strips = container.querySelectorAll('[style*="translateY"]');
+      expect(strips[0]).toHaveAttribute("style", expect.stringContaining("translateY(-10%)"));
+      expect(strips[1]).toHaveAttribute("style", expect.stringContaining("translateY(-20%)"));
+    });
+
+    it("leaves separators as static characters rather than columns", () => {
+      const { container } = render(
+        <AnimatedNumber value={1234} format={formatPrice} variant="roll" />,
+      );
+      // 4 digits roll; "$" and "," do not.
+      expect(container.querySelectorAll('[style*="translateY"]')).toHaveLength(4);
+    });
+  });
+});

--- a/src/components/AnimatedNumber/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.tsx
@@ -1,0 +1,238 @@
+import * as React from "react";
+import { cn } from "@/utils/cn";
+import { usePrefersReducedMotion } from "@/utils/usePrefersReducedMotion";
+
+/** How a value change is animated. */
+export type AnimatedNumberVariant =
+  /**
+   * Per-digit odometer: each digit column slides to its new value and the box
+   * width eases when the digit count changes. Reads as mechanical, so it suits
+   * a single headline figure rather than a grid of them.
+   */
+  | "roll"
+  /**
+   * Interpolates the value and re-formats it each frame, so the whole number
+   * counts from old to new. Calmer than `roll` when several figures on a page
+   * change at once.
+   */
+  | "count";
+
+/** Props for {@link AnimatedNumber}. */
+export interface AnimatedNumberProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  /** The value to display. Animates whenever this changes. */
+  value: number;
+  /**
+   * Turns the value into the displayed string. Receives interpolated values in
+   * the `count` variant, so it must handle non-integers.
+   * @default String(Math.round(value))
+   */
+  format?: (value: number) => string;
+  /** Which animation to run. @default "count" */
+  variant?: AnimatedNumberVariant;
+  /** Animation duration in milliseconds. @default 500 */
+  durationMs?: number;
+}
+
+const DEFAULT_DURATION_MS = 500;
+
+const defaultFormat = (value: number) => String(Math.round(value));
+
+/** Decelerating ease, so the value settles rather than stopping abruptly. */
+const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
+
+const DIGITS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+
+const isDigit = (char: string) => char >= "0" && char <= "9";
+
+/**
+ * Animates a number when its value changes, either by rolling each digit like
+ * an odometer or by counting through the intermediate values.
+ *
+ * Both variants collapse to an instant swap under
+ * `prefers-reduced-motion: reduce`.
+ *
+ * The rolling variant stacks all ten digits in each column, so the visual is
+ * hidden from assistive technology and the formatted value is exposed once as
+ * text instead.
+ *
+ * @example
+ * ```tsx
+ * // Headline figure
+ * <AnimatedNumber value={totalGross} format={formatPrice} variant="roll" />
+ *
+ * // Supporting figure
+ * <AnimatedNumber value={activeFans} variant="count" />
+ * ```
+ */
+export const AnimatedNumber = React.forwardRef<HTMLSpanElement, AnimatedNumberProps>(
+  (
+    {
+      value,
+      format = defaultFormat,
+      variant = "count",
+      durationMs = DEFAULT_DURATION_MS,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const reducedMotion = usePrefersReducedMotion();
+
+    if (variant === "roll") {
+      return (
+        <RollingNumber
+          ref={ref}
+          value={value}
+          format={format}
+          durationMs={reducedMotion ? 0 : durationMs}
+          className={className}
+          {...props}
+        />
+      );
+    }
+
+    return (
+      <CountingNumber
+        ref={ref}
+        value={value}
+        format={format}
+        durationMs={reducedMotion ? 0 : durationMs}
+        className={className}
+        {...props}
+      />
+    );
+  },
+);
+
+AnimatedNumber.displayName = "AnimatedNumber";
+
+type VariantProps = Omit<AnimatedNumberProps, "variant" | "format" | "durationMs"> & {
+  format: (value: number) => string;
+  durationMs: number;
+};
+
+const CountingNumber = React.forwardRef<HTMLSpanElement, VariantProps>(
+  ({ value, format, durationMs, className, ...props }, ref) => {
+    const [displayValue, setDisplayValue] = React.useState(value);
+    // Read the previous value inside the effect rather than depending on it, so
+    // a re-render mid-animation does not restart the tween from the current
+    // frame's position.
+    const fromRef = React.useRef(value);
+
+    React.useEffect(() => {
+      const from = fromRef.current;
+      if (from === value || durationMs === 0) {
+        fromRef.current = value;
+        setDisplayValue(value);
+        return;
+      }
+
+      let frame = 0;
+      let start: number | undefined;
+
+      const step = (now: number) => {
+        start ??= now;
+        const progress = Math.min((now - start) / durationMs, 1);
+        setDisplayValue(from + (value - from) * easeOutCubic(progress));
+        if (progress < 1) {
+          frame = requestAnimationFrame(step);
+        } else {
+          fromRef.current = value;
+        }
+      };
+
+      frame = requestAnimationFrame(step);
+      return () => {
+        cancelAnimationFrame(frame);
+        fromRef.current = value;
+      };
+    }, [value, durationMs]);
+
+    return (
+      <span ref={ref} className={cn("tabular-nums", className)} {...props}>
+        {format(displayValue)}
+      </span>
+    );
+  },
+);
+
+CountingNumber.displayName = "AnimatedNumber.Counting";
+
+const RollingNumber = React.forwardRef<HTMLSpanElement, VariantProps>(
+  ({ value, format, durationMs, className, ...props }, ref) => {
+    const display = format(value);
+    const characters = React.useMemo(() => Array.from(display), [display]);
+
+    // Lock the box to its measured width so a change in digit count eases
+    // instead of snapping: `width: auto` cannot be transitioned.
+    const contentRef = React.useRef<HTMLSpanElement>(null);
+    const [boxWidth, setBoxWidth] = React.useState<number>();
+
+    // The first measurement goes from `auto` to a pixel width, which must not
+    // transition or every mount animates its own box in from the wrong size —
+    // visible whenever a loading skeleton swaps to a rolling number.
+    const hasMeasured = boxWidth !== undefined;
+
+    React.useLayoutEffect(() => {
+      if (!display) {
+        return;
+      }
+      const measured = contentRef.current?.scrollWidth;
+      if (measured) {
+        setBoxWidth(measured);
+      }
+    }, [display]);
+
+    return (
+      <span
+        ref={ref}
+        className={cn("inline-flex overflow-hidden tabular-nums", className)}
+        style={{
+          width: boxWidth,
+          transitionProperty: "width",
+          transitionDuration: hasMeasured ? `${durationMs}ms` : "0ms",
+          transitionTimingFunction: "cubic-bezier(0.22, 1, 0.36, 1)",
+        }}
+        {...props}
+      >
+        {/* The digit columns list 0-9 apiece, which assistive tech would read
+            out in full, so expose the formatted value as text instead. */}
+        <span className="sr-only">{display}</span>
+        <span ref={contentRef} aria-hidden className="inline-flex whitespace-pre">
+          {characters.map((char, index) =>
+            isDigit(char) ? (
+              <span
+                // biome-ignore lint/suspicious/noArrayIndexKey: a column is a position in the number, so it must keep its identity (and animate) when its digit changes
+                key={`digit-${index}`}
+                className="relative inline-block overflow-hidden"
+                style={{ height: "1em", lineHeight: "1em" }}
+              >
+                <span
+                  className="flex flex-col"
+                  style={{
+                    transform: `translateY(-${Number(char) * 10}%)`,
+                    transitionProperty: "transform",
+                    transitionDuration: `${durationMs}ms`,
+                    transitionTimingFunction: "cubic-bezier(0.22, 1, 0.36, 1)",
+                  }}
+                >
+                  {DIGITS.map((digit) => (
+                    <span key={digit} style={{ height: "1em", lineHeight: "1em" }}>
+                      {digit}
+                    </span>
+                  ))}
+                </span>
+              </span>
+            ) : (
+              // biome-ignore lint/suspicious/noArrayIndexKey: same positional identity as the digit columns
+              <span key={`separator-${index}`}>{char}</span>
+            ),
+          )}
+        </span>
+      </span>
+    );
+  },
+);
+
+RollingNumber.displayName = "AnimatedNumber.Rolling";

--- a/src/components/AnimatedNumber/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.tsx
@@ -115,15 +115,16 @@ type VariantProps = Omit<AnimatedNumberProps, "variant" | "format" | "durationMs
 const CountingNumber = React.forwardRef<HTMLSpanElement, VariantProps>(
   ({ value, format, durationMs, className, ...props }, ref) => {
     const [displayValue, setDisplayValue] = React.useState(value);
-    // Read the previous value inside the effect rather than depending on it, so
-    // a re-render mid-animation does not restart the tween from the current
-    // frame's position.
-    const fromRef = React.useRef(value);
+    // Tracks what is on screen, so an interrupted tween resumes from there. Storing
+    // the abandoned *target* instead would start the next tween from a number that
+    // was never displayed, which shows as a jump to the old target before counting
+    // on — a refetch or filter change landing mid-animation is enough to hit it.
+    const displayRef = React.useRef(value);
 
     React.useEffect(() => {
-      const from = fromRef.current;
+      const from = displayRef.current;
       if (from === value || durationMs === 0) {
-        fromRef.current = value;
+        displayRef.current = value;
         setDisplayValue(value);
         return;
       }
@@ -134,19 +135,16 @@ const CountingNumber = React.forwardRef<HTMLSpanElement, VariantProps>(
       const step = (now: number) => {
         start ??= now;
         const progress = Math.min((now - start) / durationMs, 1);
-        setDisplayValue(from + (value - from) * easeOutCubic(progress));
+        const next = from + (value - from) * easeOutCubic(progress);
+        displayRef.current = next;
+        setDisplayValue(next);
         if (progress < 1) {
           frame = requestAnimationFrame(step);
-        } else {
-          fromRef.current = value;
         }
       };
 
       frame = requestAnimationFrame(step);
-      return () => {
-        cancelAnimationFrame(frame);
-        fromRef.current = value;
-      };
+      return () => cancelAnimationFrame(frame);
     }, [value, durationMs]);
 
     return (
@@ -169,19 +167,38 @@ const RollingNumber = React.forwardRef<HTMLSpanElement, VariantProps>(
     const contentRef = React.useRef<HTMLSpanElement>(null);
     const [boxWidth, setBoxWidth] = React.useState<number>();
 
-    // The first measurement goes from `auto` to a pixel width, which must not
-    // transition or every mount animates its own box in from the wrong size —
-    // visible whenever a loading skeleton swaps to a rolling number.
+    // On the render where the width is still `auto` there is nothing to
+    // transition from, so the duration is zeroed. This is belt-and-braces rather
+    // than load-bearing: `auto` to a length is not interpolatable, so no
+    // transition would run either way.
     const hasMeasured = boxWidth !== undefined;
 
+    // Re-measure rather than measuring once per `display`: the box is
+    // `overflow-hidden`, so a web font landing after the first measurement leaves
+    // the locked width too narrow for the wider glyphs and clips the number until
+    // the value next changes, which for a headline figure may be never. Observing
+    // covers a container change too. Same approach as `useCyclingTextTrackWidth`.
     React.useLayoutEffect(() => {
-      if (!display) {
+      const node = contentRef.current;
+      if (!node || !display) {
         return;
       }
-      const measured = contentRef.current?.scrollWidth;
-      if (measured) {
-        setBoxWidth(measured);
+
+      const measure = () => {
+        const measured = node.scrollWidth;
+        if (measured) {
+          setBoxWidth(measured);
+        }
+      };
+
+      measure();
+
+      if (typeof ResizeObserver === "undefined") {
+        return;
       }
+      const observer = new ResizeObserver(measure);
+      observer.observe(node);
+      return () => observer.disconnect();
     }, [display]);
 
     return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ export { AccordionTrigger } from "./components/Accordion/AccordionTrigger";
 export type { AlertProps, AlertVariant } from "./components/Alert/Alert";
 export { Alert } from "./components/Alert/Alert";
 export type {
+  AnimatedNumberProps,
+  AnimatedNumberVariant,
+} from "./components/AnimatedNumber/AnimatedNumber";
+export { AnimatedNumber } from "./components/AnimatedNumber/AnimatedNumber";
+export type {
   AudioPlayerProps,
   AudioPlayerSize,
 } from "./components/AudioPlayer/AudioPlayer";


### PR DESCRIPTION
Second of six extracted from the `insights-components` batch. Independent of the others.

Animates a number when its value changes, for the insights headline figures. Two variants because one does not fit both cases:

- `roll` is a per-digit odometer, each column sliding to its new digit with the box width easing when the digit count changes. Mechanical, so it suits a single headline figure.
- `count` interpolates the value and re-formats every frame, so the whole number counts up. Calmer when several figures on a page change at once.

`format` receives interpolated values in the `count` variant, so it has to handle non-integers. That is documented on the prop rather than left to be discovered.

Honours `usePrefersReducedMotion`, which is why this sits after #621 and #630 rather than before them.

Adds the `App.tsx` demo per `AGENTS.md`, showing both variants side by side so the difference is visible rather than described.

11 tests including axe, `tsc --noEmit` clean, biome clean.