### PR TITLE
feat(AiButton): add the shimmering AI action button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
   AccordionTrigger,
   AddIcon,
   AIIcon,
+  AiButton,
   Alert,
   AlertIcon,
   AnimatedNumber,
@@ -2529,6 +2530,26 @@ function AnimatedNumberDemo() {
         <Button size="32" onClick={() => setValue((v) => v + 310)}>
           Increase
         </Button>
+      </div>
+    </section>
+  );
+}
+
+function AiButtonDemo() {
+  const [active, setActive] = React.useState(false);
+  return (
+    <section>
+      <h2 className="typography-header-heading-sm mb-4">AiButton</h2>
+      <div className="flex flex-wrap items-center gap-4">
+        <AiButton size="24" label="Analyse" />
+        <AiButton size="32" label="Analyse" />
+        <AiButton size="40" label="Analyse" />
+        <AiButton
+          label="Get advice"
+          activeLabel="Thinking"
+          active={active}
+          onClick={() => setActive((a) => !a)}
+        />
       </div>
     </section>
   );
@@ -5864,6 +5885,7 @@ function App() {
             <UserItemTrailingDemo />
             <TrendPillDemo />
             <AnimatedNumberDemo />
+            <AiButtonDemo />
 
             {/* Checkbox */}
             <CheckboxDemo />

--- a/src/components/AiButton/AiButton.stories.tsx
+++ b/src/components/AiButton/AiButton.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { AiButton } from "./AiButton";
+
+const meta = {
+  title: "Components/AiButton",
+  component: AiButton,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: "select", options: ["24", "32", "40"] },
+    active: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    label: "Analyse",
+    activeLabel: "Analysing",
+    active: false,
+    disabled: false,
+    size: "32",
+  },
+} satisfies Meta<typeof AiButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Active: Story = {
+  args: { active: true },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      {(["24", "32", "40"] as const).map((size) => (
+        <AiButton {...args} key={size} size={size} />
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * Both labels share one grid cell, so the button keeps the width of the longer
+ * label and toggling `active` crossfades without shifting the layout around it.
+ */
+export const Toggling: Story = {
+  render: (args) => {
+    const [active, setActive] = useState(false);
+    return (
+      <div className="flex items-center gap-4">
+        <AiButton {...args} active={active} onClick={() => setActive((value) => !value)} />
+        <span className="typography-description-12px-regular text-content-secondary">
+          click to toggle
+        </span>
+      </div>
+    );
+  },
+};
+
+export const LongLabel: Story = {
+  args: { label: "Analyse this chart", activeLabel: "Analysing this chart" },
+};

--- a/src/components/AiButton/AiButton.test.tsx
+++ b/src/components/AiButton/AiButton.test.tsx
@@ -138,6 +138,23 @@ describe("AiButton", () => {
       render(<AiButton label="A B" />);
       expect(screen.getByRole("button")).toHaveTextContent("A B");
     });
+
+    it("stops shimmering and stops lighting up on hover once disabled", () => {
+      render(<AiButton label="Ana" disabled />);
+      const letter = screen
+        .getByRole("button")
+        .querySelector<HTMLElement>("[aria-hidden='true'] > span");
+      expect(letter).not.toHaveClass("[animation:fv-ai-letter_2s_ease-in-out_infinite]");
+      expect(letter).not.toHaveClass("group-hover/ai:text-content-primary");
+    });
+
+    it("still shimmers when enabled", () => {
+      render(<AiButton label="Ana" />);
+      const letter = screen
+        .getByRole("button")
+        .querySelector<HTMLElement>("[aria-hidden='true'] > span");
+      expect(letter).toHaveClass("[animation:fv-ai-letter_2s_ease-in-out_infinite]");
+    });
   });
 
   describe("accessibility", () => {

--- a/src/components/AiButton/AiButton.test.tsx
+++ b/src/components/AiButton/AiButton.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { AiButton } from "./AiButton";
+
+describe("AiButton", () => {
+  describe("API", () => {
+    it("renders the label", () => {
+      render(<AiButton label="Analyse" />);
+      expect(screen.getByRole("button")).toHaveTextContent("Analyse");
+    });
+
+    it("names the button from the label rather than its split letters", () => {
+      render(<AiButton label="Analyse" />);
+      expect(screen.getByRole("button", { name: "Analyse" })).toBeInTheDocument();
+    });
+
+    it("names the button from the active label while active", () => {
+      render(<AiButton label="Analyse" activeLabel="Analysing" active />);
+      expect(screen.getByRole("button", { name: "Analysing" })).toBeInTheDocument();
+    });
+
+    it("prefers an explicit aria-label", () => {
+      render(<AiButton label="Analyse" aria-label="Analyse earnings" />);
+      expect(screen.getByRole("button", { name: "Analyse earnings" })).toBeInTheDocument();
+    });
+
+    it("falls back to the label when no active label is given", () => {
+      render(<AiButton label="Analyse" active />);
+      expect(screen.getByRole("button", { name: "Analyse" })).toBeInTheDocument();
+    });
+
+    it("marks itself busy only while active", () => {
+      const { rerender } = render(<AiButton label="Analyse" />);
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-busy");
+      rerender(<AiButton label="Analyse" active />);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-busy", "true");
+    });
+
+    it("defaults to type=button so it never submits a surrounding form", () => {
+      render(<AiButton label="Analyse" />);
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+
+    it("forwards ref to the button element", () => {
+      const ref = React.createRef<HTMLButtonElement>();
+      render(<AiButton label="Analyse" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    it("applies custom className and spreads HTML attributes", () => {
+      render(<AiButton label="Analyse" className="custom" data-x="y" />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("custom");
+      expect(button).toHaveAttribute("data-x", "y");
+    });
+  });
+
+  describe("interaction", () => {
+    it("calls onClick", async () => {
+      const onClick = vi.fn();
+      render(<AiButton label="Analyse" onClick={onClick} />);
+      await userEvent.click(screen.getByRole("button"));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it("does not call onClick when disabled", async () => {
+      const onClick = vi.fn();
+      render(<AiButton label="Analyse" onClick={onClick} disabled />);
+      await userEvent.click(screen.getByRole("button"));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sheen tracking", () => {
+    // jsdom reports a zero-sized rect for every element, so the percentage has to
+    // be driven off a stubbed rect to mean anything.
+    const stubWidth = (button: HTMLElement, left: number, width: number) => {
+      vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+        left,
+        width,
+      } as DOMRect);
+    };
+
+    it("points the sheen at the cursor", () => {
+      render(<AiButton label="Analyse" />);
+      const button = screen.getByRole("button");
+      stubWidth(button, 100, 200);
+
+      fireEvent.pointerMove(button, { clientX: 150 });
+
+      expect(button.style.getPropertyValue("--fv-ai-x")).toBe("25%");
+    });
+
+    it("recentres the sheen once the pointer leaves", () => {
+      render(<AiButton label="Analyse" />);
+      const button = screen.getByRole("button");
+      stubWidth(button, 0, 100);
+
+      fireEvent.pointerMove(button, { clientX: 80 });
+      expect(button.style.getPropertyValue("--fv-ai-x")).toBe("80%");
+
+      fireEvent.pointerLeave(button);
+      expect(button.style.getPropertyValue("--fv-ai-x")).toBe("");
+    });
+
+    it("still calls the caller's pointer handlers", () => {
+      const onPointerMove = vi.fn();
+      const onPointerLeave = vi.fn();
+      render(
+        <AiButton label="Analyse" onPointerMove={onPointerMove} onPointerLeave={onPointerLeave} />,
+      );
+      const button = screen.getByRole("button");
+      stubWidth(button, 0, 100);
+
+      fireEvent.pointerMove(button, { clientX: 10 });
+      fireEvent.pointerLeave(button);
+
+      expect(onPointerMove).toHaveBeenCalledOnce();
+      expect(onPointerLeave).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("letters", () => {
+    it("staggers each letter's animation by its index", () => {
+      render(<AiButton label="Ana" />);
+      const letters = screen
+        .getByRole("button")
+        .querySelectorAll<HTMLElement>("[aria-hidden='true'] > span");
+      expect(letters[0]).toHaveStyle({ animationDelay: "0s" });
+      expect(letters[1]).toHaveStyle({ animationDelay: "0.08s" });
+      expect(letters[2]).toHaveStyle({ animationDelay: "0.16s" });
+    });
+
+    it("keeps whitespace between words", () => {
+      render(<AiButton label="A B" />);
+      expect(screen.getByRole("button")).toHaveTextContent("A B");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has no accessibility violations", async () => {
+      const { container } = render(<AiButton label="Analyse" activeLabel="Analysing" />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations while active", async () => {
+      const { container } = render(<AiButton label="Analyse" activeLabel="Analysing" active />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/AiButton/AiButton.tsx
+++ b/src/components/AiButton/AiButton.tsx
@@ -67,20 +67,26 @@ export interface AiButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButto
  * The run is hidden from assistive tech — the button's accessible name comes from
  * its `aria-label`, so a screen reader says "Analyse" rather than spelling it out.
  */
-const ShimmerLabel: React.FC<{ text: string }> = ({ text }) => (
+const ShimmerLabel: React.FC<{ text: string; disabled?: boolean }> = ({ text, disabled }) => (
   <span aria-hidden="true">
     {Array.from(text).map((character, index) => (
       <span
         key={`${character}-${index}`}
         className={cn(
           "inline-block whitespace-pre text-content-secondary",
-          "[animation:fv-ai-letter_2s_ease-in-out_infinite]",
-          "group-hover/ai:text-content-primary group-hover/ai:[animation:none]",
-          // On focus each letter blows up and settles, then the idle shimmer
-          // resumes underneath it — the two animations are sequenced by delay.
-          "group-focus-visible/ai:[animation:fv-ai-letter-focus_1s_ease-in-out,fv-ai-letter_1.2s_ease-in-out_infinite_1s]",
-          "group-active/ai:text-content-primary group-active/ai:[animation:none]",
-          "group-active/ai:[text-shadow:0_0_4px_var(--color-content-primary)]",
+          // Gated in JS rather than with a `group-disabled/ai:` override, because
+          // that would rely on the generated rule ordering to beat `group-hover`.
+          // A faded control that still shimmers and still lights up green under the
+          // cursor reads as busy rather than unavailable.
+          !disabled && [
+            "[animation:fv-ai-letter_2s_ease-in-out_infinite]",
+            "group-hover/ai:text-content-primary group-hover/ai:[animation:none]",
+            // On focus each letter blows up and settles, then the idle shimmer
+            // resumes underneath it — the two animations are sequenced by delay.
+            "group-focus-visible/ai:[animation:fv-ai-letter-focus_1s_ease-in-out,fv-ai-letter_1.2s_ease-in-out_infinite_1s]",
+            "group-active/ai:text-content-primary group-active/ai:[animation:none]",
+            "group-active/ai:[text-shadow:0_0_4px_var(--color-content-primary)]",
+          ],
           "motion-reduce:[animation:none]",
         )}
         style={{ animationDelay: `${index * LETTER_STAGGER}s` }}
@@ -168,11 +174,15 @@ export const AiButton = React.forwardRef<HTMLButtonElement, AiButtonProps>(
             "flex shrink-0 items-center text-content-primary",
             iconScaleVariants[size],
             "[filter:drop-shadow(0_0_2px_color-mix(in_srgb,var(--color-content-primary)_60%,transparent))]",
-            "[animation:fv-ai-flicker_2s_linear_infinite] [animation-delay:0.5s]",
-            // Settles solid on hover, lit green from below like the sheen.
-            "group-hover/ai:[animation:none]",
-            "group-hover/ai:[filter:drop-shadow(0_0_3px_var(--color-brand-primary-default))_drop-shadow(0_-4px_6px_color-mix(in_srgb,var(--color-content-always-black)_60%,transparent))]",
-            "group-focus-visible/ai:[animation-duration:1.2s] group-focus-visible/ai:[animation-delay:0.2s]",
+            // Same reasoning as the letters: no flicker and no green lift once the
+            // button is unavailable.
+            !disabled && [
+              "[animation:fv-ai-flicker_2s_linear_infinite] [animation-delay:0.5s]",
+              // Settles solid on hover, lit green from below like the sheen.
+              "group-hover/ai:[animation:none]",
+              "group-hover/ai:[filter:drop-shadow(0_0_3px_var(--color-brand-primary-default))_drop-shadow(0_-4px_6px_color-mix(in_srgb,var(--color-content-always-black)_60%,transparent))]",
+              "group-focus-visible/ai:[animation-duration:1.2s] group-focus-visible/ai:[animation-delay:0.2s]",
+            ],
             "motion-reduce:[animation:none]",
           )}
         >
@@ -187,7 +197,7 @@ export const AiButton = React.forwardRef<HTMLButtonElement, AiButtonProps>(
               active ? "opacity-0" : "opacity-100",
             )}
           >
-            <ShimmerLabel text={label} />
+            <ShimmerLabel text={label} disabled={disabled} />
           </span>
           <span
             className={cn(
@@ -195,7 +205,7 @@ export const AiButton = React.forwardRef<HTMLButtonElement, AiButtonProps>(
               active ? "opacity-100" : "opacity-0",
             )}
           >
-            <ShimmerLabel text={resolvedActiveLabel} />
+            <ShimmerLabel text={resolvedActiveLabel} disabled={disabled} />
           </span>
         </span>
       </button>

--- a/src/components/AiButton/AiButton.tsx
+++ b/src/components/AiButton/AiButton.tsx
@@ -80,7 +80,7 @@ const ShimmerLabel: React.FC<{ text: string }> = ({ text }) => (
           // resumes underneath it — the two animations are sequenced by delay.
           "group-focus-visible/ai:[animation:fv-ai-letter-focus_1s_ease-in-out,fv-ai-letter_1.2s_ease-in-out_infinite_1s]",
           "group-active/ai:text-content-primary group-active/ai:[animation:none]",
-          "group-active/ai:[text-shadow:0_0_4px_var(--color-content-always-white)]",
+          "group-active/ai:[text-shadow:0_0_4px_var(--color-content-primary)]",
           "motion-reduce:[animation:none]",
         )}
         style={{ animationDelay: `${index * LETTER_STAGGER}s` }}
@@ -165,9 +165,9 @@ export const AiButton = React.forwardRef<HTMLButtonElement, AiButtonProps>(
       >
         <span
           className={cn(
-            "flex shrink-0 items-center text-content-always-white",
+            "flex shrink-0 items-center text-content-primary",
             iconScaleVariants[size],
-            "[filter:drop-shadow(0_0_2px_color-mix(in_srgb,var(--color-content-always-white)_60%,transparent))]",
+            "[filter:drop-shadow(0_0_2px_color-mix(in_srgb,var(--color-content-primary)_60%,transparent))]",
             "[animation:fv-ai-flicker_2s_linear_infinite] [animation-delay:0.5s]",
             // Settles solid on hover, lit green from below like the sheen.
             "group-hover/ai:[animation:none]",

--- a/src/components/AiButton/AiButton.tsx
+++ b/src/components/AiButton/AiButton.tsx
@@ -1,0 +1,206 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { AIIcon } from "../Icons/AIIcon";
+import type { IconSize } from "../Icons/types";
+
+/** Height, padding and label typography, matching {@link Button}'s scale. */
+export type AiButtonSize = "24" | "32" | "40";
+
+const sizeVariants: Record<AiButtonSize, string> = {
+  // At 24 the label steps down to the 12px description scale: the 14px label
+  // Button uses at this height leaves the glyph and text crowding a 24px box,
+  // since 16px is the smallest authored icon geometry and cannot step down with it.
+  "24": "h-6 gap-1 px-2 py-1 typography-description-12px-semibold",
+  "32": "h-8 gap-2 px-3 py-[7px] typography-body-small-14px-semibold",
+  "40": "h-10 gap-2 px-4 py-2 typography-body-default-16px-semibold",
+};
+
+const iconSizeVariants: Record<AiButtonSize, IconSize> = {
+  "24": 16,
+  "32": 16,
+  "40": 24,
+};
+
+/**
+ * Optical size, applied on top of the authored geometry. Only 16, 24 and 32 have
+ * dedicated paths, so the 24 button renders the 16px glyph down at 14 to sit with
+ * its 12px label rather than towering over it.
+ */
+const iconScaleVariants: Record<AiButtonSize, string> = {
+  "24": "[&_svg]:size-3.5",
+  "32": "",
+  "40": "",
+};
+
+/** Delay between adjacent letters, in seconds. */
+const LETTER_STAGGER = 0.08;
+
+/**
+ * Points the bottom sheen at the cursor by writing its x offset, as a percentage
+ * of the button's width, straight to the DOM node. Deliberately not React state:
+ * this fires every pointer-move frame, and a re-render per frame would both cost
+ * more than the paint and leave the glow trailing the cursor.
+ */
+const trackPointer = (event: React.PointerEvent<HTMLButtonElement>) => {
+  const { left, width } = event.currentTarget.getBoundingClientRect();
+  event.currentTarget.style.setProperty("--fv-ai-x", `${((event.clientX - left) / width) * 100}%`);
+};
+
+/** Props for {@link AiButton}. */
+export interface AiButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+  /** Resting label. Also the accessible name unless `aria-label` is given. */
+  label: string;
+  /** Label shown while `active`. Falls back to {@link label}. */
+  activeLabel?: string;
+  /** Swap to {@link activeLabel} and keep the shimmer running. @default false */
+  active?: boolean;
+  /** @default "32" */
+  size?: AiButtonSize;
+  /** Replace the leading AI glyph. */
+  icon?: React.ReactNode;
+  /** @default "button" */
+  type?: "button" | "submit" | "reset";
+}
+
+/**
+ * Renders one `<span>` per character so each can carry its own animation delay.
+ * The run is hidden from assistive tech — the button's accessible name comes from
+ * its `aria-label`, so a screen reader says "Analyse" rather than spelling it out.
+ */
+const ShimmerLabel: React.FC<{ text: string }> = ({ text }) => (
+  <span aria-hidden="true">
+    {Array.from(text).map((character, index) => (
+      <span
+        key={`${character}-${index}`}
+        className={cn(
+          "inline-block whitespace-pre text-content-secondary",
+          "[animation:fv-ai-letter_2s_ease-in-out_infinite]",
+          "group-hover/ai:text-content-primary group-hover/ai:[animation:none]",
+          // On focus each letter blows up and settles, then the idle shimmer
+          // resumes underneath it — the two animations are sequenced by delay.
+          "group-focus-visible/ai:[animation:fv-ai-letter-focus_1s_ease-in-out,fv-ai-letter_1.2s_ease-in-out_infinite_1s]",
+          "group-active/ai:text-content-primary group-active/ai:[animation:none]",
+          "group-active/ai:[text-shadow:0_0_4px_var(--color-content-always-white)]",
+          "motion-reduce:[animation:none]",
+        )}
+        style={{ animationDelay: `${index * LETTER_STAGGER}s` }}
+      >
+        {character}
+      </span>
+    ))}
+  </span>
+);
+
+/**
+ * A pill button for AI actions. The label shimmers letter by letter and the glyph
+ * flickers at rest; on hover both settle and the green treatment eases in together
+ * — outline, rim and a sheen pooling along the bottom edge under the cursor, which
+ * follows it across the button. On focus each letter blooms once before the shimmer
+ * resumes. The lit rim and sheen come from the `fv-ai-button` utility in `base.css`.
+ *
+ * It shares {@link Button}'s geometry — `rounded-full`, the same heights and label
+ * typography — so it sits alongside one without looking foreign. Both labels are
+ * rendered stacked in a single grid cell, so swapping to `active` crossfades
+ * without the button changing width.
+ *
+ * Honours `prefers-reduced-motion`: the shimmer and flicker are dropped and the
+ * label renders in its settled state.
+ *
+ * @example
+ * ```tsx
+ * <AiButton label="Analyse" activeLabel="Analysing" active={isPending} onClick={run} />
+ * ```
+ */
+export const AiButton = React.forwardRef<HTMLButtonElement, AiButtonProps>(
+  (
+    {
+      label,
+      activeLabel,
+      active = false,
+      size = "32",
+      icon,
+      type = "button",
+      className,
+      disabled,
+      onPointerMove,
+      onPointerLeave,
+      ...props
+    },
+    ref,
+  ) => {
+    const resolvedActiveLabel = activeLabel ?? label;
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={disabled}
+        aria-label={props["aria-label"] ?? (active ? resolvedActiveLabel : label)}
+        aria-busy={active || undefined}
+        onPointerMove={(event) => {
+          trackPointer(event);
+          onPointerMove?.(event);
+        }}
+        // Drop back to the utility's centred default, so a keyboard focus after
+        // the pointer has left does not light up wherever the cursor last was.
+        onPointerLeave={(event) => {
+          event.currentTarget.style.removeProperty("--fv-ai-x");
+          onPointerLeave?.(event);
+        }}
+        className={cn(
+          "fv-ai-button",
+          "group/ai inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-full",
+          "border border-border-primary bg-background-primary",
+          // Matched to the rim and sheen so the whole treatment arrives as one
+          // movement — at the old 300ms the outline landed ahead of the glow.
+          "transition-[background-color,border-color] duration-[400ms] ease-out",
+          "hover:border-brand-primary-default",
+          "focus-visible:outline-none",
+          "active:border-brand-primary-hover active:bg-brand-primary-muted",
+          "disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-border-primary",
+          sizeVariants[size],
+          className,
+        )}
+        {...props}
+      >
+        <span
+          className={cn(
+            "flex shrink-0 items-center text-content-always-white",
+            iconScaleVariants[size],
+            "[filter:drop-shadow(0_0_2px_color-mix(in_srgb,var(--color-content-always-white)_60%,transparent))]",
+            "[animation:fv-ai-flicker_2s_linear_infinite] [animation-delay:0.5s]",
+            // Settles solid on hover, lit green from below like the sheen.
+            "group-hover/ai:[animation:none]",
+            "group-hover/ai:[filter:drop-shadow(0_0_3px_var(--color-brand-primary-default))_drop-shadow(0_-4px_6px_color-mix(in_srgb,var(--color-content-always-black)_60%,transparent))]",
+            "group-focus-visible/ai:[animation-duration:1.2s] group-focus-visible/ai:[animation-delay:0.2s]",
+            "motion-reduce:[animation:none]",
+          )}
+        >
+          {icon ?? <AIIcon size={iconSizeVariants[size]} filled />}
+        </span>
+        {/* Both labels occupy one grid cell so the button keeps the width of the
+            longer of the two and the swap never reflows the row around it. */}
+        <span className="grid">
+          <span
+            className={cn(
+              "col-start-1 row-start-1 transition-opacity duration-300",
+              active ? "opacity-0" : "opacity-100",
+            )}
+          >
+            <ShimmerLabel text={label} />
+          </span>
+          <span
+            className={cn(
+              "col-start-1 row-start-1 transition-opacity duration-300",
+              active ? "opacity-100" : "opacity-0",
+            )}
+          >
+            <ShimmerLabel text={resolvedActiveLabel} />
+          </span>
+        </span>
+      </button>
+    );
+  },
+);
+
+AiButton.displayName = "AiButton";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ export type { AccordionItemProps } from "./components/Accordion/AccordionItem";
 export { AccordionItem } from "./components/Accordion/AccordionItem";
 export type { AccordionTriggerProps } from "./components/Accordion/AccordionTrigger";
 export { AccordionTrigger } from "./components/Accordion/AccordionTrigger";
+export type {
+  AiButtonProps,
+  AiButtonSize,
+} from "./components/AiButton/AiButton";
+export { AiButton } from "./components/AiButton/AiButton";
 export type { AlertProps, AlertVariant } from "./components/Alert/Alert";
 export { Alert } from "./components/Alert/Alert";
 export type {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -111,6 +111,172 @@
 }
 
 /*
+ * AiButton. Each letter runs `fv-ai-letter` on a staggered delay set inline from
+ * its index, which is what produces the left-to-right sweep — the alternative,
+ * a fixed set of :nth-child delays, silently stops staggering past whatever
+ * length the rules were written for.
+ */
+@keyframes fv-ai-letter {
+  50% {
+    color: var(--color-content-primary);
+    text-shadow: 0 0 6px var(--color-content-always-white);
+  }
+}
+
+@keyframes fv-ai-flicker {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@keyframes fv-ai-letter-focus {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: blur(0);
+  }
+  50% {
+    transform: scale(1.6);
+    filter: blur(6px) brightness(150%)
+      drop-shadow(-12px 4px 8px var(--color-content-always-white));
+  }
+}
+
+/*
+ * Registering the property is what makes it animatable: an unregistered custom
+ * property is just a token string to the engine, so it would jump between values
+ * and the sheen would snap to centre on pointer-out instead of gliding there.
+ * Browsers without @property degrade to exactly that snap, which is the old
+ * behaviour rather than a broken one.
+ */
+@property --fv-ai-x {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 50%;
+}
+
+/*
+ * AiButton surface. The lit rim and the sheen are pseudo-elements rather than
+ * box-shadows on the button so they can be masked and brightened independently
+ * of the border, which is what gives the control its "powered on" feel.
+ */
+@utility fv-ai-button {
+  position: relative;
+
+  /*
+   * Horizontal centre of the sheen, as a percentage of the button's width. The
+   * component rewrites this inline on pointer move so the glow tracks the cursor;
+   * the default keeps it centred for keyboard focus and touch, where there is no
+   * pointer position to follow.
+   */
+  --fv-ai-x: 50%;
+
+  /*
+   * Rim just outside the border: unlit at rest, catching green as it lifts. It
+   * carries only inset glow — the 1px light/dark bevel pair it used to also draw
+   * read as a second outline ringing the button 3px out from its actual border.
+   */
+  &::before {
+    content: "";
+    position: absolute;
+    inset: -3px;
+    z-index: -1;
+    border-radius: inherit;
+    pointer-events: none;
+    transition: box-shadow 400ms ease-out;
+    box-shadow:
+      0 -8px 8px -6px transparent inset,
+      0 -16px 16px -8px transparent inset;
+  }
+
+  /*
+   * Sheen rising from the bottom edge, masked so it fades before the top. It is a
+   * radial pool anchored to the bottom and centred on `--fv-ai-x` rather than a
+   * flat linear wash, so it reads as light cast from wherever the cursor is.
+   *
+   * This block is the pointer-out state, and it is where the exit is shaped: the
+   * pool glides back to centre while `ease-in` holds the opacity near full before
+   * dropping it, and the filter deepens the green as it recedes. The effect is the
+   * light sliding away and going out, rather than blinking off wherever it stood.
+   */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    opacity: 0;
+    filter: brightness(150%) saturate(140%);
+    transition:
+      opacity 550ms ease-in,
+      filter 550ms ease-in,
+      --fv-ai-x 550ms ease-out;
+    background-image: radial-gradient(
+      55% 130% at var(--fv-ai-x) 100%,
+      var(--color-brand-primary-default),
+      color-mix(in srgb, var(--color-brand-primary-default) 45%, transparent)
+        35%,
+      transparent 70%
+    );
+    mask-image: linear-gradient(
+      0deg,
+      var(--color-content-always-white),
+      transparent
+    );
+  }
+
+  &:hover::before {
+    box-shadow:
+      0 -8px 8px -6px
+        color-mix(in srgb, var(--color-content-always-white) 60%, transparent)
+        inset,
+      0 -16px 16px -8px
+        color-mix(in srgb, var(--color-brand-primary-default) 30%, transparent)
+        inset;
+  }
+
+  /*
+   * Pointer-in. `ease-out` over the same 400ms as the rim and the border, so the
+   * treatment lifts in as one movement and settles rather than arriving in pieces.
+   */
+  &:hover::after {
+    opacity: 1;
+    filter: none;
+    /* `--fv-ai-x` must not be transitioned while the pointer is over the button:
+       it is rewritten every move frame, and any duration here makes the glow
+       trail the cursor instead of sitting under it. */
+    transition:
+      opacity 400ms ease-out,
+      filter 400ms ease-out,
+      --fv-ai-x 0s;
+  }
+
+  &:focus-visible::after {
+    opacity: 0.6;
+  }
+
+  &:active::before {
+    box-shadow:
+      0 -8px 12px -6px
+        color-mix(in srgb, var(--color-content-always-white) 66%, transparent)
+        inset,
+      0 -16px 16px -8px
+        color-mix(in srgb, var(--color-brand-primary-default) 80%, transparent)
+        inset;
+  }
+
+  &:active::after {
+    opacity: 1;
+    filter: brightness(200%);
+  }
+
+  &:disabled::before,
+  &:disabled::after {
+    box-shadow: none;
+    opacity: 0;
+  }
+}
+/*
  * Animate `height` between 0 and the panel's measured height
  * (`--radix-accordion-content-height`, which Radix sets from a getBoundingClientRect
  * in a useLayoutEffect). This is the canonical Radix/Collapsible pattern and keeps the


### PR DESCRIPTION
Third of six extracted from the `insights-components` batch. Independent of the others.

The AI action button from the insights designs: a per-letter shimmer at rest, a glyph flicker, and a bottom sheen that tracks the cursor. `active` swaps to `activeLabel` and keeps the shimmer running while work is in flight.

Two things worth a reviewer's eye:

**The letter run is hidden from assistive tech.** It renders one `<span>` per character to give each its own animation delay, which a screen reader would otherwise spell out. The run carries `aria-hidden` and the accessible name comes from `label` (or `aria-label`), so it says "Analyse" rather than "A, n, a, l, y, s, e".

**The 24 size steps its label down to the 12px scale**, unlike `Button`, which uses 14px at that height. Not a mismatch: 16px is the smallest authored icon geometry and cannot step down with the label, so at 14px the glyph and text crowd a 24px box. The 24 button renders the 16px glyph optically at 14 for the same reason. Both are commented at the constant.

The cursor-tracking sheen writes its x offset straight to the DOM node rather than through state, deliberately, so a pointer move does not re-render the button.

Honours `motion-reduce`.

**Three biome warnings come across with the code** and I have left them rather than widening the diff: two `useSortedClasses` inside arbitrary-value arrays where reordering risks changing specificity, and one `noArrayIndexKey` on the character run, where the index genuinely is the identity because characters repeat. Happy to add a `biome-ignore` with that rationale if you would rather it were explicit. Neither fails lint (`biome check` exits 0 on warnings) and `App.tsx` already ships two of the same kind.

24 tests including axe, `tsc --noEmit` clean.