### PR TITLE
feat(Tooltip, Select, ChartCard, Table): the DS changes the insights dashboard needs

### DIFF
--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -185,6 +185,34 @@ describe("Chart", () => {
       expect(screen.getByText("1,234")).toBeInTheDocument();
     });
 
+    it("formats the figure with valueFormatter, keeping the series name", () => {
+      const payload = [{ ...TOOLTIP_ITEM, value: 1234 }];
+      render(
+        <ChartContext.Provider value={{ config: SAMPLE_CONFIG }}>
+          <ChartTooltipContent active payload={payload} valueFormatter={(v) => `$${v}`} />
+        </ChartContext.Provider>,
+      );
+      expect(screen.getByText("$1234")).toBeInTheDocument();
+      expect(screen.queryByText("1,234")).not.toBeInTheDocument();
+      expect(screen.getAllByText("Revenue").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("lets formatter win over valueFormatter, since it replaces the whole row", () => {
+      const payload = [{ ...TOOLTIP_ITEM, value: 1234 }];
+      render(
+        <ChartContext.Provider value={{ config: SAMPLE_CONFIG }}>
+          <ChartTooltipContent
+            active
+            payload={payload}
+            valueFormatter={(v) => `$${v}`}
+            formatter={() => <span>whole row</span>}
+          />
+        </ChartContext.Provider>,
+      );
+      expect(screen.getByText("whole row")).toBeInTheDocument();
+      expect(screen.queryByText("$1234")).not.toBeInTheDocument();
+    });
+
     it("hides label when hideLabel is true", () => {
       render(
         <ChartContext.Provider value={{ config: SAMPLE_CONFIG }}>
@@ -319,6 +347,35 @@ describe("Chart", () => {
         </ChartCard>,
       );
       expect(container.querySelector(".mt-auto")).not.toBeNull();
+    });
+
+    it("swaps the children for the skeleton while loading", () => {
+      render(
+        <ChartCard title="Revenue" loading skeleton={<div>placeholder</div>}>
+          <div>chart</div>
+        </ChartCard>,
+      );
+      expect(screen.getByText("placeholder")).toBeInTheDocument();
+      expect(screen.queryByText("chart")).not.toBeInTheDocument();
+    });
+
+    it("renders the children once loading finishes", () => {
+      render(
+        <ChartCard title="Revenue" loading={false} skeleton={<div>placeholder</div>}>
+          <div>chart</div>
+        </ChartCard>,
+      );
+      expect(screen.getByText("chart")).toBeInTheDocument();
+      expect(screen.queryByText("placeholder")).not.toBeInTheDocument();
+    });
+
+    it("keeps rendering the children while loading when no skeleton is given", () => {
+      render(
+        <ChartCard title="Revenue" loading>
+          <div>chart</div>
+        </ChartCard>,
+      );
+      expect(screen.getByText("chart")).toBeInTheDocument();
     });
 
     it("renders the outlined info glyph rather than the filled disc", () => {

--- a/src/components/Chart/ChartCard.tsx
+++ b/src/components/Chart/ChartCard.tsx
@@ -37,6 +37,14 @@ export interface ChartCardProps extends Omit<React.HTMLAttributes<HTMLDivElement
   };
   /** Show loading skeleton instead of content. @default false */
   loading?: boolean;
+  /**
+   * Placeholder shown in place of {@link children} while {@link loading} —
+   * usually a `ChartSkeleton` of the variant matching the body it stands in for,
+   * so the card does not resize when the real content arrives. Omit it to keep
+   * rendering the children while loading, which is what a card whose body is
+   * decorative wants.
+   */
+  skeleton?: React.ReactNode;
   /** Chart content rendered below the header. */
   children?: React.ReactNode;
 }
@@ -84,6 +92,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
       dateInfo,
       trendChip,
       loading = false,
+      skeleton,
       children,
       ...props
     },
@@ -159,7 +168,11 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
               )}
             </>
           )}
