### PR TITLE
feat(UserItem): add trailing, primary and secondary slots plus UserItemTrailing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -265,6 +265,8 @@ import {
   UserCircleIcon,
   UserDisplayName,
   UserIcon,
+  UserItem,
+  UserItemTrailing,
   UsersIcon,
   VideoIcon,
   VipBadgeIcon,
@@ -2476,6 +2478,28 @@ function AudioRecordButtonDemo() {
         </div>
       </div>
     </div>
+  );
+}
+
+function UserItemTrailingDemo() {
+  return (
+    <section>
+      <h2 className="typography-header-heading-sm mb-4">UserItem trailing</h2>
+      <div className="flex max-w-sm flex-col gap-2">
+        <UserItem
+          user={{ displayName: "Jane Doe", handle: "jane_doe" }}
+          avatarSize={32}
+          showHandle={false}
+          trailing={<UserItemTrailing value="$14,523.59" meta="12 purchases" />}
+        />
+        <UserItem
+          user={{ displayName: "Alex Kim", handle: "alex_kim" }}
+          avatarSize={32}
+          showHandle={false}
+          trailing={<UserItemTrailing value="$980.00" meta="3 purchases" />}
+        />
+      </div>
+    </section>
   );
 }
 
@@ -5768,6 +5792,7 @@ function App() {
 
             {/* Pill */}
             <PillDemo />
+            <UserItemTrailingDemo />
 
             {/* Checkbox */}
             <CheckboxDemo />

--- a/src/components/UserItem/UserItem.stories.tsx
+++ b/src/components/UserItem/UserItem.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { UserItem } from "./UserItem";
+import { UserItemTrailing } from "./UserItemTrailing";
 
 const SAMPLE_AVATAR =
   "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop";
@@ -137,6 +138,82 @@ export const States: Story = {
       <UserItem {...args} showHandle={false} />
       <UserItem {...args} showAvatar={false} />
       <UserItem {...args} user={{ ...sampleUser, nickname: "Aitana" }} />
+    </div>
+  ),
+};
+
+export const Trailing: Story = {
+  args: {
+    avatarSize: 32,
+    showHandle: false,
+    trailing: <UserItemTrailing value="$14,523.59" />,
+  },
+};
+
+/**
+ * Trailing content keeps its intrinsic width while the name truncates, so values
+ * stay aligned down a list whatever the display names do.
+ */
+export const TrailingList: Story = {
+  name: "Trailing (list)",
+  render: (args) => (
+    <div className="flex w-96 flex-col gap-2">
+      {[
+        { name: "Caroline King", value: "$14,523.59" },
+        { name: "Agency Chatter", value: "$12,837.17" },
+        { name: "Agency Managed Creator 1 Fan", value: "$12,545.95" },
+      ].map(({ name, value }) => (
+        <UserItem
+          {...args}
+          key={name}
+          user={{ ...sampleUser, displayName: name }}
+          avatarSize={32}
+          showHandle={false}
+          trailing={<UserItemTrailing value={value} />}
+        />
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * An activity feed: `primary` carries a sentence about the user instead of their
+ * name, and the value sits above its timestamp at the end of the row.
+ */
+export const ActivityFeed: Story = {
+  name: "Activity feed (secondary + trailing)",
+  render: (args) => (
+    <div className="flex w-96 flex-col gap-2">
+      {[
+        {
+          name: "Benjamin Griffin",
+          action: "subscribed to your feed",
+          value: "$421.32",
+          meta: "7 hours ago",
+        },
+        {
+          name: "Caroline King",
+          action: "renewed their subscription",
+          value: "$102.05",
+          meta: "22 hours ago",
+        },
+        {
+          name: "Agency Chatter",
+          action: "purchased a post",
+          value: "$21.88",
+          meta: "1 day ago",
+        },
+      ].map(({ name, action, value, meta }) => (
+        <UserItem
+          {...args}
+          key={name}
+          user={{ ...sampleUser, displayName: name }}
+          avatarSize={32}
+          showHandle={false}
+          secondary={action}
+          trailing={<UserItemTrailing value={value} meta={meta} />}
+        />
+      ))}
     </div>
   ),
 };

--- a/src/components/UserItem/UserItem.test.tsx
+++ b/src/components/UserItem/UserItem.test.tsx
@@ -147,10 +147,81 @@ describe("UserItem", () => {
     });
   });
 
+  describe("trailing", () => {
+    it("renders no trailing slot by default", () => {
+      render(<UserItem user={baseUser} data-testid="item" />);
+      expect(screen.getByTestId("item").children).toHaveLength(2);
+    });
+
+    it("renders trailing content as the last child of the row", () => {
+      render(<UserItem user={baseUser} trailing={<span>$14,523.59</span>} data-testid="item" />);
+      expect(screen.getByText("$14,523.59")).toBeInTheDocument();
+      expect(screen.getByTestId("item").lastElementChild).toHaveTextContent("$14,523.59");
+    });
+
+    it("keeps trailing content at its intrinsic width", () => {
+      render(<UserItem user={baseUser} trailing={<span>12</span>} data-testid="item" />);
+      expect(screen.getByTestId("item").lastElementChild).toHaveClass("shrink-0");
+    });
+  });
+
+  describe("primary", () => {
+    it("renders the display name when primary is not given", () => {
+      render(<UserItem user={baseUser} />);
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    });
+
+    it("replaces the display-name line with custom content", () => {
+      render(<UserItem user={baseUser} primary={<span>Jane Doe subscribed</span>} />);
+      expect(screen.getByText("Jane Doe subscribed")).toBeInTheDocument();
+      expect(screen.queryByText("Jane Doe")).not.toBeInTheDocument();
+    });
+
+    it("still renders the handle alongside custom primary content", () => {
+      render(<UserItem user={baseUser} primary={<span>Jane Doe subscribed</span>} />);
+      expect(screen.getByText("@jane_doe")).toBeInTheDocument();
+    });
+  });
+
+  describe("secondary", () => {
+    it("renders no secondary line by default", () => {
+      render(<UserItem user={baseUser} showHandle={false} data-testid="item" />);
+      expect(screen.getByTestId("item").querySelector("p")).not.toBeInTheDocument();
+    });
+
+    it("renders the secondary line under the name", () => {
+      render(<UserItem user={baseUser} showHandle={false} secondary="subscribed to your feed" />);
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.getByText("subscribed to your feed")).toBeInTheDocument();
+    });
+
+    it("renders the secondary line on the same tier as trailing meta", () => {
+      render(
+        <UserItem
+          user={baseUser}
+          showHandle={false}
+          secondary="subscribed to your feed"
+          data-testid="item"
+        />,
+      );
+      expect(screen.getByText("subscribed to your feed")).toHaveClass(
+        "typography-description-12px-regular",
+        "text-content-secondary",
+      );
+    });
+  });
+
   describe("accessibility", () => {
     it("has no accessibility violations", async () => {
       const { container } = render(
         <UserItem user={{ ...baseUser, nickname: "JD" }} isMuted isOnline showOnlineStatus />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations with trailing content", async () => {
+      const { container } = render(
+        <UserItem user={baseUser} showHandle={false} trailing={<span>$14,523.59</span>} />,
       );
       expect(await axe(container)).toHaveNoViolations();
     });

--- a/src/components/UserItem/UserItem.tsx
+++ b/src/components/UserItem/UserItem.tsx
@@ -46,15 +46,50 @@ export interface UserItemProps extends React.HTMLAttributes<HTMLDivElement> {
   verified?: boolean;
   /** Accessible label for the verified badge. @default "Verified" */
   verifiedLabel?: string;
+  /**
+   * Content pinned to the end of the row — a value, count, timestamp or action.
+   * It keeps its intrinsic width while the name block absorbs the remaining
+   * space, so trailing content stays aligned down the rows of a list.
+   *
+   * Prefer {@link UserItemTrailing} over composing the lines yourself.
+   */
+  trailing?: React.ReactNode;
+  /**
+   * Replace the display-name line with arbitrary content, for rows that read as
+   * a sentence about the user rather than their name — an activity feed entry,
+   * for instance. Badges do not apply to custom content.
+   */
+  primary?: React.ReactNode;
+  /**
+   * A supporting line under the name, mirroring {@link UserItemTrailing}'s `meta`.
+   * Both are block lines on the same 18px advance, so a row using `secondary` on
+   * the left and `meta` on the right reads as two aligned tiers. Prefer it over
+   * letting a long primary wrap, which mixes line heights and drifts out of step.
+   */
+  secondary?: React.ReactNode;
 }
 
 /**
  * A compact user row showing an avatar, display name (or nickname) and handle,
  * with optional verified and AI-disclosure badges and online and muted indicators.
  *
+ * Pass {@link UserItemProps.trailing} to pin a value to the end of the row, the
+ * shape most list rows need — top spenders, most active fans, a recent-activity
+ * feed.
+ *
  * @example
  * ```tsx
  * <UserItem user={{ displayName: "Jane Doe", handle: "jane_doe" }} />
+ * ```
+ *
+ * @example A list row with a trailing value
+ * ```tsx
+ * <UserItem
+ *   user={user}
+ *   avatarSize={32}
+ *   showHandle={false}
+ *   trailing={<span className="typography-body-small-14px-semibold">$14,523.59</span>}
+ * />
  * ```
  */
 export const UserItem = React.forwardRef<HTMLDivElement, UserItemProps>(
@@ -71,6 +106,9 @@ export const UserItem = React.forwardRef<HTMLDivElement, UserItemProps>(
       aiDisclosureLabel,
       verified = false,
       verifiedLabel,
+      trailing,
+      primary,
+      secondary,
       className,
       ...props
     },
@@ -97,17 +135,25 @@ export const UserItem = React.forwardRef<HTMLDivElement, UserItemProps>(
           />
         )}
         <div className="flex-1 overflow-hidden pl-2">
-          <UserDisplayName
-            aiDisclosure={aiDisclosure}
-            aiDisclosureLabel={aiDisclosureLabel}
-            verified={verified}
-            verifiedLabel={verifiedLabel}
-            className="typography-body-small-14px-semibold"
-          >
-            {user.nickname || user.displayName}
-          </UserDisplayName>
+          {primary ?? (
+            <UserDisplayName
+              aiDisclosure={aiDisclosure}
+              aiDisclosureLabel={aiDisclosureLabel}
+              verified={verified}
+              verifiedLabel={verifiedLabel}
+              className="typography-body-small-14px-semibold"
+            >
+              {user.nickname || user.displayName}
+            </UserDisplayName>
+          )}
+          {secondary && (
+            <p className="typography-description-12px-regular truncate text-content-secondary">
+              {secondary}
+            </p>
+          )}
           {showHandle && <UserHandle>{user.handle}</UserHandle>}
         </div>
+        {trailing && <div className="shrink-0 pl-2">{trailing}</div>}
       </div>
     );
   },

--- a/src/components/UserItem/UserItemTrailing.test.tsx
+++ b/src/components/UserItem/UserItemTrailing.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { UserItemTrailing } from "./UserItemTrailing";
+
+describe("UserItemTrailing", () => {
+  it("renders the value", () => {
+    render(<UserItemTrailing value="$421.32" />);
+    expect(screen.getByText("$421.32")).toBeInTheDocument();
+  });
+
+  it("renders no meta line when meta is not given", () => {
+    render(<UserItemTrailing value="12" data-testid="trailing" />);
+    expect(screen.getByTestId("trailing").children).toHaveLength(1);
+  });
+
+  it("renders the meta line under the value", () => {
+    render(<UserItemTrailing value="$421.32" meta="7 hours ago" data-testid="trailing" />);
+    const trailing = screen.getByTestId("trailing");
+    expect(trailing.children).toHaveLength(2);
+    expect(trailing.lastElementChild).toHaveTextContent("7 hours ago");
+  });
+
+  it("aligns its content to the end of the row", () => {
+    render(<UserItemTrailing value="12" data-testid="trailing" />);
+    expect(screen.getByTestId("trailing")).toHaveClass("flex", "flex-col", "items-end");
+  });
+
+  it("applies custom className and spreads HTML attributes", () => {
+    render(<UserItemTrailing value="12" className="custom" data-testid="trailing" data-x="y" />);
+    const trailing = screen.getByTestId("trailing");
+    expect(trailing).toHaveClass("custom");
+    expect(trailing).toHaveAttribute("data-x", "y");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<UserItemTrailing value="$421.32" meta="7 hours ago" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/src/components/UserItem/UserItemTrailing.tsx
+++ b/src/components/UserItem/UserItemTrailing.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** Props for {@link UserItemTrailing}. */
+export interface UserItemTrailingProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The headline figure — an amount, a count, a percentage. */
+  value: React.ReactNode;
+  /** Optional supporting line under the value, such as a timestamp. */
+  meta?: React.ReactNode;
+}
+
+/**
+ * The end-of-row block for a {@link UserItem}: a value with an optional
+ * supporting line beneath it, both aligned to the right edge so figures line up
+ * down a list.
+ *
+ * Pass it to {@link UserItem}'s `trailing` slot rather than composing the two
+ * lines at each call site, so value and meta typography stay consistent
+ * wherever a list row carries a figure.
+ *
+ * @example
+ * ```tsx
+ * <UserItem
+ *   user={user}
+ *   showHandle={false}
+ *   trailing={<UserItemTrailing value="$421.32" meta="7 hours ago" />}
+ * />
+ * ```
+ */
+export const UserItemTrailing = React.forwardRef<HTMLDivElement, UserItemTrailingProps>(
+  ({ value, meta, className, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cn("flex flex-col items-end", className)} {...props}>
+        <span className="typography-body-small-14px-semibold text-content-primary">{value}</span>
+        {meta && (
+          <span className="typography-description-12px-regular text-content-secondary">{meta}</span>
+        )}
+      </div>
+    );
+  },
+);
+
+UserItemTrailing.displayName = "UserItemTrailing";

--- a/src/index.ts
+++ b/src/index.ts
@@ -849,6 +849,8 @@ export type {
   UserItemUser,
 } from "./components/UserItem/UserItem";
 export { UserItem } from "./components/UserItem/UserItem";
+export type { UserItemTrailingProps } from "./components/UserItem/UserItemTrailing";
+export { UserItemTrailing } from "./components/UserItem/UserItemTrailing";
 export type {
   VoiceNoteProps,
   VoiceNoteSize,


### PR DESCRIPTION
Fifth of six extracted from the `insights-components` batch. The only one of the six that touches an existing component, so it is the one with real blast radius: `UserItem` has 15 consumers across `eden` and `fadmin`.

All three new props are optional and nothing renders differently without them, which is why the full suite passes unchanged (4545 tests). Worth confirming that claim rather than taking it, since it is the whole safety argument for this PR.

**What it adds**

- `trailing` pins content to the end of the row. It keeps its intrinsic width while the name block absorbs the remaining space, so figures stay aligned down a list rather than drifting with name length.
- `UserItemTrailing` is the thing to put in that slot: a value with an optional `meta` line, right-aligned.
- `primary` replaces the display-name line for rows that read as a sentence about the user rather than their name, such as an activity feed entry. Badges deliberately do not apply to custom content.
- `secondary` adds a supporting line under the name, mirroring `UserItemTrailing`'s `meta`. Both sit on the same 18px advance, so a row using `secondary` on the left and `meta` on the right reads as two aligned tiers.

`secondary` exists specifically to avoid letting a long primary wrap, which mixes line heights and drifts the rows out of step. That is documented on the prop.

Serves top spenders, most active fans and the recent-activity feed in agency insights.

57 tests in `UserItem` including axe, full suite 4545/4545, `tsc --noEmit` clean.