### PR TITLE
feat(DropdownMenu): add DropdownMenuCheckboxItem and align the menu with V2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuHeader,
   DropdownMenuItem,
@@ -2859,6 +2860,7 @@ function SelectDemo() {
 }
 
 function DropdownMenuDemo() {
+  const [selectedCreators, setSelectedCreators] = React.useState<string[]>(["Jane Doe"]);
   return (
     <div id="dropdownmenu" className="flex scroll-mt-20 flex-col gap-4">
       <h2 className="typography-header-heading-sm mb-4">Dropdown menu</h2>
@@ -2891,6 +2893,43 @@ function DropdownMenuDemo() {
               <DropdownMenuItem destructive leadingIcon={<TrashBinIcon className="size-4" />}>
                 Delete
               </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className="typography-description-12px-semibold text-content-secondary">
+            Multi-select with a search header
+          </span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="secondary" size="40" rightIcon={<ChevronDownIcon />}>
+                Creators
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuHeader
+                type="search"
+                title="Creators"
+                searchProps={{ autoFocus: true, placeholder: "Search creators" }}
+              />
+              {["Jane Doe", "Alex Kim", "Sam Patel"].map((name) => (
+                <DropdownMenuCheckboxItem
+                  key={name}
+                  checked={selectedCreators.includes(name)}
+                  onCheckedChange={() =>
+                    setSelectedCreators((current) =>
+                      current.includes(name)
+                        ? current.filter((n) => n !== name)
+                        : [...current, name],
+                    )
+                  }
+                  onSelect={(event) => event.preventDefault()}
+                  helper="12 purchases"
+                >
+                  {name}
+                </DropdownMenuCheckboxItem>
+              ))}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -9,6 +9,7 @@ import { StarIcon } from "../Icons/StarIcon";
 import { TrashBinIcon } from "../Icons/TrashBinIcon";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuHeader,
@@ -226,6 +227,76 @@ export const WithSearchHeader: Story = {
                 <DropdownMenuItem key={name} onSelect={(event) => event.preventDefault()}>
                   {name}
                 </DropdownMenuItem>
+              ))
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    };
+    return <Demo />;
+  },
+};
+
+export const CreatorMultiSelect: Story = {
+  name: "Creator multi-select (search + avatars)",
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/23x2vofTPkLpbcJyRdDa55/Creator---Management%E2%80%A8--Teams?node-id=7393-62008",
+    },
+  },
+  play: openMenu,
+  render: () => {
+    const Demo = () => {
+      // Starts closed so `play` can open it: a modal Radix menu aria-hides the
+      // rest of the canvas, which would leave the trigger unqueryable.
+      const [open, setOpen] = React.useState(false);
+      const [query, setQuery] = React.useState("");
+      const [selected, setSelected] = React.useState(
+        new Set(["@sofiabloom", "@aria.lane", "@novaknight", "@miarivers", "@lunavale"]),
+      );
+      const creators = ["@sofiabloom", "@aria.lane", "@novaknight", "@miarivers", "@lunavale"];
+      const filtered = creators.filter((handle) =>
+        handle.toLowerCase().includes(query.toLowerCase()),
+      );
+      const toggle = (handle: string) =>
+        setSelected((prev) => {
+          const next = new Set(prev);
+          if (next.has(handle)) {
+            next.delete(handle);
+          } else {
+            next.add(handle);
+          }
+          return next;
+        });
+      return (
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button variant="secondary">All Creators</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-72">
+            <DropdownMenuHeader
+              type="search"
+              showClose={false}
+              searchProps={{
+                value: query,
+                onChange: setQuery,
+                placeholder: "Search\u2026",
+              }}
+            />
+            {filtered.length === 0 ? (
+              <DropdownMenuLabel position="top">No results</DropdownMenuLabel>
+            ) : (
+              filtered.map((handle) => (
+                <DropdownMenuCheckboxItem
+                  key={handle}
+                  checked={selected.has(handle)}
+                  onCheckedChange={() => toggle(handle)}
+                  onSelect={(event) => event.preventDefault()}
+                  avatar={<Avatar size={32} fallback={handle.slice(1, 3).toUpperCase()} />}
+                >
+                  {handle}
+                </DropdownMenuCheckboxItem>
               ))
             )}
           </DropdownMenuContent>

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -49,6 +49,32 @@ describe("DropdownMenu", () => {
   });
 
   describe("API", () => {
+    it("sits the avatar, count and icons on a two-line row's title line", () => {
+      renderMenu(
+        <DropdownMenuItem
+          avatar={<span data-testid="avatar">A</span>}
+          count="12"
+          description="Product designer"
+        >
+          Alex Smith
+        </DropdownMenuItem>,
+      );
+      // 18px is the title's leading; a `pt-1` nudge would sit them 3px low.
+      expect(screen.getByTestId("avatar").parentElement).toHaveClass("h-[18px]");
+      expect(screen.getByText("12")).toHaveClass("h-[18px]");
+      expect(screen.getByText("12")).not.toHaveClass("pt-1");
+    });
+
+    it("leaves a single-line row's siblings vertically centred by the row", () => {
+      renderMenu(
+        <DropdownMenuItem avatar={<span data-testid="avatar">A</span>} count="12">
+          Alex Smith
+        </DropdownMenuItem>,
+      );
+      expect(screen.getByTestId("avatar").parentElement).not.toHaveClass("h-[18px]");
+      expect(screen.getByText("12")).not.toHaveClass("h-[18px]");
+    });
+
     it("gives the panel the 12px menu radius, not the 8px row radius", () => {
       renderMenu(<DropdownMenuItem>Item</DropdownMenuItem>);
       const panel = screen.getByRole("menu");

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -49,6 +49,14 @@ describe("DropdownMenu", () => {
   });
 
   describe("API", () => {
+    it("gives the panel the 12px menu radius, not the 8px row radius", () => {
+      renderMenu(<DropdownMenuItem>Item</DropdownMenuItem>);
+      const panel = screen.getByRole("menu");
+      expect(panel).toHaveClass("rounded-sm");
+      expect(panel).not.toHaveClass("rounded-xs");
+      expect(panel).not.toHaveClass("rounded-lg");
+    });
+
     it("does not render content when closed", () => {
       renderMenu(<DropdownMenuItem>Hidden</DropdownMenuItem>, {
         defaultOpen: false,

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuHeader,
@@ -64,6 +65,27 @@ describe("DropdownMenu", () => {
       );
       expect(screen.getByText("First")).toBeInTheDocument();
       expect(screen.getByText("Second")).toBeInTheDocument();
+    });
+
+    // The pointer-dismissal path (no focus ring left on the trigger) can't be
+    // driven in jsdom: a modal menu sets pointer-events:none on the body, and
+    // Radix's dismissal never completes from synthesised events. This covers the
+    // regression that broke it — the props spread replacing our handler.
+    it("composes a consumer's onCloseAutoFocus rather than replacing it", async () => {
+      const onCloseAutoFocus = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <DropdownMenu defaultOpen>
+          <DropdownMenuTrigger>trigger</DropdownMenuTrigger>
+          <DropdownMenuContent onCloseAutoFocus={onCloseAutoFocus}>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+
+      await user.keyboard("{Escape}");
+      await waitFor(() => expect(onCloseAutoFocus).toHaveBeenCalled());
+      expect(screen.getByRole("button", { name: "trigger" })).toHaveFocus();
     });
 
     it("calls onOpenChange on Escape key", async () => {
@@ -745,6 +767,29 @@ describe("DropdownMenuHeader", () => {
       expect(onChange).toHaveBeenLastCalledWith("ab");
     });
 
+    it("focuses the search input on open when autoFocus is set", async () => {
+      renderMenu(
+        <>
+          <DropdownMenuHeader type="search" searchProps={{ autoFocus: true }} />
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </>,
+      );
+
+      await waitFor(() => expect(screen.getByRole("searchbox")).toHaveFocus());
+    });
+
+    it("leaves the search input unfocused when autoFocus is not set", async () => {
+      renderMenu(
+        <>
+          <DropdownMenuHeader type="search" />
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </>,
+      );
+
+      await waitFor(() => expect(screen.getByRole("menuitem", { name: "Item" })).toBeVisible());
+      expect(screen.getByRole("searchbox")).not.toHaveFocus();
+    });
+
     it("keeps focus on the search input while typing characters", async () => {
       const user = userEvent.setup();
       const SearchDemo = () => {
@@ -812,6 +857,80 @@ describe("DropdownMenuHeader", () => {
         </>,
       );
       expect(screen.queryByRole("button", { name: /close/i })).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("DropdownMenuCheckboxItem", () => {
+  it("does not shade a row just because it is checked", () => {
+    renderMenu(
+      <>
+        <DropdownMenuCheckboxItem checked>@sofiabloom</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem checked={false}>@aria.lane</DropdownMenuCheckboxItem>
+      </>,
+    );
+
+    // A menu that opens fully selected would otherwise render every row shaded.
+    for (const name of ["@sofiabloom", "@aria.lane"]) {
+      const row = screen.getByRole("menuitemcheckbox", { name });
+      expect(row.className).not.toContain("data-[state=checked]:bg-");
+    }
+  });
+
+  describe("accessibility", () => {
+    it("has no a11y violations", async () => {
+      const { container } = renderMenu(
+        <>
+          <DropdownMenuCheckboxItem checked helper="Helper text">
+            @sofiabloom
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={false}>@aria.lane</DropdownMenuCheckboxItem>
+        </>,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe("API", () => {
+    it("exposes the menuitemcheckbox role and reflects checked state", () => {
+      renderMenu(
+        <>
+          <DropdownMenuCheckboxItem checked={false}>One</DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked>Two</DropdownMenuCheckboxItem>
+        </>,
+      );
+      const items = screen.getAllByRole("menuitemcheckbox");
+      expect(items[0]).toHaveAttribute("data-state", "unchecked");
+      expect(items[1]).toHaveAttribute("data-state", "checked");
+    });
+
+    it("renders the helper text when provided", () => {
+      renderMenu(
+        <DropdownMenuCheckboxItem checked helper="Managed creator">
+          @novaknight
+        </DropdownMenuCheckboxItem>,
+      );
+      expect(screen.getByText("Managed creator")).toBeInTheDocument();
+    });
+
+    it("renders a leading avatar when provided", () => {
+      renderMenu(
+        <DropdownMenuCheckboxItem checked avatar={<span data-testid="avatar" />}>
+          @miarivers
+        </DropdownMenuCheckboxItem>,
+      );
+      expect(screen.getByTestId("avatar")).toBeInTheDocument();
+    });
+
+    it("calls onCheckedChange when toggled", async () => {
+      const onCheckedChange = vi.fn();
+      renderMenu(
+        <DropdownMenuCheckboxItem checked={false} onCheckedChange={onCheckedChange}>
+          @lunavale
+        </DropdownMenuCheckboxItem>,
+      );
+      await userEvent.click(screen.getByRole("menuitemcheckbox"));
+      expect(onCheckedChange).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -9,6 +9,7 @@ import { IconButton } from "../IconButton/IconButton";
 import { CheckIcon } from "../Icons/CheckIcon";
 import { CloseIcon } from "../Icons/CloseIcon";
 import { SearchIcon } from "../Icons/SearchIcon";
+import { TickIcon } from "../Icons/TickIcon";
 
 // Movement, in CSS px, above which a touch press-and-release counts as a drag.
 const TAP_MOVEMENT_THRESHOLD_PX = 10;
@@ -217,20 +218,39 @@ export const DropdownMenuContent = React.forwardRef<
       // is enough to keep the menu flipping/shifting to stay on screen — no
       // hand-rolled reposition logic needed.
       collisionPadding = FLOATING_CONTENT_COLLISION_PADDING,
+      onPointerDownOutside,
+      onCloseAutoFocus,
       children,
       ...props
     },
     ref,
   ) => {
     const variant = React.useContext(DropdownMenuVariantContext);
+    // Radix returns focus to the trigger when the menu closes. That is right for
+    // the keyboard, but Chrome's :focus-visible heuristic also paints the ring on
+    // that programmatic refocus, so dismissing with a click left a focus ring
+    // sitting on the trigger. Track pointer dismissals and skip the restore for
+    // them only — Escape and Tab still hand focus back with the ring.
+    const dismissedByPointer = React.useRef(false);
 
     if (variant === "sheet") {
       return (
         <DrawerContent
           ref={ref}
           position="bottom"
-          variant="sheet"
-          className={cn("flex flex-col gap-1 p-1", className)}
+          // `"sheet"` sits flush to the bottom edge at full width; the design draws
+          // this panel inset from all three sides and rounded on every corner, which
+          // is `"menu"`. Both carry the same modal surface.
+          variant="menu"
+          // The design's `blur + shadow/menu` effect is a background blur, and the
+          // panel's own fill is opaque — so the blur has to go on the overlay to be
+          // visible at all. Scoped here rather than on DrawerOverlay so only menus
+          // shown this way blur the page behind them.
+          overlayProps={{ className: "backdrop-blur-[8px]" }}
+          // `pb-4` gives the design's 16px below the last row. The rows inset
+          // themselves horizontally (see the item's `mx-3`) rather than the panel
+          // padding doing it, so the header and its rule can still run full width.
+          className={cn("flex flex-col gap-1 p-1 pb-4", className)}
           style={style}
           {...props}
         >
@@ -243,10 +263,21 @@ export const DropdownMenuContent = React.forwardRef<
       <DropdownMenuPrimitive.Portal>
         <DropdownMenuPrimitive.Content
           ref={ref}
+          onPointerDownOutside={(event) => {
+            dismissedByPointer.current = true;
+            onPointerDownOutside?.(event);
+          }}
+          onCloseAutoFocus={(event) => {
+            if (dismissedByPointer.current) event.preventDefault();
+            dismissedByPointer.current = false;
+            onCloseAutoFocus?.(event);
+          }}
           sideOffset={sideOffset}
           collisionPadding={collisionPadding}
           className={cn(
-            "w-max min-w-(--radix-dropdown-menu-trigger-width) max-w-(--radix-dropdown-menu-content-available-width) overflow-y-auto rounded-sm border border-neutral-alphas-200 bg-surface-primary p-1 text-content-primary shadow-lg",
+            // `rounded-lg` is the panel radius `V2 Menu Dropdown` carries (24px).
+            // The 12px `rounded-sm` belongs to the rows inside it, not the panel.
+            "w-max min-w-(--radix-dropdown-menu-trigger-width) max-w-(--radix-dropdown-menu-content-available-width) overflow-y-auto rounded-lg border border-border-primary bg-surface-primary p-1 text-content-primary shadow-blur-menu backdrop-blur-[4px]",
             "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
             "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
             "data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-in-from-top-2",
@@ -357,7 +388,14 @@ const ITEM_COUNT_TYPOGRAPHY: Record<"40" | "32", string> = {
 function SelectedCheckIndicator({ hasDescription }: { hasDescription: boolean }) {
   return (
     <CheckIcon
-      className={cn("size-4 shrink-0 text-content-primary", hasDescription && "self-start")}
+      className={cn(
+        "size-4 shrink-0 text-content-primary",
+        // The two-line layout switches the row to `items-start`, which would hang
+        // the tick off the title's line. A leading icon or avatar belongs there —
+        // it labels the title — but the tick is a property of the whole row, so it
+        // centres against both lines. {@link SelectItem} already does this.
+        hasDescription && "self-center",
+      )}
     />
   );
 }
@@ -445,8 +483,17 @@ export const DropdownMenuItem = React.forwardRef<
     const hasDescription = description != null;
     const hasAvatar = avatar != null;
     const itemClassName = cn(
-      "group flex w-full cursor-pointer gap-2 rounded-xs px-3 outline-none",
+      // `text-start` because the sheet variant renders the row as a <button>, and
+      // the UA centres a button's text — which centred the two-line title and
+      // description while the popper variant (a div) inherited the panel's start
+      // alignment. Both read from the same edge now.
+      "group flex w-full cursor-pointer gap-2 rounded-xs px-3 text-start outline-none",
       hasDescription ? "items-start" : "items-center",
+      // The sheet's header runs the full width of the panel, so its rows have to
+      // come in off the edge themselves — 12px here on the panel's own 4px is the
+      // design's 16px. `w-auto` lets the column stretch them to the space left
+      // over; `w-full` plus a margin would overflow.
+      variant === "sheet" && "mx-3 w-auto",
       ITEM_SIZE_CLASSES[normalizedSize],
       // A 24px avatar would push the compact 32px row past its height with the
       // default padding; tighten it so the avatar variant keeps the 32px contract.
@@ -513,7 +560,14 @@ export const DropdownMenuItem = React.forwardRef<
         )}
         {hasDescription ? (
           <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span className="truncate">{children}</span>
+            {/*
+             * The two-line row sets its own title type rather than inheriting the
+             * row's: `V2 Menu Item` pairs a 14px semibold title with the 14px
+             * regular description below it, where a single-line row's title is the
+             * size's own 16px regular. It also settles the row's height — 18 + 2 +
+             * 18 of text inside `py-2` is the design's 54px.
+             */}
+            <span className="typography-body-small-14px-semibold truncate">{children}</span>
             <span className="typography-body-small-14px-regular truncate text-content-secondary">
               {description}
             </span>
@@ -649,6 +703,12 @@ export interface DropdownMenuHeaderSearchProps {
   placeholder?: string;
   /** Accessible label for the search input. @default "Search" */
   "aria-label"?: string;
+  /**
+   * Focus the input as soon as the menu opens, so typing filters immediately.
+   * Radix parks initial focus on the content element (which is what drives its
+   * typeahead), so without this the first keystrokes never reach the input.
+   */
+  autoFocus?: boolean;
 }
 
 export interface DropdownMenuHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -701,11 +761,13 @@ export const DropdownMenuHeader = React.forwardRef<HTMLDivElement, DropdownMenuH
     },
     ref,
   ) => {
+    // Regular, not semibold: `V2 Menu Header` titles the menu at
+    // `Body Default 16px/Regular`. The weight belongs to the rows' own titles,
+    // which is where the two-line layout puts a semibold.
     const titleTypography =
-      size === "32"
-        ? "typography-body-small-14px-semibold"
-        : "typography-body-default-16px-semibold";
+      size === "32" ? "typography-body-small-14px-regular" : "typography-body-default-16px-regular";
     const toggleOpen = React.useContext(ToggleOpenContext);
+    const variant = React.useContext(DropdownMenuVariantContext);
 
     const handleClose = () => {
       onClose?.();
@@ -724,6 +786,10 @@ export const DropdownMenuHeader = React.forwardRef<HTMLDivElement, DropdownMenuH
           // default (title) variant uses 4px because the title baseline sits
           // closer to the divider naturally.
           type === "search" ? "gap-2" : "gap-1",
+          // The sheet is a taller, roomier surface than a trigger-anchored panel:
+          // the design sets 16px between the rule and the first row, which this
+          // margin plus the panel's own 4px gap adds up to.
+          variant === "sheet" && "mb-3",
           className,
         )}
         {...props}
@@ -746,7 +812,18 @@ export const DropdownMenuHeader = React.forwardRef<HTMLDivElement, DropdownMenuH
             />
           )}
         </div>
-        <DropdownMenuSeparator className="my-0" />
+        {/*
+         * Full-bleed, as the design draws it: the rule runs the panel's whole
+         * width rather than stopping at the text. `-mx-2` cancels both insets it
+         * sits inside — this header's own `px-1` and the content panel's `p-1`.
+         *
+         * `border-strong` is the colour the design gives this rule. The separator's
+         * own default is `neutral-alphas-200`, which in the dark theme is a 20%
+         * *white* alpha — as a hairline running the full width it reads as a white
+         * line rather than a divider. Group separators between items keep the
+         * alpha; this is the header's rule only.
+         */}
+        <DropdownMenuSeparator className="-mx-2 my-0 bg-border-strong" />
       </div>
     );
   },
@@ -759,12 +836,21 @@ function SearchInput({
   onChange,
   placeholder = "Search\u2026",
   "aria-label": ariaLabel = "Search",
+  autoFocus,
 }: DropdownMenuHeaderSearchProps = {}) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Focus after mount rather than via the `autoFocus` attribute, so the focus
+  // move is explicit and only happens when the consumer asked for it.
+  React.useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
   return (
     <label
       className={cn(
         "flex min-w-0 flex-1 items-center gap-2 rounded-xs border border-border-primary",
-        "bg-neutral-alphas-50 px-3 py-1 text-content-primary",
+        "bg-inputs-inputs-primary px-3 py-1 text-content-primary",
         "focus-within:shadow-focus-ring focus-within:outline-none",
       )}
     >
@@ -775,6 +861,7 @@ function SearchInput({
           "typography-body-default-16px-regular min-w-0 flex-1 bg-transparent outline-none",
           "placeholder:text-content-tertiary",
         )}
+        ref={inputRef}
         value={value}
         defaultValue={defaultValue}
         placeholder={placeholder}
@@ -882,3 +969,84 @@ export const DropdownMenuRadioItem = React.forwardRef<
   );
 });
 DropdownMenuRadioItem.displayName = "DropdownMenuRadioItem";
+
+/** Height preset for a {@link DropdownMenuCheckboxItem}. */
+export type DropdownMenuCheckboxItemSize = "40";
+
+export interface DropdownMenuCheckboxItemProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> {
+  /** Optional secondary text shown below the title. */
+  helper?: string;
+  /** Leading avatar rendered between the checkbox and the title. Render at 32px to match the design. */
+  avatar?: React.ReactNode;
+  /** Height of the item row. @default "40" */
+  size?: DropdownMenuCheckboxItemSize;
+}
+
+/**
+ * A single multi-select choice within a dropdown menu. Shows a square indicator
+ * that fills when checked, an optional leading avatar, and an optional helper
+ * line underneath the title.
+ *
+ * Pair with {@link DropdownMenuHeader} at `type="search"` for filterable menus.
+ * Use {@link DropdownMenuRadioItem} instead when only one option may be active.
+ *
+ * @example
+ * ```tsx
+ * <DropdownMenuCheckboxItem
+ *   checked={selected.has(creator.id)}
+ *   onCheckedChange={() => toggle(creator.id)}
+ *   avatar={<Avatar size={32} src={creator.avatarUrl} />}
+ * >
+ *   @sofiabloom
+ * </DropdownMenuCheckboxItem>
+ * ```
+ */
+export const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  DropdownMenuCheckboxItemProps
+>(({ className, children, helper, avatar, size: _size = "40", ...props }, ref) => {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      ref={ref}
+      className={cn(
+        "group flex w-full cursor-pointer items-center gap-3 rounded-xs px-3 py-2 outline-none",
+        // Checked state is carried by the tick alone. A background here would
+        // leave every selected row shaded, which reads as "all highlighted" on
+        // a menu that starts fully selected.
+        "data-[highlighted]:bg-neutral-alphas-50",
+        "data-[disabled]:cursor-not-allowed data-[disabled]:text-content-disabled",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className={cn(
+          "flex size-4 shrink-0 items-center justify-center rounded-2xs border border-icons-primary",
+          "group-data-[state=checked]:bg-icons-primary",
+          "group-data-[disabled]:border-content-disabled",
+        )}
+        aria-hidden="true"
+      >
+        <DropdownMenuPrimitive.ItemIndicator asChild>
+          <TickIcon className="size-4 text-content-primary-inverted" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {avatar && <span className="shrink-0">{avatar}</span>}
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="typography-body-default-16px-semibold truncate">{children}</span>
+        {helper && (
+          <span
+            className={cn(
+              "typography-description-12px-regular text-content-secondary",
+              "group-data-[disabled]:text-content-disabled",
+            )}
+          >
+            {helper}
+          </span>
+        )}
+      </span>
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+});
+DropdownMenuCheckboxItem.displayName = "DropdownMenuCheckboxItem";

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -275,9 +275,9 @@ export const DropdownMenuContent = React.forwardRef<
           sideOffset={sideOffset}
           collisionPadding={collisionPadding}
           className={cn(
-            // `rounded-lg` is the panel radius `V2 Menu Dropdown` carries (24px).
-            // The 12px `rounded-sm` belongs to the rows inside it, not the panel.
-            "w-max min-w-(--radix-dropdown-menu-trigger-width) max-w-(--radix-dropdown-menu-content-available-width) overflow-y-auto rounded-lg border border-border-primary bg-surface-primary p-1 text-content-primary shadow-blur-menu backdrop-blur-[4px]",
+            // `rounded-sm` (12px) is the panel radius `V2 Menu Dropdown` carries.
+            // The 8px `rounded-xs` belongs to the rows inside it, not the panel.
+            "w-max min-w-(--radix-dropdown-menu-trigger-width) max-w-(--radix-dropdown-menu-content-available-width) overflow-y-auto rounded-sm border border-border-primary bg-surface-primary p-1 text-content-primary shadow-blur-menu backdrop-blur-[4px]",
             "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
             "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
             "data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-in-from-top-2",

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -854,7 +854,7 @@ function SearchInput({
         "focus-within:shadow-focus-ring focus-within:outline-none",
       )}
     >
-      <SearchIcon className="size-4 shrink-0 text-content-tertiary" aria-hidden="true" />
+      <SearchIcon className="size-4 shrink-0 text-content-primary" aria-hidden="true" />
       <input
         type="search"
         className={cn(

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -794,7 +794,15 @@ export const DropdownMenuHeader = React.forwardRef<HTMLDivElement, DropdownMenuH
         )}
         {...props}
       >
-        <div className="flex items-center gap-4 pl-2">
+        {/*
+         * The title is inset a further 8px so it clears the panel's rounded
+         * corner; the search input is not, because the design runs it to the
+         * header's own padding (`V2 Menu Dropdown` node `7393:62008`: the search
+         * row is `flex gap-16 w-full` with no inset, so the field sits 8px from
+         * the panel edge on both sides). Insetting it left-only left the field
+         * 16px in on the left and 8px on the right.
+         */}
+        <div className={cn("flex items-center gap-4", type === "default" && "pl-2")}>
           {type === "default" ? (
             <div className={cn("min-w-0 flex-1 truncate text-content-primary", titleTypography)}>
               {children ?? title}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -275,8 +275,14 @@ export const DropdownMenuContent = React.forwardRef<
           sideOffset={sideOffset}
           collisionPadding={collisionPadding}
           className={cn(
-            // `rounded-sm` (12px) is the panel radius `V2 Menu Dropdown` carries.
-            // The 8px `rounded-xs` belongs to the rows inside it, not the panel.
+            // `rounded-sm` (12px) is the panel radius `V2 Menu Dropdown` carries
+            // (product file node `7393:62008`). The 8px `rounded-xs` belongs to the
+            // rows inside it, not the panel.
+            //
+            // The `sheet` variant is deliberately not 12px: it renders through
+            // `DrawerContent variant="menu"`, whose `MENU_CLASSES` is `rounded-lg`
+            // (24px). A bottom sheet is a full-width surface with its own radius,
+            // not a scaled-up popper, so the two are meant to differ.
             "w-max min-w-(--radix-dropdown-menu-trigger-width) max-w-(--radix-dropdown-menu-content-available-width) overflow-y-auto rounded-sm border border-border-primary bg-surface-primary p-1 text-content-primary shadow-blur-menu backdrop-blur-[4px]",
             "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
             "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
@@ -984,17 +990,12 @@ export const DropdownMenuRadioItem = React.forwardRef<
 });
 DropdownMenuRadioItem.displayName = "DropdownMenuRadioItem";
 
-/** Height preset for a {@link DropdownMenuCheckboxItem}. */
-export type DropdownMenuCheckboxItemSize = "40";
-
 export interface DropdownMenuCheckboxItemProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> {
   /** Optional secondary text shown below the title. */
   helper?: string;
   /** Leading avatar rendered between the checkbox and the title. Render at 32px to match the design. */
   avatar?: React.ReactNode;
-  /** Height of the item row. @default "40" */
-  size?: DropdownMenuCheckboxItemSize;
 }
 
 /**
@@ -1019,7 +1020,7 @@ export interface DropdownMenuCheckboxItemProps
 export const DropdownMenuCheckboxItem = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   DropdownMenuCheckboxItemProps
->(({ className, children, helper, avatar, size: _size = "40", ...props }, ref) => {
+>(({ className, children, helper, avatar, ...props }, ref) => {
   return (
     <DropdownMenuPrimitive.CheckboxItem
       ref={ref}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -514,14 +514,20 @@ export const DropdownMenuItem = React.forwardRef<
       className,
     );
 
-    // In the two-line (description) layout, icons sit on the title's line.
-    // 24px title line-height vs 16px icon → 4px (pt-1) centres the icon on it.
-    const iconAlignClassName = hasDescription ? "flex shrink-0 items-center pt-1" : null;
+    // In the two-line (description) layout everything beside the title sits on
+    // the title's line, not the centre of the two-line block. A box the height of
+    // that line centres each sibling on it whatever its own size — a 16px icon, a
+    // 24px avatar, or the count's larger text box. The height is the title's, from
+    // `typography-body-small-14px-semibold`; a `pt-*` nudge cannot do this because
+    // the correct offset differs per sibling, and the previous `pt-1` was computed
+    // against the single-line title's 24px leading, leaving all four 3px low.
+    const iconAlignClassName = hasDescription ? "flex h-[18px] shrink-0 items-center" : null;
 
     const countNode = count != null && (
       <span
         className={cn(
           "shrink-0 tabular-nums",
+          iconAlignClassName,
           ITEM_COUNT_TYPOGRAPHY[normalizedSize],
           destructive ? "text-error-content" : "text-content-tertiary",
           "group-data-[disabled]:text-content-disabled",
@@ -549,7 +555,7 @@ export const DropdownMenuItem = React.forwardRef<
     const itemChildren = (
       <>
         {avatar != null ? (
-          <span className="shrink-0">{avatar}</span>
+          <span className={cn("shrink-0", iconAlignClassName)}>{avatar}</span>
         ) : (
           leadingIcon != null &&
           (hasDescription ? (

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,8 @@ export {
   DrawerTrigger,
 } from "./components/Drawer/Drawer";
 export type {
+  DropdownMenuCheckboxItemProps,
+  DropdownMenuCheckboxItemSize,
   DropdownMenuContentProps,
   DropdownMenuGroupProps,
   DropdownMenuHeaderProps,
@@ -239,6 +241,7 @@ export type {
 } from "./components/DropdownMenu/DropdownMenu";
 export {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuHeader,

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,6 @@ export {
 } from "./components/Drawer/Drawer";
 export type {
   DropdownMenuCheckboxItemProps,
-  DropdownMenuCheckboxItemSize,
   DropdownMenuContentProps,
   DropdownMenuGroupProps,
   DropdownMenuHeaderProps,


### PR DESCRIPTION
Last of six extracted from the `insights-components` batch. It is the one bundle in the set, because all four changes land in the same file and serve the same design. Reviewing them as four separate concerns:

**1. `DropdownMenuCheckboxItem`** — a multi-select row: square indicator that fills when checked, optional leading avatar, optional helper line. This is the new export. Used by the agency insights creator filter.

**2. A search header can take focus on open.** `DropdownMenuHeader` gains `searchProps.autoFocus`. Focus is applied after mount rather than through the `autoFocus` attribute, because Radix moves focus to the content on open and the attribute loses that race.

**3. No focus ring left on the trigger after a click-away.** Radix returns focus to the trigger on close, which is right for Escape and wrong for a pointer dismiss: clicking outside left a visible ring on a button the user had moved away from. Now `onPointerDownOutside` records that the dismissal was a pointer, and `onCloseAutoFocus` preventDefaults on that path only. Keyboard dismissal still returns focus, which is the behaviour that matters for a11y.

**4. Menu surface matches `V2 Menu Dropdown`.** Checked against the reference code for node `7393:62008` in the product file rather than by eye. The panel takes `rounded-sm` (12px) and rows take `rounded-xs` (8px); padding, `backdrop-blur-[4px]` and the `0px 6px 12px rgba(0,0,0,0.1)` shadow all already matched. Checked rows stop being shaded.

The `sheet` path is deliberately 24px: it renders through `DrawerContent variant="menu"`, whose `MENU_CLASSES` is `rounded-lg`. A bottom sheet is an inset full-width surface with its own radius, not a scaled-up popper. Noted at the class so the two are not reconciled by mistake later.

## Review fixes

- Search field runs to the header padding. It was inset 16px left and 8px right, because the row kept a left-only inset from the layout that assumed a trailing close button; Figma's search row has no inset at all.
- Search icon is theme-aware (`content-primary`), at Jackson's request. Note this now differs from the placeholder beside it, which Figma draws muted.
- Two-line rows: avatar, count and icons sit on the title's line. The old `pt-1` was computed against the single-line title's 24px leading but only ever applied when a description is present, where the title is 14px/18px, so all four sat 3px low. Pre-existing on `main`.
- Dropped the inert `size` prop and `DropdownMenuCheckboxItemSize`.

## Not in scope, raising separately

Two pre-existing DropdownMenu deviations found while checking the above: `DropdownMenuRadioItem` is `px-4` where the design and `DropdownMenuCheckboxItem` are `px-3`, and the header divider is `pr-[4px]` in Figma against our full-bleed `-mx-2`. The second needs a decision rather than a fix, since the existing comment says the full bleed is deliberate.

**Lint note:** the 7 biome warnings in this file are pre-existing. `main` reports the identical 7 (1 complexity, 4 `useSortedClasses`, 2 `noNonNullAssertion`), so this PR adds none.

Full suite green, `tsc --noEmit` clean.