### PR TITLE
fix(DropdownMenu): keep the Figma radius token out of consumers' Tailwind scan (ENG-13175)

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
       "minimatch": ">=10.2.3",
       "ajv": ">=8.18.0",
       "fast-uri": ">=3.1.4",
-      "brace-expansion": ">=5.0.8",
+      "brace-expansion": ">=5.0.9",
       "yaml": ">=2.8.3",
       "postcss": ">=8.5.18",
       "tmp": ">=0.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   minimatch: '>=10.2.3'
   ajv: '>=8.18.0'
   fast-uri: '>=3.1.4'
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   yaml: '>=2.8.3'
   postcss: '>=8.5.18'
   tmp: '>=0.2.7'
@@ -2215,8 +2215,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -6364,7 +6364,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.3
 
@@ -7627,7 +7627,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -499,15 +499,8 @@ export const DropdownMenuItem = React.forwardRef<
     const hasDescription = description != null;
     const hasAvatar = avatar != null;
     const itemClassName = cn(
-      // `rounded-sm` (12px), not the 8px the rows carried before: `V2 Menu Item` is
-      // `rounded-[var(--radius/rounded-sm,12px)]` (node `21542:8629`). Deliberately
-      // different from `DropdownMenuRadioItem` and `DropdownMenuCheckboxItem`, which
-      // `V2 Menu Radio Item` draws at `rounded-xs` (node `7393:62008`).
-      //
-      // `text-start` because the sheet variant renders the row as a <button>, and
-      // the UA centres a button's text — which centred the two-line title and
-      // description while the popper variant (a div) inherited the panel's start
-      // alignment. Both read from the same edge now.
+      // `text-start` because the sheet variant renders the row as a <button>,
+      // whose UA-centred text misaligned it from the popper variant's rows.
       "group flex w-full cursor-pointer gap-2 rounded-sm px-3 text-start outline-none",
       hasDescription ? "items-start" : "items-center",
       // The sheet's header runs the full width of the panel, so its rows have to


### PR DESCRIPTION
Closes ENG-13175. The V2 Menu Item comment quoted its Figma radius token as the class-shaped string `rounded-[var(--radius/rounded-sm,12px)]`. Pandora's eden scans `@fanvue/ui/dist` with Tailwind v4 via `@source`, and Tailwind lifts class-like text out of comments — so the string was emitted as a real utility whose `var()` name contains a slash, and Lightning CSS failed the entire CSS parse. Every pandora dev build on `@fanvue/ui` 3.24.0 is currently broken:

```
./eden/src/styles/fanvue-ui.css
Parsing CSS source code failed: Unexpected token Delim('/')
```

Removed the Figma-node narration entirely (it didn't earn its length) and kept only a compact note on why `text-start` is set. Takeaway for future comments in this package: never quote Figma tokens as class-shaped strings — consumers' Tailwind scans this dist, comments included. Needs a 3.24.1 release + pandora bump once merged.

## Also: green the Security Audit check

Second commit fixes the failing `Security Audit` job, which is red on `main` too and not caused by the comment change. `pnpm audit --audit-level=high` flagged GHSA-rgw5-rvv9-x895 (high, DoS via unbounded intermediate arrays in `brace-expansion`, bypassing the CVE-2026-14257 mitigation).

The advisory's vulnerable range is `>=4.0.0 <5.0.9`, and our existing override floor was `>=5.0.9`'s predecessor `>=5.0.8` — inside the range — so the lockfile resolved `brace-expansion@5.0.8`, the last affected version. Bumped the override to `>=5.0.9` and regenerated the lockfile. It reaches us only transitively, through `minimatch@10.2.4` under `@storybook/react-vite`, `style-dictionary`, and `vite-plugin-dts` (4 paths, all dev).

Verified locally on pnpm 9.15.4 (matching CI's `packageManager` pin):

- `pnpm audit --audit-level=high` exits 0; the one remaining finding is moderate, below the job's threshold and pre-existing.
- `pnpm install --frozen-lockfile` produces no further lockfile drift.
- Lockfile diff is 5 lines, `lockfileVersion` unchanged at `9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