-          {children && <div className="mt-auto">{children}</div>}
+          {loading && skeleton ? (
+            <div className="mt-auto">{skeleton}</div>
+          ) : (
+            children && <div className="mt-auto">{children}</div>
+          )}
         </div>
       </Card>
     );

--- a/src/components/Chart/ChartHelpers.stories.tsx
+++ b/src/components/Chart/ChartHelpers.stories.tsx
@@ -43,6 +43,19 @@ export const CardLoading: Story = {
   ),
 };
 
+export const CardLoadingWithSkeleton: Story = {
+  render: () => (
+    <div className="flex w-full max-w-lg flex-col gap-4">
+      <ChartCard title="Revenue" subtitle="$4,523" loading skeleton={<ChartSkeleton rows={4} />}>
+        <SimpleLineChart config={simpleLineConfig} />
+      </ChartCard>
+      <ChartCard title="Top Creators" loading skeleton={<ChartSkeleton variant="table" rows={4} />}>
+        <div className="h-48 w-full" />
+      </ChartCard>
+    </div>
+  ),
+};
+
 export const CardWithTooltip: Story = {
   render: () => (
     <div className="w-full max-w-lg">
@@ -127,11 +140,31 @@ function SeriesToggleInteractive() {
     <div className="w-full max-w-lg">
       <ChartSeriesToggle
         items={[
-          { key: "photos", label: "Photos", color: "var(--color-special-chart-teal)" },
-          { key: "videos", label: "Videos", color: "var(--color-special-chart-sky)" },
-          { key: "messages", label: "Messages", color: "var(--color-special-chart-orange)" },
-          { key: "tips", label: "Tips", color: "var(--color-special-chart-gray)" },
-          { key: "subs", label: "Subscriptions", color: "var(--color-special-chart-pink)" },
+          {
+            key: "photos",
+            label: "Photos",
+            color: "var(--color-special-chart-teal)",
+          },
+          {
+            key: "videos",
+            label: "Videos",
+            color: "var(--color-special-chart-sky)",
+          },
+          {
+            key: "messages",
+            label: "Messages",
+            color: "var(--color-special-chart-orange)",
+          },
+          {
+            key: "tips",
+            label: "Tips",
+            color: "var(--color-special-chart-gray)",
+          },
+          {
+            key: "subs",
+            label: "Subscriptions",
+            color: "var(--color-special-chart-pink)",
+          },
         ]}
         value={visible}
         onValueChange={setVisible}
@@ -150,11 +183,31 @@ function SeriesTogglePartialInteractive() {
     <div className="w-full max-w-lg">
       <ChartSeriesToggle
         items={[
-          { key: "photos", label: "Photos", color: "var(--color-special-chart-teal)" },
-          { key: "videos", label: "Videos", color: "var(--color-special-chart-sky)" },
-          { key: "messages", label: "Messages", color: "var(--color-special-chart-orange)" },
-          { key: "tips", label: "Tips", color: "var(--color-special-chart-gray)" },
-          { key: "subs", label: "Subscriptions", color: "var(--color-special-chart-pink)" },
+          {
+            key: "photos",
+            label: "Photos",
+            color: "var(--color-special-chart-teal)",
+          },
+          {
+            key: "videos",
+            label: "Videos",
+            color: "var(--color-special-chart-sky)",
+          },
+          {
+            key: "messages",
+            label: "Messages",
+            color: "var(--color-special-chart-orange)",
+          },
+          {
+            key: "tips",
+            label: "Tips",
+            color: "var(--color-special-chart-gray)",
+          },
+          {
+            key: "subs",
+            label: "Subscriptions",
+            color: "var(--color-special-chart-pink)",
+          },
         ]}
         value={visible}
         onValueChange={setVisible}
@@ -173,13 +226,41 @@ function SeriesToggleManyInteractive() {
     <div className="w-full max-w-3xl">
       <ChartSeriesToggle
         items={[
-          { key: "total", label: "Total", color: "var(--color-special-chart-purple)" },
-          { key: "subs", label: "Subs", color: "var(--color-special-chart-sky)" },
-          { key: "messages", label: "Messages", color: "var(--color-special-chart-orange)" },
-          { key: "posts", label: "Posts", color: "var(--color-special-chart-magenta)" },
-          { key: "tips", label: "Tips", color: "var(--color-special-chart-teal)" },
-          { key: "referrals", label: "Referrals", color: "var(--color-special-chart-pink)" },
-          { key: "other", label: "Other", color: "var(--color-special-chart-gray)" },
+          {
+            key: "total",
+            label: "Total",
+            color: "var(--color-special-chart-purple)",
+          },
+          {
+            key: "subs",
+            label: "Subs",
+            color: "var(--color-special-chart-sky)",
+          },
+          {
+            key: "messages",
+            label: "Messages",
+            color: "var(--color-special-chart-orange)",
+          },
+          {
+            key: "posts",
+            label: "Posts",
+            color: "var(--color-special-chart-magenta)",
+          },
+          {
+            key: "tips",
+            label: "Tips",
+            color: "var(--color-special-chart-teal)",
+          },
+          {
+            key: "referrals",
+            label: "Referrals",
+            color: "var(--color-special-chart-pink)",
+          },
+          {
+            key: "other",
+            label: "Other",
+            color: "var(--color-special-chart-gray)",
+          },
         ]}
         value={visible}
         onValueChange={setVisible}

--- a/src/components/Chart/ChartTooltip.tsx
+++ b/src/components/Chart/ChartTooltip.tsx
@@ -25,7 +25,7 @@ export interface ChartTooltipContentProps extends React.HTMLAttributes<HTMLDivEl
     label: string | number,
     payload: Payload<ValueType, NameType>[],
   ) => React.ReactNode;
-  /** Custom value formatter. */
+  /** Replaces the whole row. Takes precedence over {@link valueFormatter}. */
   formatter?: (
     value: ValueType,
     name: NameType,
@@ -33,6 +33,13 @@ export interface ChartTooltipContentProps extends React.HTMLAttributes<HTMLDivEl
     index: number,
     payload: Payload<ValueType, NameType>[],
   ) => React.ReactNode;
+  /**
+   * Formats each row's figure, so a chart can show its values in its own units —
+   * a currency series wants a price, not a bare thousands-separated number.
+   * Unlike {@link formatter} this keeps the row's layout, indicator and series
+   * name, and changes only the figure.
+   */
+  valueFormatter?: (value: ValueType) => React.ReactNode;
   /** CSS class for the label element. */
   labelClassName?: string;
   /** Hide the tooltip header label. @default false */
@@ -63,6 +70,7 @@ function TooltipRow({
   hideIndicator,
   nestLabel,
   tooltipLabel,
+  valueFormatter,
 }: {
   item: Payload<ValueType, NameType>;
   itemConfig: ChartConfigEntry | undefined;
@@ -71,6 +79,7 @@ function TooltipRow({
   hideIndicator: boolean;
   nestLabel: boolean;
   tooltipLabel: React.ReactNode;
+  valueFormatter: ((value: ValueType) => React.ReactNode) | undefined;
 }) {
   return (
     <>
@@ -106,7 +115,11 @@ function TooltipRow({
         </div>
         {item.value !== undefined && (
           <span className="font-medium font-mono text-content-primary tabular-nums">
-            {typeof item.value === "number" ? item.value.toLocaleString() : item.value}
+            {valueFormatter
+              ? valueFormatter(item.value)
+              : typeof item.value === "number"
+                ? item.value.toLocaleString()
+                : item.value}
           </span>
         )}
       </div>
@@ -140,6 +153,7 @@ export const ChartTooltipContent = React.forwardRef<HTMLDivElement, ChartTooltip
       labelFormatter,
       labelClassName,
       formatter,
+      valueFormatter,
       color,
       nameKey,
       labelKey,
@@ -210,6 +224,7 @@ export const ChartTooltipContent = React.forwardRef<HTMLDivElement, ChartTooltip
                     hideIndicator={hideIndicator}
                     nestLabel={nestLabel}
                     tooltipLabel={tooltipLabel}
+                    valueFormatter={valueFormatter}
                   />
                 )}
               </div>

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -268,6 +268,34 @@ export const WithGroupsAndSeparator: Story = {
   ),
 };
 
+export const SelectedTwoLineRow: Story = {
+  name: "Selected row, two-line",
+  decorators: [
+    (Story) => (
+      <div style={{ width: "375px", height: "260px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    label: "Earnings view",
+    defaultValue: "gross",
+    defaultOpen: true,
+  },
+  render: (args) => (
+    <Select {...args}>
+      <SelectContent>
+        <SelectItem value="gross" description="Before platform fees are deducted">
+          Gross earnings
+        </SelectItem>
+        <SelectItem value="net" description="After platform fees are deducted">
+          Net earnings
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
 export const WithItemIcons: Story = {
   name: "Rows with leading icons",
   decorators: [

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -128,7 +128,9 @@ describe("Select", () => {
 
   describe("left icon", () => {
     it("renders left icon", () => {
-      const { container } = renderSelect({ leftIcon: <HomeIcon data-testid="left-icon" /> });
+      const { container } = renderSelect({
+        leftIcon: <HomeIcon data-testid="left-icon" />,
+      });
       expect(container.querySelector('[data-testid="left-icon"]')).toBeInTheDocument();
     });
   });
@@ -264,6 +266,37 @@ describe("Select", () => {
     it("keeps 40px rows for the larger trigger sizes", () => {
       renderOpen(<SelectItem value="a">Option A</SelectItem>, "48");
       expect(screen.getByRole("option", { name: "Option A" })).toHaveClass("min-h-10");
+    });
+
+    it("renders the panel on the shared menu surface, not a flat background", () => {
+      renderOpen(<SelectItem value="a">Option A</SelectItem>);
+      const panel = screen.getByRole("listbox");
+      expect(panel).toHaveClass("bg-surface-primary", "border-border-primary", "shadow-blur-menu");
+      expect(panel).not.toHaveClass("bg-background-primary", "border-neutral-alphas-200");
+    });
+
+    it("shades the selected row one step above the hover fill", () => {
+      renderOpen(<SelectItem value="a">Option A</SelectItem>);
+      const option = screen.getByRole("option", { name: "Option A" });
+      expect(option).toHaveClass("data-[state=checked]:bg-neutral-alphas-100");
+      expect(option).toHaveClass("data-[state=checked]:data-highlighted:bg-neutral-alphas-200");
+      expect(option).toHaveClass("data-highlighted:bg-neutral-alphas-50");
+    });
+
+    it("centres the check indicator against the whole two-line row", () => {
+      render(
+        <Select aria-label="Test" defaultOpen defaultValue="a">
+          <SelectContent>
+            <SelectItem value="a" description="Secondary line">
+              Option A
+            </SelectItem>
+          </SelectContent>
+        </Select>,
+      );
+      const option = screen.getByRole("option", { name: /Option A/ });
+      expect(option).toHaveClass("items-start");
+      expect(option.lastElementChild).toHaveClass("self-center");
+      expect(option.lastElementChild).not.toHaveClass("self-start");
     });
 
     it("has no accessibility violations for a feature row", async () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -197,6 +197,15 @@ export interface SelectContentProps
   extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> {}
 
 /**
+ * The same surface {@link DropdownMenuContent} uses, so a Select popup and a
+ * DropdownMenu popup sitting side by side read as one family: the surface token
+ * rather than a flat background, a solid border, and the shared menu shadow
+ * behind a blur.
+ */
+const CONTENT_SURFACE_CLASSES =
+  "border border-border-primary bg-surface-primary shadow-blur-menu backdrop-blur-[4px]";
+
+/**
  * The dropdown panel rendered inside a portal. Place {@link SelectItem} elements
  * (and optionally {@link SelectGroup} / {@link SelectLabel}) as children.
  */
@@ -224,7 +233,8 @@ export const SelectContent = React.forwardRef<
         collisionPadding={collisionPadding}
         style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
         className={cn(
-          "relative w-max min-w-(--radix-select-trigger-width) max-w-(--radix-select-content-available-width) overflow-hidden rounded-sm border border-neutral-alphas-200 bg-background-primary text-content-primary shadow-[0_4px_16px_rgba(0,0,0,0.10)]",
+          "relative w-max min-w-(--radix-select-trigger-width) max-w-(--radix-select-content-available-width) overflow-hidden rounded-sm text-content-primary",
+          CONTENT_SURFACE_CLASSES,
           "data-[state=closed]:animate-out data-[state=open]:animate-in",
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
           "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
@@ -281,6 +291,28 @@ function isRenderableNode(node: React.ReactNode): boolean {
 }
 
 /**
+ * Shades the row holding the current value. Radix marks that row itself, so it
+ * stays marked whether or not the consumer re-derives what is selected.
+ *
+ * Plain hover sits at `neutral-alphas-50`, so this takes the next step up the
+ * ramp and its own hover the one after; sharing 50 would paint "selected" and
+ * "merely hovered" identically. Mirrors {@link DropdownMenuItem}'s `selected`
+ * ramp. Listed after the hover rule so tailwind-merge keeps both, and the
+ * two-attribute selector wins on specificity when a row is selected and hovered
+ * at once.
+ */
+const ITEM_SELECTED_CLASSES =
+  "data-[state=checked]:bg-neutral-alphas-100 data-[state=checked]:data-highlighted:bg-neutral-alphas-200";
+
+/**
+ * Centres the check indicator on the two-line row. That layout switches the row
+ * to `items-start`, which would otherwise hang the tick off the title's line — a
+ * leading icon or avatar belongs there because it labels the title, but the tick
+ * is a property of the whole row.
+ */
+const ITEM_INDICATOR_ALIGN_CLASSES = "self-center";
+
+/**
  * An individual option inside {@link SelectContent}, following the V2 Menu Item spec.
  *
  * Supports a leading icon or avatar, an optional two-line layout via `description`,
@@ -313,6 +345,7 @@ export const SelectItem = React.forwardRef<
         ITEM_SIZE_CLASSES[itemSize],
         hasAvatar && !hasDescription && itemSize === "32" && "py-1",
         "focus:bg-neutral-alphas-50 data-highlighted:bg-neutral-alphas-50",
+        ITEM_SELECTED_CLASSES,
         "data-disabled:pointer-events-none data-disabled:text-content-disabled",
         className,
       )}
@@ -352,7 +385,7 @@ export const SelectItem = React.forwardRef<
       <SelectPrimitive.ItemIndicator
         className={cn(
           "ml-auto flex size-4 shrink-0 items-center justify-center",
-          hasDescription && "self-start",
+          hasDescription && ITEM_INDICATOR_ALIGN_CLASSES,
         )}
       >
         <CheckIcon className="size-4 text-content-primary group-data-[disabled]:text-content-disabled" />

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -64,7 +64,10 @@ type ProductRow = {
   created: string;
   price: string;
   purchases: string;
-  status: { label: "Active" | "Inactive" | "Warning"; variant: "green" | "red" | "gold" };
+  status: {
+    label: "Active" | "Inactive" | "Warning";
+    variant: "green" | "red" | "gold";
+  };
 };
 
 const PRODUCT_ROWS: ProductRow[] = [
@@ -267,7 +270,10 @@ export const Sortable: Story = {
     type Direction = "asc" | "desc" | null;
     const Demo = () => {
       const [direction, setDirection] = React.useState<Direction>("asc");
-      const next: Record<NonNullable<Direction>, Direction> = { asc: "desc", desc: null };
+      const next: Record<NonNullable<Direction>, Direction> = {
+        asc: "desc",
+        desc: null,
+      };
       const cycle = () => setDirection((d) => (d == null ? "asc" : next[d]));
       return (
         <TableCard className="max-w-2xl">
@@ -307,6 +313,34 @@ export const Sortable: Story = {
     };
     return <Demo />;
   },
+};
+
+export const CondensedWithoutCard: Story = {
+  name: "Variant — condensed, sized on the Table itself",
+  render: () => (
+    <div className="max-w-3xl">
+      <TableScrollArea>
+        <Table size="condensed">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[42px]">#</TableHead>
+              <TableHead>Creator</TableHead>
+              <TableHead>Earnings</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {["Sofia Bloom", "Jayna Patel", "Alex Rivera"].map((name, index) => (
+              <TableRow key={name}>
+                <TableCell className="text-content-secondary">{index + 1}</TableCell>
+                <TableCell>{name}</TableCell>
+                <TableCell intent="sideLabel">${(3120 - index * 480).toLocaleString()}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableScrollArea>
+    </div>
+  ),
 };
 
 export const LargeRows: Story = {
@@ -557,9 +591,21 @@ export const AllStatesV2: Story = {
             </TableHeader>
             <TableBody>
               {[
-                { status: "Active" as const, variant: "green" as const, progress: 80 },
-                { status: "Warning" as const, variant: "gold" as const, progress: 40 },
-                { status: "Inactive" as const, variant: "red" as const, progress: 10 },
+                {
+                  status: "Active" as const,
+                  variant: "green" as const,
+                  progress: 80,
+                },
+                {
+                  status: "Warning" as const,
+                  variant: "gold" as const,
+                  progress: 40,
+                },
+                {
+                  status: "Inactive" as const,
+                  variant: "red" as const,
+                  progress: 10,
+                },
               ].map((row, idx) => (
                 <TableRow key={row.status}>
                   <TableCell intent="checkbox">

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -94,6 +94,57 @@ describe("Table", () => {
       expect(cell).toHaveClass("min-h-12");
     });
 
+    it("renders body cells at 48px when Table size is condensed and there is no card", () => {
+      const { container } = render(
+        <TableScrollArea>
+          <Table size="condensed">
+            <TableBody>
+              <TableRow>
+                <TableCell>Value</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableScrollArea>,
+      );
+      const cell = container.querySelector("td");
+      expect(cell).toHaveClass("h-12");
+      expect(cell).toHaveClass("min-h-12");
+    });
+
+    it("inherits the card's density when Table has no size of its own", () => {
+      const { container } = render(
+        <TableCard size="lg">
+          <TableScrollArea>
+            <Table>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Value</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableScrollArea>
+        </TableCard>,
+      );
+      expect(container.querySelector("td")).toHaveClass("h-20");
+    });
+
+    it("lets the Table's own size override the card's", () => {
+      const { container } = render(
+        <TableCard size="lg">
+          <TableScrollArea>
+            <Table size="condensed">
+              <TableBody>
+                <TableRow>
+                  <TableCell>Value</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableScrollArea>
+        </TableCard>,
+      );
+      expect(container.querySelector("td")).toHaveClass("h-12");
+    });
+
     it("uses 14px header typography when TableCard size is condensed", () => {
       const { container } = render(
         <TableCard size="condensed">

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -132,14 +132,26 @@ export const TableScrollArea = React.forwardRef<HTMLDivElement, TableScrollAreaP
 );
 TableScrollArea.displayName = "TableScrollArea";
 
-export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {}
+export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {
+  /**
+   * Row density for this table's cells. Omit to inherit from an enclosing
+   * {@link TableCard}, which is the usual case; set it when the table sits in
+   * some other surface — a `ChartCard`, say — and so has no card to inherit
+   * from.
+   */
+  size?: TableSize;
+}
 
 /**
  * Semantic `<table>` element. Place inside {@link TableScrollArea}.
+ *
+ * A {@link TableProps.size} is only provided to the cells when one is given, so
+ * omitting it still inherits the enclosing {@link TableCard}'s density rather
+ * than resetting to the context default.
  */
 export const Table = React.forwardRef<HTMLTableElement, TableProps>(
-  ({ className, ...props }, ref) => {
-    return (
+  ({ className, size, ...props }, ref) => {
+    const table = (
       <table
         ref={ref}
         className={cn(
@@ -148,6 +160,12 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         )}
         {...props}
       />
+    );
+
+    return size ? (
+      <TableSizeContext.Provider value={size}>{table}</TableSizeContext.Provider>
+    ) : (
+      table
     );
   },
 );

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -66,6 +66,52 @@ describe("Tooltip", () => {
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     });
 
+    it("fades the content in and out rather than blinking it on", async () => {
+      const user = userEvent.setup();
+      renderTooltip({ className: "styled-content" });
+      await user.hover(screen.getByRole("button", { name: "Hover me" }));
+      await screen.findByRole("tooltip");
+      expect(document.querySelector(".styled-content")).toHaveClass(
+        "data-[state=delayed-open]:[animation:fv-tooltip-in_150ms_ease-out]",
+        "data-[state=instant-open]:[animation:fv-tooltip-in_150ms_ease-out]",
+        "data-[state=closed]:[animation:fv-tooltip-out_120ms_ease-in]",
+      );
+    });
+
+    it("renders the v2 surface: tight radius, visible border, light shadow", async () => {
+      const user = userEvent.setup();
+      renderTooltip({ className: "styled-content" });
+      await user.hover(screen.getByRole("button", { name: "Hover me" }));
+      await screen.findByRole("tooltip");
+      const content = document.querySelector(".styled-content");
+      expect(content).toHaveClass("rounded-xs", "border", "border-border-selected", "shadow-sm");
+      expect(content).not.toHaveClass("rounded-sm");
+    });
+
+    it("drops the animation when the viewer asks for reduced motion", async () => {
+      const user = userEvent.setup();
+      renderTooltip({ className: "styled-content" });
+      await user.hover(screen.getByRole("button", { name: "Hover me" }));
+      await screen.findByRole("tooltip");
+      expect(document.querySelector(".styled-content")).toHaveClass(
+        "motion-reduce:[animation:none]",
+      );
+    });
+
+    it("lets a consumer override the exit animation, since its own class comes last", async () => {
+      const user = userEvent.setup();
+      renderTooltip({
+        className: "styled-content data-[state=closed]:[animation:none]",
+      });
+      await user.hover(screen.getByRole("button", { name: "Hover me" }));
+      await screen.findByRole("tooltip");
+      const content = document.querySelector(".styled-content");
+      expect(content).toHaveClass("data-[state=closed]:[animation:none]");
+      expect(content).not.toHaveClass(
+        "data-[state=closed]:[animation:fv-tooltip-out_120ms_ease-in]",
+      );
+    });
+
     it("applies custom className to content", async () => {
       const user = userEvent.setup();
       renderTooltip({ className: "custom-class" });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -69,6 +69,23 @@ export interface TooltipContentProps
   title?: React.ReactNode;
 }
 
+/**
+ * Fades the tooltip in and out, so it reads as arriving rather than blinking on.
+ *
+ * Opacity only, deliberately: the content is portalled and positioned by Radix's
+ * popper, which owns its transform — animating one here would fight it, and a
+ * transform on the content would also make it a stacking context. Declaring an
+ * exit animation is what keeps the content mounted long enough to play it, since
+ * Radix defers the unmount until `animationend`.
+ *
+ * Radix reports all three states through `data-state`, and the two open states
+ * are matched separately rather than as "not closed", so the exit rule can never
+ * be beaten by a broader selector. A consumer's own `data-[state=*]:` override
+ * still wins, since tailwind-merge sees the same variant and property.
+ */
+const ANIMATION_CLASSES =
+  "data-[state=delayed-open]:[animation:fv-tooltip-in_150ms_ease-out] data-[state=instant-open]:[animation:fv-tooltip-in_150ms_ease-out] data-[state=closed]:[animation:fv-tooltip-out_120ms_ease-in] motion-reduce:[animation:none]";
+
 export const TooltipContent = React.forwardRef<
   React.ComponentRef<typeof TooltipPrimitive.Content>,
   TooltipContentProps
@@ -98,7 +115,8 @@ export const TooltipContent = React.forwardRef<
           collisionPadding={8}
           style={{ zIndex: "var(--fanvue-ui-portal-z-index, 50)", ...style }}
           className={cn(
-            "typography-description-12px-semibold max-w-[320px] rounded-sm bg-surface-primary-inverted px-4 py-2 text-content-primary-inverted shadow-[0px_1px_4px_0px_rgba(0,0,0,0.06),0px_1px_3px_0px_rgba(0,0,0,0.05)]",
+            "typography-description-12px-semibold max-w-[320px] rounded-xs border border-border-selected bg-surface-primary-inverted px-4 py-2 text-content-primary-inverted shadow-sm",
+            ANIMATION_CLASSES,
             className,
           )}
           {...props}

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -111,6 +111,25 @@
 }
 
 /*
+ * Tooltip enter/exit. Opacity only, deliberately: the tooltip is portalled and
+ * positioned by Radix's popper, which owns its transform — animating one here
+ * would fight it, and any transform on the content also makes it a stacking
+ * context. Fading in is also what lets the exit run at all; without an animation
+ * Radix unmounts the content the moment it closes.
+ */
+@keyframes fv-tooltip-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes fv-tooltip-out {
+  to {
+    opacity: 0;
+  }
+}
+
+/*
  * AiButton. Each letter runs `fv-ai-letter` on a staggered delay set inline from
  * its index, which is what produces the left-to-right sweep — the alternative,
  * a fixed set of :nth-child delays, silently stops staggering past whatever


### PR DESCRIPTION
The insights dashboard was built against an unreleased `@fanvue/ui`, so Eden ended up carrying local overrides for things that belong in the library, and shipped without three props it was written to use. This closes that gap so the Eden side can drop its workarounds.

### The props

- **`ChartCard.skeleton`** — a placeholder shown in place of the children while `loading`, so a card keeps its shape instead of collapsing to just the header. Pass a `ChartSkeleton` of the matching variant. Omitting it keeps today's behaviour exactly.
- **`Table.size`** — for a table that sits in something other than a `TableCard` and so has no card to inherit density from. The insight cards put tables inside a `ChartCard`. Only provided to the cells when given, so omitting it still inherits.
- **`ChartTooltipContent.valueFormatter`** — changes a row's figure while keeping the row's layout, indicator and series name. A currency chart wants a price, not a thousands-separated number. `formatter` replaces the whole row and still takes precedence.

### Select

The Select popup and a `DropdownMenu` popup sit side by side in the insights toolbar and did not match — the Select panel was a flat background behind a plain shadow, the menu was the surface token behind the blur. Two `SelectItem` fixes ride along: the check indicator hung off the title's line on a two-line row, where the tick marks the whole row; and the row holding the current value painted identically to a merely hovered one, so it now takes the next step up the `neutral-alphas` ramp.

Both mirror what `DropdownMenuItem` already does. Its comment claimed `SelectItem` centred its tick too — that was aspirational, and is now true.

### Tooltip

Tooltips appeared and vanished instantly. They now fade, and take the v2 surface the design draws (tighter radius, visible border, lighter shadow).

Opacity only, deliberately: the content is portalled and positioned by Radix's popper, which owns its transform, and a transform here would also make it a stacking context. Declaring an exit animation is what keeps the content mounted long enough to play it.

### Blast radius

The tooltip change is the one to look at — **every tooltip in the product** changes shape and gains motion, and no automated check can catch that. Chromatic will show a wide diff. The Select surface affects every `Select` in Eden. The three props are additive and inert unless passed.

### Notes for review

- `valueFormatter` does **not** let Eden's `EarningsByTypeChart` drop its `formatter` override — that one needs the value-then-name row order, which is a separate change touching all 12 recharts cards. Left for its own PR.
- Rationale lives in JSDoc'd constants rather than inline comments, per `AGENTS.md` line 69.
- New stories cover the skeleton, the condensed table and the selected two-line row.

4666 unit tests pass, `tsc --noEmit` clean, no new lint warnings.
