### PR TITLE
fix(DropdownMenu): keep the Figma radius token out of consumers' Tailwind scan (ENG-13175)

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -499,15 +499,8 @@ export const DropdownMenuItem = React.forwardRef<
     const hasDescription = description != null;
     const hasAvatar = avatar != null;
     const itemClassName = cn(
-      // `rounded-sm` (12px), not the 8px the rows carried before: `V2 Menu Item` is
-      // `rounded-[var(--radius/rounded-sm,12px)]` (node `21542:8629`). Deliberately
-      // different from `DropdownMenuRadioItem` and `DropdownMenuCheckboxItem`, which
-      // `V2 Menu Radio Item` draws at `rounded-xs` (node `7393:62008`).
-      //
-      // `text-start` because the sheet variant renders the row as a <button>, and
-      // the UA centres a button's text — which centred the two-line title and
-      // description while the popper variant (a div) inherited the panel's start
-      // alignment. Both read from the same edge now.
+      // `text-start` because the sheet variant renders the row as a <button>,
+      // whose UA-centred text misaligned it from the popper variant's rows.
       "group flex w-full cursor-pointer gap-2 rounded-sm px-3 text-start outline-none",
       hasDescription ? "items-start" : "items-center",
       // The sheet's header runs the full width of the panel, so its rows have to


### PR DESCRIPTION
Closes ENG-13175. The V2 Menu Item comment quoted its Figma radius token as the class-shaped string `rounded-[var(--radius/rounded-sm,12px)]`. Pandora's eden scans `@fanvue/ui/dist` with Tailwind v4 via `@source`, and Tailwind lifts class-like text out of comments — so the string was emitted as a real utility whose `var()` name contains a slash, and Lightning CSS failed the entire CSS parse. Every pandora dev build on `@fanvue/ui` 3.24.0 is currently broken:

```
./eden/src/styles/fanvue-ui.css
Parsing CSS source code failed: Unexpected token Delim('/')
```

Removed the Figma-node narration entirely (it didn't earn its length) and kept only a compact note on why `text-start` is set. Takeaway for future comments in this package: never quote Figma tokens as class-shaped strings — consumers' Tailwind scans this dist, comments included. Needs a 3.24.1 release + pandora bump once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)