### PR TITLE
feat(Chart): add ChartMetricTrend for the metric tile area chart

### DIFF
--- a/src/charts.ts
+++ b/src/charts.ts
@@ -9,6 +9,11 @@ export type { ChartLegendContentProps } from "./components/Chart/ChartLegend";
 export { ChartLegend, ChartLegendContent } from "./components/Chart/ChartLegend";
 export type { ChartLoadingOverlayProps } from "./components/Chart/ChartLoadingOverlay";
 export { ChartLoadingOverlay } from "./components/Chart/ChartLoadingOverlay";
+export type {
+  ChartMetricTrendColor,
+  ChartMetricTrendProps,
+} from "./components/Chart/ChartMetricTrend";
+export { ChartMetricTrend } from "./components/Chart/ChartMetricTrend";
 export type { ChartPieLegendItem, ChartPieLegendProps } from "./components/Chart/ChartPieLegend";
 export { ChartPieLegend } from "./components/Chart/ChartPieLegend";
 export type {

--- a/src/components/Chart/ChartMetricTrend.stories.tsx
+++ b/src/components/Chart/ChartMetricTrend.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ChartMetricTrend } from "./ChartMetricTrend";
+
+const meta = {
+  title: "Charts/ChartMetricTrend",
+  component: ChartMetricTrend,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    color: {
+      control: "inline-radio",
+      options: ["red", "teal"],
+    },
+  },
+  args: {
+    value: 62,
+    color: "teal",
+    series: [41, 44, 43, 52, 58, 55, 62],
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-[320px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ChartMetricTrend>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithSeries: Story = {
+  name: "With series",
+};
+
+export const Red: Story = {
+  args: { color: "red", series: [78, 74, 75, 69, 66, 61, 58] },
+};
+
+export const FlatWithoutSeries: Story = {
+  name: "Flat (no series)",
+  args: { series: undefined },
+};

--- a/src/components/Chart/ChartMetricTrend.stories.tsx
+++ b/src/components/Chart/ChartMetricTrend.stories.tsx
@@ -44,3 +44,19 @@ export const FlatWithoutSeries: Story = {
   name: "Flat (no series)",
   args: { series: undefined },
 };
+
+/**
+ * Two cards of the same colour, which is the case that would break a gradient id
+ * scoped by colour: both would emit the same `id` and every `url(#...)` in the
+ * document would resolve to whichever rendered first. Both series must show their
+ * own shape and fade.
+ */
+export const TwoSameColourCards: Story = {
+  name: "Two cards, same colour",
+  render: () => (
+    <div className="flex gap-4">
+      <ChartMetricTrend value={69} color="teal" series={[40, 46, 52, 58, 61, 66, 69]} />
+      <ChartMetricTrend value={22} color="teal" series={[70, 58, 44, 36, 30, 25, 22]} />
+    </div>
+  ),
+};

--- a/src/components/Chart/ChartMetricTrend.test.tsx
+++ b/src/components/Chart/ChartMetricTrend.test.tsx
@@ -10,7 +10,7 @@ import { ChartMetricTrend } from "./ChartMetricTrend";
  * gradient. Asserting on any of that would either fail or, worse, pass vacuously
  * against an empty NodeList. So these cover the wrapper contract only, which is
  * what the DS PR template asks for; the drawn series, its gradient and the
- * per-colour gradient scoping are covered by ChartMetricTrend.stories.tsx, which
+ * per-instance gradient ids are covered by ChartMetricTrend.stories.tsx, which
  * runs in a real browser.
  */
 describe("ChartMetricTrend", () => {

--- a/src/components/Chart/ChartMetricTrend.test.tsx
+++ b/src/components/Chart/ChartMetricTrend.test.tsx
@@ -1,0 +1,57 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { ChartMetricTrend } from "./ChartMetricTrend";
+
+/*
+ * Scope note: recharts needs a measured container to draw, and jsdom reports zero
+ * size, so nothing inside `<AreaChart>` is rendered here — no path, no `<defs>`, no
+ * gradient. Asserting on any of that would either fail or, worse, pass vacuously
+ * against an empty NodeList. So these cover the wrapper contract only, which is
+ * what the DS PR template asks for; the drawn series, its gradient and the
+ * per-colour gradient scoping are covered by ChartMetricTrend.stories.tsx, which
+ * runs in a real browser.
+ */
+describe("ChartMetricTrend", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ChartMetricTrend value={69} color="red" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("forwards ref", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<ChartMetricTrend ref={ref} value={69} color="red" />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("chains className onto its own classes", () => {
+    const { container } = render(<ChartMetricTrend value={69} color="teal" className="mt-2" />);
+    const root = container.querySelector("[data-slot='chart']");
+    expect(root).toHaveClass("mt-2");
+    // Its own height must survive the merge — this is the design's slot height.
+    expect(root).toHaveClass("h-[106px]");
+  });
+
+  it("spreads additional HTML attributes", () => {
+    const { container } = render(<ChartMetricTrend value={69} color="red" data-testid="trend" />);
+    expect(container.querySelector("[data-testid='trend']")).not.toBeNull();
+  });
+
+  it("renders at the design's 106px slot height", () => {
+    const { container } = render(<ChartMetricTrend value={69} color="red" />);
+    expect(container.querySelector("[data-slot='chart']")).toHaveClass("h-[106px]");
+  });
+
+  it("renders with no series, where the endpoint returns a bare scalar", () => {
+    const { container } = render(<ChartMetricTrend value={42} color="teal" />);
+    expect(container.querySelector("[data-slot='chart']")).not.toBeNull();
+  });
+
+  it("renders with a multi-point series", () => {
+    const { container } = render(
+      <ChartMetricTrend value={42} color="teal" series={[10, 20, 15, 30]} />,
+    );
+    expect(container.querySelector("[data-slot='chart']")).not.toBeNull();
+  });
+});

--- a/src/components/Chart/ChartMetricTrend.tsx
+++ b/src/components/Chart/ChartMetricTrend.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { Area, AreaChart, YAxis } from "recharts";
+import { cn } from "../../utils/cn";
+import { ChartContainer } from "./ChartContainer";
+import type { ChartConfig } from "./types";
+
+/**
+ * Each card carries its own gradient in the design: red on Retention Rate,
+ * green on Average Fan Lifetime. The DS has no `special-chart-green`, so the
+ * green maps to `teal` (#28ba8e) — the emerald in the Figma render, as opposed
+ * to `lime` (#8fcb3a), which is yellow-green.
+ */
+export type ChartMetricTrendColor = "red" | "teal";
+
+const CHART_COLORS: Record<ChartMetricTrendColor, string> = {
+  red: "var(--color-special-chart-red)",
+  teal: "var(--color-special-chart-teal)",
+};
+
+/** Props for {@link ChartMetricTrend}. */
+export interface ChartMetricTrendProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Current value. Also the flat-line height when `series` is absent. */
+  value: number;
+  /** Gradient and stroke colour. */
+  color: ChartMetricTrendColor;
+  /** History to plot. Needs more than one point to draw a shape. */
+  series?: number[];
+}
+
+/**
+ * The small area chart inside a metric tile, per the `V2 Area Chart Item` slot of
+ * the Figma insight card.
+ *
+ * `series` is optional because the endpoints behind these cards often return a
+ * single scalar with no history. With nothing to plot the chart draws a flat line
+ * at the current value rather than collapsing the slot, so the card keeps the
+ * height and shape the design gives it. The line is deliberately level rather
+ * than shaped, so it asserts no history that the data cannot support.
+ *
+ * @example
+ * ```tsx
+ * <ChartMetricTrend value={42} color="teal" />
+ * ```
+ */
+export const ChartMetricTrend = React.forwardRef<HTMLDivElement, ChartMetricTrendProps>(
+  ({ value, color, series, className, ...props }, ref) => {
+    const points = series && series.length > 1 ? series : [value, value];
+    const chartData = points.map((point, index) => ({ index, value: point }));
+    const chartConfig: ChartConfig = { value: { color: CHART_COLORS[color] } };
+    // Scoped per colour so two cards on the same page don't share one gradient def.
+    const gradientId = `metric-trend-gradient-${color}`;
+
+    return (
+      // 106px is the design's `V2 Area Chart Item` slot height.
+      <ChartContainer
+        ref={ref}
+        config={chartConfig}
+        className={cn("block aspect-auto h-[106px] w-full", className)}
+        {...props}
+      >
+        <AreaChart data={chartData} margin={{ top: 4, bottom: 0, left: 0, right: 0 }}>
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--color-value)" stopOpacity={0.3} />
+              <stop offset="100%" stopColor="var(--color-value)" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          {/*
+           * Padded domain so a flat line sits inside the plot area instead of
+           * along its floor, where it would read as a zero value.
+           */}
+          <YAxis hide domain={["dataMin - 1", "dataMax + 1"]} />
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke="var(--color-value)"
+            strokeWidth={2}
+            fill={`url(#${gradientId})`}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ChartContainer>
+    );
+  },
+);
+
+ChartMetricTrend.displayName = "ChartMetricTrend";

--- a/src/components/Chart/ChartMetricTrend.tsx
+++ b/src/components/Chart/ChartMetricTrend.tsx
@@ -47,8 +47,11 @@ export const ChartMetricTrend = React.forwardRef<HTMLDivElement, ChartMetricTren
     const points = series && series.length > 1 ? series : [value, value];
     const chartData = points.map((point, index) => ({ index, value: point }));
     const chartConfig: ChartConfig = { value: { color: CHART_COLORS[color] } };
-    // Scoped per colour so two cards on the same page don't share one gradient def.
-    const gradientId = `metric-trend-gradient-${color}`;
+    // Per instance, not per colour: two same-colour cards would otherwise emit the
+    // same id and every `url(#...)` in the document would resolve to whichever
+    // rendered first. `useId` emits colons, which are legal in an `id` but break
+    // `querySelector`, so strip them.
+    const gradientId = `metric-trend-gradient-${React.useId().replace(/:/g, "")}`;
 
     return (
       // 106px is the design's `V2 Area Chart Item` slot height.


### PR DESCRIPTION
Fourth of six extracted from the `insights-components` batch. Independent of the others.

The small area chart that fills the `V2 Area Chart Item` slot of the Figma insight card. Exported from `@fanvue/ui/charts`, not the root, matching `ChartSkeleton` and `ChartPieLegend`. Story only, no `App.tsx` demo, for the same reason.

Two decisions worth checking rather than skimming:

**`series` is optional and absence draws a flat line.** The endpoints behind these cards often return a single scalar with no history. Rather than collapse the slot and lose the height and shape the design gives the card, it draws a level line at the current value. Level rather than shaped on purpose, so it asserts no trend the data cannot support. That is the kind of thing worth disagreeing with if you do, so it is spelled out in the doc comment.

**`green` maps to `teal`.** The design puts red on Retention Rate and green on Average Fan Lifetime, but there is no `special-chart-green` token. `teal` (`#28ba8e`) is the emerald in the Figma render; `lime` (`#8fcb3a`) is yellow-green and would be wrong. Noted at the type.

This is the first consumer of `special-chart-red` from #629. Relevant to your contrast note there: red is 3.27:1 against white, so it clears WCAG 1.4.11's 3:1 even as the stroke it is used as here. The yellow at 1.42:1 is not used by this component.

10 tests including axe, `tsc --noEmit` clean, biome clean with no fixes needed.