### PR TITLE
feat(Demographics): add the breakdown row, with its sky ProgressBar and token

### DIFF
--- a/src/components/Demographics/Demographics.stories.tsx
+++ b/src/components/Demographics/Demographics.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Demographics } from "./Demographics";
+
+const meta = {
+  title: "Components/Demographics",
+  component: Demographics,
+  parameters: {
+    layout: "padded",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/23x2vofTPkLpbcJyRdDa55/Creator---Management%E2%80%A8--Teams?node-id=8294-29097",
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Demographics>;
+
+export default meta;
+type Story = StoryObj<typeof Demographics>;
+
+const COUNTRIES = [
+  { label: "United States", value: 52.6 },
+  { label: "United Kingdom", value: 29.2 },
+  { label: "Netherlands", value: 7.6 },
+  { label: "Italy", value: 7.3 },
+  { label: "Spain", value: 6.9 },
+];
+
+/**
+ * `icon` is any node, so these stories fill the slot with a plain disc rather
+ * than depending on `CountryFlag`. Agency insights pairs it with a real flag
+ * from `@fanvue/ui/flags`; the row itself neither knows nor cares.
+ */
+const Glyph = () => <span aria-hidden className="size-5 rounded-full bg-special-chart-sky" />;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-full max-w-sm">
+      <Demographics label="United States" value={52.6} formattedValue="52.6%" icon={<Glyph />} />
+    </div>
+  ),
+};
+
+export const Breakdown: Story = {
+  name: "Stacked breakdown",
+  render: () => (
+    <div className="flex w-full max-w-sm flex-col gap-4">
+      {COUNTRIES.map((country) => (
+        <Demographics
+          key={country.label}
+          label={country.label}
+          value={country.value}
+          formattedValue={`${country.value}%`}
+          icon={<Glyph />}
+        />
+      ))}
+    </div>
+  ),
+};
+
+export const WithoutIcon: Story = {
+  render: () => (
+    <div className="flex w-full max-w-sm flex-col gap-4">
+      <Demographics label="Direct" value={64} formattedValue="64%" />
+      <Demographics label="Referral" value={36} formattedValue="36%" />
+    </div>
+  ),
+};

--- a/src/components/Demographics/Demographics.test.tsx
+++ b/src/components/Demographics/Demographics.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { Demographics } from "./Demographics";
+
+describe("Demographics", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Demographics label="United States" value={52.6} formattedValue="52.6%" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("renders the label and the formatted share", () => {
+    render(<Demographics label="United States" value={52.6} formattedValue="52.6%" />);
+    expect(screen.getByText("United States")).toBeInTheDocument();
+    expect(screen.getByText("52.6%")).toBeInTheDocument();
+  });
+
+  it("names the bar after the row so the value is not announced bare", () => {
+    render(<Demographics label="United States" value={52.6} formattedValue="52.6%" />);
+    const bar = screen.getByRole("progressbar", { name: "United States" });
+    expect(bar).toHaveAttribute("aria-valuenow", "52.6");
+  });
+
+  it("renders a leading icon when given one", () => {
+    render(
+      <Demographics
+        label="United States"
+        value={52.6}
+        formattedValue="52.6%"
+        icon={<span data-testid="flag">US</span>}
+      />,
+    );
+    expect(screen.getByTestId("flag")).toBeInTheDocument();
+  });
+
+  it("clamps an out-of-range share", () => {
+    render(<Demographics label="Everywhere" value={140} formattedValue="140%" />);
+    expect(screen.getByRole("progressbar", { name: "Everywhere" })).toHaveAttribute(
+      "aria-valuenow",
+      "100",
+    );
+  });
+});

