### PR TITLE
fix(DropdownMenu): align row radius, radio padding and count size to V2

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -83,6 +83,53 @@ describe("DropdownMenu", () => {
       expect(panel).not.toHaveClass("rounded-lg");
     });
 
+    // Each of these three drifted from the design unnoticed, so they are asserted
+    // rather than left to the eye. Node references are in the component.
+    it("gives a menu item the 12px row radius", () => {
+      renderMenu(<DropdownMenuItem>Item</DropdownMenuItem>);
+      const item = screen.getByRole("menuitem");
+      expect(item).toHaveClass("rounded-sm");
+      expect(item).not.toHaveClass("rounded-xs");
+    });
+
+    it("keeps the 8px radius on a radio item, which the design draws differently", () => {
+      renderMenu(
+        <DropdownMenuRadioGroup value="a">
+          <DropdownMenuRadioItem value="a">A</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>,
+      );
+      const item = screen.getByRole("menuitemradio");
+      expect(item).toHaveClass("rounded-xs");
+      expect(item).not.toHaveClass("rounded-sm");
+    });
+
+    it("indents a radio item the same as any other row", () => {
+      renderMenu(
+        <DropdownMenuRadioGroup value="a">
+          <DropdownMenuRadioItem value="a">A</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>,
+      );
+      const item = screen.getByRole("menuitemradio");
+      expect(item).toHaveClass("px-3");
+      expect(item).not.toHaveClass("px-4");
+    });
+
+    it("draws the count at 14px at both row heights", () => {
+      renderMenu(
+        <>
+          <DropdownMenuItem size="40" count="12">
+            Forty
+          </DropdownMenuItem>
+          <DropdownMenuItem size="32" count="34">
+            Thirty two
+          </DropdownMenuItem>
+        </>,
+      );
+      expect(screen.getByText("12")).toHaveClass("typography-body-small-14px-regular");
+      expect(screen.getByText("12")).not.toHaveClass("typography-body-default-16px-regular");
+      expect(screen.getByText("34")).toHaveClass("typography-body-small-14px-regular");
+    });
+
     it("does not render content when closed", () => {
       renderMenu(<DropdownMenuItem>Hidden</DropdownMenuItem>, {
         defaultOpen: false,

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -381,8 +381,14 @@ const ITEM_SIZE_CLASSES: Record<"40" | "32", string> = {
   "32": "min-h-8 py-[7px] typography-body-small-14px-regular",
 };
 
+/*
+ * Both sizes are 14px: `V2 Menu Item` draws the count as `Body Small 14px/Regular`
+ * in `content-tertiary` regardless of the row height (node `21542:8629`). The 40
+ * row previously stepped up to 16px, which also put the count's line box at 24px
+ * against the two-line layout's 18px title leading.
+ */
 const ITEM_COUNT_TYPOGRAPHY: Record<"40" | "32", string> = {
-  "40": "typography-body-default-16px-regular",
+  "40": "typography-body-small-14px-regular",
   "32": "typography-body-small-14px-regular",
 };
 
@@ -489,11 +495,16 @@ export const DropdownMenuItem = React.forwardRef<
     const hasDescription = description != null;
     const hasAvatar = avatar != null;
     const itemClassName = cn(
+      // `rounded-sm` (12px), not the 8px the rows carried before: `V2 Menu Item` is
+      // `rounded-[var(--radius/rounded-sm,12px)]` (node `21542:8629`). Deliberately
+      // different from `DropdownMenuRadioItem` and `DropdownMenuCheckboxItem`, which
+      // `V2 Menu Radio Item` draws at `rounded-xs` (node `7393:62008`).
+      //
       // `text-start` because the sheet variant renders the row as a <button>, and
       // the UA centres a button's text — which centred the two-line title and
       // description while the popper variant (a div) inherited the panel's start
       // alignment. Both read from the same edge now.
-      "group flex w-full cursor-pointer gap-2 rounded-xs px-3 text-start outline-none",
+      "group flex w-full cursor-pointer gap-2 rounded-sm px-3 text-start outline-none",
       hasDescription ? "items-start" : "items-center",
       // The sheet's header runs the full width of the panel, so its rows have to
       // come in off the edge themselves — 12px here on the panel's own 4px is the
@@ -949,7 +960,10 @@ export const DropdownMenuRadioItem = React.forwardRef<
     <DropdownMenuPrimitive.RadioItem
       ref={ref}
       className={cn(
-        "group flex w-full cursor-pointer items-start gap-3 rounded-xs px-4 py-2 outline-none",
+        // `px-3` (12px), not 16px: `V2 Menu Radio Item` is `px-[12px] py-[8px]`
+        // (node `7393:62008`), and at 16px a radio row indented 4px further than a
+        // `DropdownMenuCheckboxItem` in the same menu.
+        "group flex w-full cursor-pointer items-start gap-3 rounded-xs px-3 py-2 outline-none",
         "data-[highlighted]:bg-neutral-alphas-50",
         "data-[disabled]:cursor-not-allowed data-[disabled]:text-content-disabled",
         // See DropdownMenuItem above: bg-interaction-hover aliases to the same

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -382,10 +382,14 @@ const ITEM_SIZE_CLASSES: Record<"40" | "32", string> = {
 };
 
 /*
- * Both sizes are 14px: `V2 Menu Item` draws the count as `Body Small 14px/Regular`
- * in `content-tertiary` regardless of the row height (node `21542:8629`). The 40
- * row previously stepped up to 16px, which also put the count's line box at 24px
- * against the two-line layout's 18px title leading.
+ * 14px at both heights. `V2 Menu Item` draws the count as `Body Small 14px/Regular`
+ * in `content-tertiary` (node `21542:8629`), and the 40 row previously stepped up to
+ * 16px — which also put the count's line box at 24px against the two-line layout's
+ * 18px title leading.
+ *
+ * Only the 40 row is drawn in Figma: the component set's variants are Type and State
+ * with no size axis. The 32 row is ours, and 14px matches the body type it already
+ * uses, so both entries agree by construction rather than by design reference.
  */
 const ITEM_COUNT_TYPOGRAPHY: Record<"40" | "32", string> = {
   "40": "typography-body-small-14px-regular",


### PR DESCRIPTION
Reopens #640, which GitHub auto-closed when its base branch `ds/dropdown-multiselect` was deleted on #639's merge. Same branch, rebased onto `main` with #639's commits dropped since they are squashed there now. **Already approved by @alfonsovo-fv on #640** — no changes since, so this needs no second review, only a merge.

Three pre-existing deviations from the design, none introduced by #639. Split out because each changes every dropdown in eden and fadmin, not just the rows #639 touched.

Every value is read from the Figma reference code, not inferred from a screenshot, and each is commented at the line with its node id.

| what | was | is | source |
| --- | --- | --- | --- |
| `DropdownMenuItem` row radius | `rounded-xs` (8px) | `rounded-sm` (12px) | `V2 Menu Item`, node `21542:8629` |
| `DropdownMenuRadioItem` padding | `px-4` (16px) | `px-3` (12px) | `V2 Menu Radio Item`, node `7393:62008` |
| count typography at size 40 | 16px/24px | 14px/18px | `V2 Menu Item`, node `21542:8629` |

**The two row radii genuinely differ, and that is not a mistake.** `V2 Menu Item` is `rounded-sm` (12px); `V2 Menu Radio Item` is `rounded-xs` (8px). So this changes the plain item and deliberately leaves the radio and checkbox items alone, with a test asserting the radio item *stays* at 8px so the next person to spot the inconsistency finds the reason instead of tidying it away.

**The count size compounded #639's alignment fix.** At 16px its line box is 24px against the two-line layout's 18px title leading, so it was both the wrong size and the wrong height. #639 centred it regardless, which had the effect of hiding the size error.

## Tests

Four, one per change plus the radio-radius guard. Verified against `main`: the three change assertions fail, the guard passes on both.

```
× gives a menu item the 12px row radius
✓ keeps the 8px radius on a radio item, which the design draws differently
× indents a radio item the same as any other row
× draws the count at 14px at both row heights
```

Verified in a local Storybook too, `FeatureItems` dark, every row's siblings sharing their title's centre:

```
row                     rowRadius  title        titleC  iconC  count        countC
Jane Doe (1 line)       12px       16px/24px    20.8    20.8   -            -
Alex Smith (2 line)     12px       14px/18px    17      -      14px/18px    17
Favourites (1 line)     12px       16px/24px    20      20     14px/18px    20
Edit profile (2 line)   12px       14px/18px    17      17     -            -
```

103 tests, `tsc --noEmit` clean.

## Not included, needs a decision

The header divider. Ours is full-bleed `-mx-2` with a comment saying the rule spans the panel deliberately; the search header in node `7393:62008` draws its `V2 Divider` with `pr-[4px]`. Left alone because the evidence is inconsistent across variants — the Default Desktop header (node `21549:6769`) has **no divider at all** and uses 12px padding where that instance uses 4px.