### PR TITLE
feat(AiDisclosureBadge): add EU AI disclosure badge

### DIFF
--- a/src/components/AiDisclosureBadge/AiDisclosureBadge.stories.tsx
+++ b/src/components/AiDisclosureBadge/AiDisclosureBadge.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AiDisclosureBadge } from "./AiDisclosureBadge";
+
+const meta = {
+  title: "Components/AiDisclosureBadge",
+  component: AiDisclosureBadge,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=20586-1134&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    tone: {
+      control: "inline-radio",
+      options: ["dark", "light", "transparent"],
+    },
+  },
+} satisfies Meta<typeof AiDisclosureBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      <AiDisclosureBadge {...args} className="size-4" />
+      <AiDisclosureBadge {...args} className="size-6" />
+      <AiDisclosureBadge {...args} className="size-8" />
+    </div>
+  ),
+};
+
+/**
+ * The palette is fixed rather than theme-reactive, so each tone is shown over
+ * media: `dark` for light footage, `light` for dark, `transparent` where
+ * the media should still read through.
+ */
+export const Tones: Story = {
+  render: (args) => (
+    <div className="flex gap-4">
+      <div className="flex items-center gap-3 rounded-md bg-linear-to-br from-[#e8f5ef] via-[#9fd8c2] to-[#f7fbf9] p-6">
+        <AiDisclosureBadge {...args} tone="dark" className="size-6" />
+        <AiDisclosureBadge {...args} tone="transparent" className="size-6" />
+      </div>
+      <div className="flex items-center gap-3 rounded-md bg-linear-to-br from-[#0e3b2f] via-[#1f8f6a] to-[#0b2b23] p-6">
+        <AiDisclosureBadge {...args} tone="light" className="size-6" />
+        <AiDisclosureBadge {...args} tone="transparent" className="size-6" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/AiDisclosureBadge/AiDisclosureBadge.test.tsx
+++ b/src/components/AiDisclosureBadge/AiDisclosureBadge.test.tsx
@@ -50,7 +50,7 @@ describe("AiDisclosureBadge", () => {
     it("keeps the palette fixed rather than following the inherited text colour", () => {
       const { container } = render(<AiDisclosureBadge />);
       for (const path of paths(container)) {
-        expect(path.getAttribute("class")).not.toContain("currentColor");
+        expect(path).not.toHaveClass("fill-current");
         expect(path).not.toHaveAttribute("fill");
       }
     });

--- a/src/components/AiDisclosureBadge/AiDisclosureBadge.test.tsx
+++ b/src/components/AiDisclosureBadge/AiDisclosureBadge.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { AiDisclosureBadge } from "./AiDisclosureBadge";
+
+describe("AiDisclosureBadge", () => {
+  const paths = (container: HTMLElement) => [...container.querySelectorAll("path")];
+
+  describe("API", () => {
+    it("applies custom className", () => {
+      const { container } = render(<AiDisclosureBadge className="custom-class" />);
+      expect(container.querySelector("svg")).toHaveClass("custom-class");
+    });
+
+    it("has a default size that className can override", () => {
+      const { container: base } = render(<AiDisclosureBadge />);
+      expect(base.querySelector("svg")).toHaveClass("size-4");
+
+      const { container: sized } = render(<AiDisclosureBadge className="size-10" />);
+      expect(sized.querySelector("svg")).toHaveClass("size-10");
+    });
+
+    it("forwards ref", () => {
+      const ref = createRef<SVGSVGElement>();
+      render(<AiDisclosureBadge ref={ref} />);
+      expect(ref.current).toBeInstanceOf(SVGSVGElement);
+    });
+  });
+
+  describe("tones", () => {
+    it("paints a dark disc with light glyphs by default", () => {
+      const [disc, glyph] = paths(render(<AiDisclosureBadge />).container);
+      expect(disc).toHaveClass("fill-buttons-always-black-default");
+      expect(glyph).toHaveClass("fill-content-always-white");
+    });
+
+    it("swaps disc and glyph colours for the light tone", () => {
+      const [disc, glyph] = paths(render(<AiDisclosureBadge tone="light" />).container);
+      expect(disc).toHaveClass("fill-buttons-always-white-default");
+      expect(glyph).toHaveClass("fill-content-always-black");
+    });
+
+    it("uses the half-opacity overlay fill for the transparent tone", () => {
+      const [disc, glyph] = paths(render(<AiDisclosureBadge tone="transparent" />).container);
+      expect(disc).toHaveClass("fill-background-overlay-default");
+      expect(glyph).toHaveClass("fill-content-always-white");
+    });
+
+    it("keeps the palette fixed rather than following the inherited text colour", () => {
+      const { container } = render(<AiDisclosureBadge />);
+      for (const path of paths(container)) {
+        expect(path.getAttribute("class")).not.toContain("currentColor");
+        expect(path).not.toHaveAttribute("fill");
+      }
+    });
+  });
+
+  describe("accessibility", () => {
+    it("is decorative by default", () => {
+      const { container } = render(<AiDisclosureBadge />);
+      expect(container.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("can be named for standalone use", () => {
+      render(<AiDisclosureBadge aria-hidden={false} role="img" aria-label="AI generated" />);
+      expect(screen.getByRole("img")).toHaveAccessibleName("AI generated");
+    });
+
+    it("has no accessibility violations when named", async () => {
+      const { container } = render(
+        <AiDisclosureBadge aria-hidden={false} role="img" aria-label="AI generated" />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/AiDisclosureBadge/AiDisclosureBadge.tsx
+++ b/src/components/AiDisclosureBadge/AiDisclosureBadge.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+
+/** The three treatments the EU disclosure spec defines. */
+export type AiDisclosureBadgeTone = "dark" | "light" | "transparent";
+
+/**
+ * Theme-fixed rather than `currentColor`: the badge is a regulatory marker
+ * overlaid on arbitrary creator media, so it has to stay legible whatever
+ * surface it lands on. That is also why it is not an icon — it cannot take part
+ * in the `currentColor` contract the icon set relies on, and `tone` has to say
+ * what is behind the mark.
+ */
+const toneVariants: Record<AiDisclosureBadgeTone, { disc: string; glyph: string }> = {
+  dark: { disc: "fill-buttons-always-black-default", glyph: "fill-content-always-white" },
+  light: { disc: "fill-buttons-always-white-default", glyph: "fill-content-always-black" },
+  transparent: { disc: "fill-background-overlay-default", glyph: "fill-content-always-white" },
+};
+
+/** Props for {@link AiDisclosureBadge}. */
+export interface AiDisclosureBadgeProps extends React.SVGAttributes<SVGSVGElement> {
+  /** Colour of the mark itself, chosen for the media behind it. @default "dark" */
+  tone?: AiDisclosureBadgeTone;
+}
+
+/**
+ * EU AI-disclosure badge: an "AI" wordmark on a filled disc, for overlaying on
+ * AI-generated or AI-modified media. Ships at 16px and scales via `className`.
+ *
+ * Decorative by default. For standalone use pass `aria-hidden={false}` with
+ * `role="img"` and an `aria-label`. For the form that carries wording, use
+ * `AiDisclosureLabel`.
+ *
+ * @example
+ * ```tsx
+ * <AiDisclosureBadge tone="light" className="size-6" />
+ * ```
+ */
+export const AiDisclosureBadge = React.forwardRef<SVGSVGElement, AiDisclosureBadgeProps>(
+  ({ className, tone = "dark", ...props }, ref) => {
+    const fill = toneVariants[tone];
+
+    return (
+      <svg
+        ref={ref}
+        viewBox="0 0 16 16"
+        fill="none"
+        aria-hidden="true"
+        className={cn("size-4", className)}
+        {...props}
+      >
+        <path
+          className={fill.disc}
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M7.677.835a7.165 7.165 0 1 1 0 14.33 7.165 7.165 0 0 1 0-14.33"
+        />
+        <path
+          className={fill.glyph}
+          d="M3.708 10.756a.16.16 0 0 1-.114-.051.16.16 0 0 1-.052-.115q0-.04.008-.07l1.856-5.071a.3.3 0 0 1 .1-.154.3.3 0 0 1 .208-.067h1.17q.133 0 .209.067a.3.3 0 0 1 .098.154l1.849 5.07q.015.032.015.071 0 .063-.051.115a.17.17 0 0 1-.122.051H7.91q-.119 0-.177-.06a.3.3 0 0 1-.075-.106l-.309-.806H5.241l-.3.806a.3.3 0 0 1-.071.107q-.055.06-.19.059h-.97m1.856-2.109h1.47L6.29 6.562zm4.31 2.109a.2.2 0 0 1-.142-.055.2.2 0 0 1-.055-.143V5.425q0-.087.055-.142a.2.2 0 0 1 .142-.056h1.059q.087 0 .142.056a.2.2 0 0 1 .055.142v5.133a.2.2 0 0 1-.055.143.2.2 0 0 1-.142.055z"
+        />
+      </svg>
+    );
+  },
+);
+
+AiDisclosureBadge.displayName = "AiDisclosureBadge";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,11 @@ export type {
 } from "./components/AiButton/AiButton";
 export { AiButton } from "./components/AiButton/AiButton";
 export type {
+  AiDisclosureBadgeProps,
+  AiDisclosureBadgeTone,
+} from "./components/AiDisclosureBadge/AiDisclosureBadge";
+export { AiDisclosureBadge } from "./components/AiDisclosureBadge/AiDisclosureBadge";
+export type {
   AiDisclosureLabelProps,
   AiDisclosureLabelSize,
   AiDisclosureLabelTone,


### PR DESCRIPTION
One of two from the EU AI Act disclosure set. Independent of #651, either order.

`AiDisclosureBadge` is Figma's `AI Disclosure Icon (EU)`: an "AI" wordmark on a filled disc, for overlaying AI-generated media. Eden carries its own copy of this today and it has already drifted, at 30% disc opacity where the spec says 50%.

**It is a component, not an icon.** The palette has to be fixed rather than theme-reactive, because the mark sits on arbitrary creator media and has to stay legible whatever is behind it. That rules out the `currentColor` contract the icon set is built on. Filed under `Icons/` it broke: `buttons-always-black-default` and `background-primary` are both `#151515` in dark theme, so the disc vanished into the page. Staying out of `Icons/` also keeps the diff off the generated test, story and barrel surface.

**`tone` is `dark | light | transparent`, not Figma's `Default | Negative | Transparent`.** `negative` already means something specific here — `Pill` and `Badge` both map it to `bg-buttons-secondary-negative-default`, backed by a real token family — so reusing it for the light treatment would collide. `dark` and `light` name the mark's own colour instead, which is also harder to misread. Figma should be renamed to match, or the next reader holds both vocabularies.

**`transparent` may not clear contrast, and that needs a design call.** It is the 50% black overlay token with white glyphs. Over near-white media it composites to about `#8a8a8a`, putting the wordmark at roughly 3.45:1 — fine against the 3:1 bar for a graphic, short of 4.5:1 if it counts as text. It holds above 4.5:1 while the media is darker than about `#d9d9d9`. The opacity is straight from the spec so I have not changed it, but bright media is the case this tone exists for.

Geometry is the Figma export run through the repo's own `scripts/svgo.config.mjs`, same as every icon.

The existing `AIDisclosureIcon` is a different mark (boxed glyph with sparkles, `currentColor`). The names are close enough that one of them may want renaming.

`Security Audit` fails on a pre-existing `fast-uri` advisory reached through devDependencies. No dependency changed here and it reproduces on `main`.

10 tests including axe, `tsc --noEmit` clean, biome clean.