--- a/src/components/Demographics/Demographics.tsx
+++ b/src/components/Demographics/Demographics.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+import { ProgressBar } from "../ProgressBar/ProgressBar";
+
+/** Props for {@link Demographics}. */
+export interface DemographicsProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+  /** Row label, e.g. a country name. Pass a translated string for i18n. */
+  label: React.ReactNode;
+  /** Share of the total, 0–100. Drives the bar and is announced to assistive tech. */
+  value: number;
+  /** Formatted share shown at the end of the row, e.g. `"52.6%"`. */
+  formattedValue: React.ReactNode;
+  /** Leading 20px glyph — a flag for a country row. */
+  icon?: React.ReactNode;
+}
+
+/**
+ * One row of a breakdown: a leading glyph and label, its share at the far end,
+ * and a bar underneath. Stack these to show how a total splits across
+ * categories — the top-countries breakdown on the insights dashboard, and the
+ * same list expanded inside a dialog.
+ *
+ * @example
+ * ```tsx
+ * <Demographics
+ *   icon={<span aria-hidden>🇺🇸</span>}
+ *   label="United States"
+ *   value={52.6}
+ *   formattedValue="52.6%"
+ * />
+ * ```
+ */
+export const Demographics = React.forwardRef<HTMLDivElement, DemographicsProps>(
+  ({ label, value, formattedValue, icon, className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex w-full flex-col gap-2", className)} {...props}>
+      <div className="flex w-full items-center justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-2">
+          {icon && <span className="flex size-5 shrink-0 items-center justify-center">{icon}</span>}
+          <span className="typography-body-small-14px-semibold truncate text-content-primary">
+            {label}
+          </span>
+        </span>
+        <span className="typography-body-small-14px-regular shrink-0 text-content-primary">
+          {formattedValue}
+        </span>
+      </div>
+      <ProgressBar
+        variant="sky"
+        size="medium"
+        value={value}
+        ariaLabel={typeof label === "string" ? label : undefined}
+      />
+    </div>
+  ),
+);
+
+Demographics.displayName = "Demographics";

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,22 +1,24 @@
 import * as React from "react";
 import { cn } from "@/utils/cn";
 
-/** Track height — `"default"` (12px) or `"small"` (6px). */
-export type ProgressBarSize = "default" | "small";
+/** Track height — `"default"` (12px), `"medium"` (8px) or `"small"` (6px). */
+export type ProgressBarSize = "default" | "medium" | "small";
 /**
  * Colour mode.
  * - `"brand"` — V2 brand (green) fill on a tinted track.
  * - `"mono"` — V2 monochrome fill on a tinted track (theme-aware).
  * - `"default"` — legacy value-coded red/yellow/green.
  * - `"generic"` — legacy solid brand green on a neutral track.
+ * - `"sky"` — chart sky fill on the muted-sky track, for data bars such as the
+ *   demographics breakdown.
  * - `"neutral"` — legacy theme-aware inverse colour on a neutral track.
  */
-export type ProgressBarVariant = "brand" | "mono" | "default" | "generic" | "neutral";
+export type ProgressBarVariant = "brand" | "mono" | "sky" | "default" | "generic" | "neutral";
 
 export interface ProgressBarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   /** Current progress value, clamped to 0–100. */
   value: number;
-  /** Track height — `"default"` (12px) or `"small"` (6px). @default "default" */
+  /** Track height — `"default"` (12px), `"medium"` (8px) or `"small"` (6px). @default "default" */
   size?: ProgressBarSize;
   /** Colour mode. Prefer `"brand"` or `"mono"` (V2); `"default"`/`"generic"`/`"neutral"` are legacy. @default "default" */
   variant?: ProgressBarVariant;
@@ -40,11 +42,13 @@ export interface ProgressBarProps extends Omit<React.HTMLAttributes<HTMLDivEleme
 
 const TRACK_HEIGHT: Record<ProgressBarSize, string> = {
   default: "h-3",
+  medium: "h-2",
   small: "h-1.5",
 };
 
 const GAP: Record<ProgressBarSize, string> = {
   default: "gap-3",
+  medium: "gap-2",
   small: "gap-1",
 };
 
@@ -76,6 +80,12 @@ function resolveColors(
       barColor: "bg-progress-bar-mono-active",
       textColor: "text-content-primary",
       trackColor: "bg-progress-bar-mono-inactive",
+    };
+  if (variant === "sky")
+    return {
+      barColor: "bg-special-chart-sky",
+      textColor: "text-content-primary",
+      trackColor: "bg-special-chart-muted-sky",
     };
   if (variant === "neutral")
     return {
@@ -126,7 +136,9 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
     ref,
   ) => {
     const clampedValue = Math.min(100, Math.max(0, value));
-    const isSmall = size === "small";
+    // `medium` groups with `small`: both are compact bars, so the completion
+    // figure uses the smaller heading rather than the display size.
+    const isSmall = size !== "default";
     const { barColor, textColor, trackColor } = resolveColors(variant, clampedValue);
 
     const showHeader = title != null || showCompletion || stepsLabel != null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,8 @@ export type {
   CyclingTextSizing,
 } from "./components/CyclingText/CyclingText";
 export { CyclingText } from "./components/CyclingText/CyclingText";
+export type { DemographicsProps } from "./components/Demographics/Demographics";
+export { Demographics } from "./components/Demographics/Demographics";
 export type {
   DialogBodyProps,
   DialogCloseProps,

--- a/src/styles/styleTokens.json
+++ b/src/styles/styleTokens.json
@@ -2546,6 +2546,13 @@
               "type": "color",
               "value": "#ff4d4dff",
               "blendMode": "normal"
+            },
+            "muted": {
+              "sky": {
+                "type": "color",
+                "value": "#e3f3feff",
+                "blendMode": "normal"
+              }
             }
           },
           "default": {
@@ -6202,6 +6209,13 @@
               "type": "color",
               "value": "#ff4d4dff",
               "blendMode": "normal"
+            },
+            "muted": {
+              "sky": {
+                "type": "color",
+                "value": "#30506aff",
+                "blendMode": "normal"
+              }
             }
           },
           "default": {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -136,6 +136,7 @@
   --color-special-chart-yellow: #f5d90aff;
   --color-special-chart-lime: #8fcb3aff;
   --color-special-chart-red: #ff4d4dff;
+  --color-special-chart-muted-sky: #e3f3feff;
   --color-special-default: #9c27b0ff;
   --color-special-background: #fdf1ffff;
   --color-brand-primary-default: var(--primitives-color-green-500);
@@ -530,6 +531,7 @@
   --color-special-chart-yellow: #f5d90aff;
   --color-special-chart-lime: #8fcb3aff;
   --color-special-chart-red: #ff4d4dff;
+  --color-special-chart-muted-sky: #e3f3feff;
   --color-special-default: #9c27b0ff;
   --color-special-background: #fdf1ffff;
   --color-brand-primary-default: var(--primitives-color-green-500);
@@ -747,6 +749,7 @@
   --color-special-chart-yellow: #f5d90aff;
   --color-special-chart-lime: #8fcb3aff;
   --color-special-chart-red: #ff4d4dff;
+  --color-special-chart-muted-sky: #30506aff;
   --color-special-default: #ed81ffff;
   --color-special-background: #4f1259ff;
   --color-brand-primary-default: var(--primitives-color-green-500);


### PR DESCRIPTION
Eighth and last of the `insights-components` extraction. Stacked on #641 because the stories render real flags; it will retarget to `main` when that merges. After this, eden has every symbol it imports.

One row of a breakdown: leading glyph, label, share at the far end, bar underneath. Stacked for the top-countries card on agency insights.

## Three changes, not one

I planned this as a 168-line component PR. It is not — `tsc` refused it, which is how I found the rest. Reviewing them separately:

**1. `special-chart-muted-sky` token.** `#e3f3fe` light, `#30506a` dark. Added to `styleTokens.json` and `theme.css` regenerated via `node src/styles/buildStyles.js` rather than hand-edited — the file carries an `AUTO-GENERATED` header. The regenerated output differs from `main` by exactly the 3 expected lines.

This is the first token from the `Color/Special/Chart/Muted/*` ramp, which is the ramp I flagged as entirely unexported in the contrast thread on #629. So that question now has one concrete answer: the muted ramp is the **track** colour behind a full-strength chart bar, not an alternative to it.

**2. `ProgressBar` gains `size="medium"` (8px) and `variant="sky"`.** `sky` is `bg-special-chart-sky` on a `bg-special-chart-muted-sky` track. Additive — every existing variant and size is untouched, which the 48 existing ProgressBar tests confirm.

**3. `Demographics` itself.** Takes `icon` as a plain `ReactNode`, so it has no dependency on `CountryFlag`; only its stories do. That keeps the generic row cheap and the 38 kB flag payload confined to `@fanvue/ui/flags` (see #641).

## Verified in Storybook, both themes

The token is the part that could have failed silently — a missing custom property yields no background rather than an error, so a track would simply be invisible. Measured on `Breakdown`:

```
light   token #e3f3feff   track rgb(227,243,254)   fill rgb(79,178,249)   trackH 8px
dark    token #30506aff   track rgb(48,80,106)     fill rgb(79,178,249)   label #fff
```

Five rows with `aria-valuenow` of 52.6 / 29.2 / 7.6 / 7.3 / 6.9 and fill widths proportional to each.

Full suite 4579, `tsc --noEmit` clean.