### PR TITLE
fix(CreatorTile): progressive-blur the bottom scrim (DES-815)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3014,7 +3014,10 @@ function DropdownMenuDemo() {
               <DropdownMenuHeader
                 type="search"
                 title="Creators"
-                searchProps={{ autoFocus: true, placeholder: "Search creators" }}
+                searchProps={{
+                  autoFocus: true,
+                  placeholder: "Search creators",
+                }}
               />
               {["Jane Doe", "Alex Kim", "Sam Patel"].map((name) => (
                 <DropdownMenuCheckboxItem
@@ -5592,6 +5595,8 @@ function CreatorTileDemo() {
     "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=720&h=400&fit=crop";
   const sampleAvatar =
     "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop";
+  const highDetailImage =
+    "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=720&h=400&fit=crop";
 
   return (
     <div id="creator-tile" className="flex scroll-mt-20 flex-col gap-4">
@@ -5670,6 +5675,39 @@ function CreatorTileDemo() {
           }
           aspectRatio="banner"
           className="rounded-lg"
+        />
+      </div>
+
+      <h3 className="typography-body-default-16px-semibold mt-4">Progressive scrim</h3>
+      <div className="w-[361px]">
+        <CreatorTile
+          background={<img src={highDetailImage} alt="" loading="lazy" />}
+          avatar={{ src: sampleAvatar, alt: "Aitana Lopez", fallback: "AL" }}
+          name="Aitana Lopez"
+          tagline="@fit_aitana"
+          action={
+            <Button variant="primary" size="32">
+              Follow
+            </Button>
+          }
+          className="rounded-lg"
+        />
+      </div>
+
+      <h3 className="typography-body-default-16px-semibold mt-4">Narrow banner</h3>
+      <div className="w-[260px]">
+        <CreatorTile
+          background={<img src={highDetailImage} alt="" loading="lazy" />}
+          avatar={{ src: sampleAvatar, alt: "Jane Doe", fallback: "JD" }}
+          name="Jane Doe"
+          tagline="@jane_doe"
+          action={
+            <Button variant="white" size="32" className="rounded-full">
+              View Profile
+            </Button>
+          }
+          aspectRatio="banner"
+          className="rounded-sm"
         />
       </div>
     </div>

--- a/src/components/CreatorTile/CreatorTile.stories.tsx
+++ b/src/components/CreatorTile/CreatorTile.stories.tsx
@@ -7,6 +7,8 @@ const SAMPLE_BACKGROUND =
   "https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=720&h=400&fit=crop";
 const SAMPLE_AVATAR =
   "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop";
+const HIGH_DETAIL_BACKGROUND =
+  "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=720&h=400&fit=crop";
 
 const meta = {
   title: "Components/CreatorTile",
@@ -93,6 +95,45 @@ export const Banner: Story = {
         }
         tagline="@jane_doe"
         avatar={{ src: SAMPLE_AVATAR, alt: "Jane Doe", fallback: "JD" }}
+        action={
+          <Button variant="white" size="32" className="rounded-full">
+            View Profile
+          </Button>
+        }
+      />
+    </div>
+  ),
+};
+
+/**
+ * The scrim blurs progressively from 0 to 32px towards the bottom. A high-frequency background
+ * shows the ramp; the soft sample used elsewhere hides it almost entirely.
+ */
+export const ProgressiveScrim: Story = {
+  args: {
+    background: <img src={HIGH_DETAIL_BACKGROUND} alt="" loading="lazy" />,
+  },
+  render: (args) => (
+    <div className="w-90">
+      <CreatorTile {...args} className="rounded-lg" />
+    </div>
+  ),
+};
+
+/**
+ * Below roughly 308px of width a `banner` tile's profile row rises above the scrim's 40% start
+ * line, so its top edge sits on unscrimmed media. This is the shape the chat creator embed uses.
+ */
+export const NarrowBanner: Story = {
+  args: {
+    aspectRatio: "banner",
+    background: <img src={HIGH_DETAIL_BACKGROUND} alt="" loading="lazy" />,
+  },
+  render: (args) => (
+    <div className="w-[260px]">
+      <CreatorTile
+        {...args}
+        className="rounded-sm"
         action={
           <Button variant="white" size="32" className="rounded-full">
             View Profile

--- a/src/components/CreatorTile/CreatorTile.test.tsx
+++ b/src/components/CreatorTile/CreatorTile.test.tsx
@@ -36,6 +36,23 @@ describe("CreatorTile", () => {
       );
     });
 
+    it("ramps the scrim blur from 2px to 32px over the gradient", () => {
+      const { container } = render(<CreatorTile {...baseProps} />);
+      const blurLayers = container.querySelectorAll('[class*="backdrop-blur-"]');
+      expect(blurLayers).toHaveLength(5);
+      expect(blurLayers[0]).toHaveClass("backdrop-blur-[2px]");
+      expect(blurLayers[4]).toHaveClass("backdrop-blur-[32px]");
+      expect(container.querySelector('[class*="from-40%"]')).not.toBeNull();
+    });
+
+    it("keeps every blur layer non-interactive and radius-inheriting", () => {
+      const { container } = render(<CreatorTile {...baseProps} />);
+      for (const layer of container.querySelectorAll('[class*="backdrop-blur-"]')) {
+        expect(layer).toHaveClass("pointer-events-none");
+        expect(layer).toHaveClass("rounded-[inherit]");
+      }
+    });
+
     it("renders avatar fallback content", async () => {
       render(<CreatorTile {...baseProps} avatar={{ fallback: "AL" }} />);
       expect(await screen.findByText("AL")).toBeInTheDocument();

--- a/src/components/CreatorTile/CreatorTile.tsx
+++ b/src/components/CreatorTile/CreatorTile.tsx
@@ -12,6 +12,38 @@ const ASPECT_RATIO_CLASSES: Record<CreatorTileAspectRatio, string> = {
   banner: "aspect-5/2",
 };
 
+/**
+ * Progressive blur over the scrim, ramping 0 to 32px across the bottom 60% of the tile.
+ *
+ * `backdrop-filter` applies one uniform radius and `mask-image` then varies the alpha of the
+ * already-blurred result, so a single masked layer cross-fades a uniformly blurred copy rather
+ * than ramping the radius. Sibling layers do ramp it: an element with `backdrop-filter` is a
+ * backdrop root for its descendants, so nesting samples nothing, while each later sibling samples
+ * everything painted before it inside the root's `isolate`. Radii therefore compound, in
+ * quadrature, and the one-step overlap between adjacent masks keeps the effective radius
+ * continuous instead of banding.
+ *
+ * Complete literal strings rather than interpolated radii, because Tailwind scans raw file text.
+ * Arbitrary `[mask-image:…]` rather than the `mask-b-from-*` utilities, which need Tailwind 4.1
+ * while the peer range is `^4.0.0` — on 4.0.x they emit nothing and every layer would blur the
+ * whole tile at full radius.
+ */
+const SCRIM_BLUR_LAYER_CLASSES = [
+  "pointer-events-none absolute inset-0 rounded-[inherit] backdrop-blur-[2px] [-webkit-mask-image:linear-gradient(to_bottom,transparent_40%,black_50%,black_60%,transparent_70%)] [mask-image:linear-gradient(to_bottom,transparent_40%,black_50%,black_60%,transparent_70%)]",
+  "pointer-events-none absolute inset-0 rounded-[inherit] backdrop-blur-[4px] [-webkit-mask-image:linear-gradient(to_bottom,transparent_50%,black_60%,black_70%,transparent_80%)] [mask-image:linear-gradient(to_bottom,transparent_50%,black_60%,black_70%,transparent_80%)]",
+  "pointer-events-none absolute inset-0 rounded-[inherit] backdrop-blur-[8px] [-webkit-mask-image:linear-gradient(to_bottom,transparent_60%,black_70%,black_80%,transparent_90%)] [mask-image:linear-gradient(to_bottom,transparent_60%,black_70%,black_80%,transparent_90%)]",
+  "pointer-events-none absolute inset-0 rounded-[inherit] backdrop-blur-[16px] [-webkit-mask-image:linear-gradient(to_bottom,transparent_70%,black_80%,black_90%,transparent_100%)] [mask-image:linear-gradient(to_bottom,transparent_70%,black_80%,black_90%,transparent_100%)]",
+  "pointer-events-none absolute inset-0 rounded-[inherit] backdrop-blur-[32px] [-webkit-mask-image:linear-gradient(to_bottom,transparent_80%,black_90%)] [mask-image:linear-gradient(to_bottom,transparent_80%,black_90%)]",
+];
+
+/**
+ * Transparent to 88%-opaque `#151515`, starting at 40% of the height. The primitive carries the
+ * colour because the `blackalpha` ramp has no 88% step (800/900/950 only) and no gradient token
+ * matches; `theme.css` is generated from a Figma export, so the step cannot be added by hand.
+ */
+const SCRIM_GRADIENT_CLASS =
+  "pointer-events-none absolute inset-0 rounded-[inherit] bg-linear-to-b from-transparent from-40% to-[var(--primitives-color-gray-black)]/88";
+
 export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Decorative background media rendered behind the creator content. */
   background: React.ReactNode;
@@ -38,6 +70,10 @@ export interface CreatorTileProps extends React.HTMLAttributes<HTMLDivElement> {
    * width before the ratio makes the tile shorter than its own row and the top
    * of the row is clipped. The taller presets reach that floor at widths too
    * narrow to be practical.
+   *
+   * Separately, the scrim starts at 40% of the height, so below roughly 308px of
+   * width a `banner` tile's row rises above it and its top edge sits on unscrimmed
+   * media. `medium` reaches that at 185px, the other presets narrower still.
    *
    * @default "medium"
    */
@@ -80,8 +116,10 @@ export const CreatorTile = React.forwardRef<HTMLDivElement, CreatorTileProps>(
         <div className="pointer-events-none absolute inset-0 select-none *:h-full *:w-full [&>img]:object-cover [&>video]:object-cover">
           {background}
         </div>
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 rounded-b-[inherit] bg-linear-to-t from-black/60 to-transparent" />
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 overflow-hidden rounded-b-[inherit] backdrop-blur-md [-webkit-mask-image:linear-gradient(to_top,black,transparent)] [mask-image:linear-gradient(to_top,black,transparent)]" />
+        <div className={SCRIM_GRADIENT_CLASS} />
+        {SCRIM_BLUR_LAYER_CLASSES.map((layerClassName) => (
+          <div key={layerClassName} className={layerClassName} />
+        ))}
         <div className="relative flex items-center justify-between gap-4 p-4">
           <div className="flex min-w-0 items-center gap-2">
             <Avatar


### PR DESCRIPTION
Design QA on the in-chat creator callout asked for a progressive background blur over the tile's gradient, to add depth.

- Blur ramps 0 → 32px across the bottom 60%
- Gradient becomes `#151515` at 0% opacity from 40% of the height to 88% at the bottom

## Why five layers

`backdrop-filter` applies one uniform radius and `mask-image` then varies the alpha of the already-blurred result, so the single masked layer we had cross-faded a uniformly 12px-blurred copy over the sharp original — it faded contrast, not blur, and detail edges stayed visible to the bottom.

Sibling layers do ramp the radius: an element with `backdrop-filter` is a backdrop root for its *descendants*, so nesting samples nothing, while each later sibling samples everything already painted inside the root's `isolate`. Radii compound in quadrature, and the one-step overlap between adjacent trapezoid masks keeps the effective radius continuous rather than banded.

Verified in the browser that all of it compiles: 5 layers at `blur(2/4/8/16/32px)`, every mask present stepping 40% → 100%, gradient resolving to `#151515` at 88%, and `border-radius` inherited on each layer with the content row painting last and no ancestor filter.

## Notes for review

- Arbitrary `[mask-image:…]` rather than the `mask-b-from-*` utilities on purpose: those need Tailwind 4.1 and our peer range is `^4.0.0`, where they emit nothing and every layer would blur the whole tile at full radius.
- Layers are `inset-0` rather than `h-[60%]` so the mask percentages read directly against Figma's, and so each layer's edge-clamped `backdrop-filter` boundary sits where mask alpha is already 0.
- `rounded-[inherit]` not `rounded-b-[inherit]`, since the layers now have top corners on the tile boundary. Load-bearing on the blur layers: composited `backdrop-filter` descendants have a history of leaking square corners past an ancestor's `overflow-hidden` in WebKit.
- No `will-change` — 5 layers × 20 tiles in the Home carousel would trade a paint cost for a memory cliff.
- 88% is not on the `blackalpha` ramp (800/900/950 only) and no gradient token matches, so the primitive plus an alpha modifier carries it. A real token needs a Figma export; worth raising separately.
- Geometry improves rather than regresses: the scrim starting at 40% instead of 50% lowers the width at which the ~74px profile row rises above it for every preset (`banner` 370px → 308px). Documented in the `aspectRatio` JSDoc and shown by the new `NarrowBanner` story.
- **Heads-up for the two non-chat consumers:** `SuggestedCreatorsV2` and `SFWDiscoveryRecommendedCreators` both pass a `variant="primary"` Follow button, which is solid `#151515` — the same colour as the new scrim, at up to 88%. The pill keeps its white label but loses edge definition. The chat embed card is unaffected (`variant="white"`). Flagging for design rather than changing two surfaces that were not part of this QA pass.

Part of DES-815