### PR TITLE
feat(AiDisclosureLabel): add EU AI generated/modified disclosure label

### DIFF
--- a/src/components/AiDisclosureLabel/AiDisclosureLabel.stories.tsx
+++ b/src/components/AiDisclosureLabel/AiDisclosureLabel.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AiDisclosureLabel } from "./AiDisclosureLabel";
+
+const meta = {
+  title: "Components/AiDisclosureLabel",
+  component: AiDisclosureLabel,
+  parameters: {
+    layout: "centered",
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/S8zFdcOjt4qN4PrwntuCdt/Fanvue-Library?node-id=20586-1134&m=dev",
+    },
+  },
+  tags: ["autodocs"],
+  args: { label: "Generated" },
+  argTypes: {
+    size: { control: "inline-radio", options: ["12", "16", "20"] },
+    tone: {
+      control: "inline-radio",
+      options: ["dark", "light", "transparent"],
+    },
+  },
+} satisfies Meta<typeof AiDisclosureLabel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Generated: Story = {};
+
+export const Modified: Story = {
+  args: { label: "Modified" },
+};
+
+export const Sizes: Story = {
+  args: { label: "Modified" },
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      <AiDisclosureLabel {...args} size="12" />
+      <AiDisclosureLabel {...args} size="16" />
+      <AiDisclosureLabel {...args} size="20" />
+    </div>
+  ),
+};
+
+/** Every tone is fixed rather than theme-reactive, so each is shown over media. */
+export const Tones: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-4 rounded-md bg-linear-to-br from-[#0e3b2f] via-[#1f8f6a] to-[#35d0a5] p-6">
+      <AiDisclosureLabel {...args} tone="dark" />
+      <AiDisclosureLabel {...args} tone="light" />
+      <AiDisclosureLabel {...args} tone="transparent" />
+    </div>
+  ),
+};
+
+/** The wording is live text, so a translated string flows through unchanged. */
+export const Translated: Story = {
+  args: { label: "Modifié" },
+};

--- a/src/components/AiDisclosureLabel/AiDisclosureLabel.test.tsx
+++ b/src/components/AiDisclosureLabel/AiDisclosureLabel.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
+import { AiDisclosureLabel } from "./AiDisclosureLabel";
+
+describe("AiDisclosureLabel", () => {
+  describe("API", () => {
+    it("applies custom className", () => {
+      render(<AiDisclosureLabel label="Modified" className="custom-class" />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass("custom-class");
+    });
+
+    it("forwards ref", () => {
+      const ref = createRef<HTMLSpanElement>();
+      render(<AiDisclosureLabel label="Modified" ref={ref} />);
+      expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+    });
+  });
+
+  describe("wording", () => {
+    it("renders the caller's wording after the AI mark", () => {
+      render(<AiDisclosureLabel label="Modifié" />);
+      expect(screen.getByText("AI")).toBeInTheDocument();
+      expect(screen.getByText("Modifié")).toBeInTheDocument();
+    });
+
+    it("uppercases the wording in CSS so callers pass sentence case", () => {
+      render(<AiDisclosureLabel label="Modifié" />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass("uppercase");
+    });
+
+    it("tracks each run against its own font size rather than the inherited one", () => {
+      render(<AiDisclosureLabel label="Modified" />);
+      expect(screen.getByText("AI")).toHaveClass("tracking-[0.1em]");
+      expect(screen.getByText("Modified")).toHaveClass("tracking-[0.1em]");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("announces the mark and wording as a separated phrase", () => {
+      render(<AiDisclosureLabel label="Generated" />);
+      expect(screen.getByRole("img")).toHaveAccessibleName("AI Generated");
+    });
+
+    it("carries the translation into the accessible name", () => {
+      render(<AiDisclosureLabel label="Modifié" />);
+      expect(screen.getByRole("img")).toHaveAccessibleName("AI Modifié");
+    });
+
+    it("lets a caller override the accessible name", () => {
+      render(<AiDisclosureLabel label="Modifié" aria-label="Retouché par IA" />);
+      expect(screen.getByRole("img")).toHaveAccessibleName("Retouché par IA");
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = render(<AiDisclosureLabel label="Generated" />);
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe("tones", () => {
+    it("paints a dark pill with light text by default", () => {
+      render(<AiDisclosureLabel label="Modified" />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass(
+        "bg-buttons-always-black-default",
+        "text-content-always-white",
+      );
+    });
+
+    it("inverts pill and text for the light tone", () => {
+      render(<AiDisclosureLabel label="Modified" tone="light" />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass(
+        "bg-buttons-always-white-default",
+        "text-content-always-black",
+      );
+    });
+
+    it("uses the half-opacity overlay fill for the transparent tone", () => {
+      render(<AiDisclosureLabel label="Modified" tone="transparent" />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass(
+        "bg-background-overlay-default",
+        "text-content-always-white",
+      );
+    });
+  });
+
+  describe("sizes", () => {
+    it("defaults to the 20px height", () => {
+      render(<AiDisclosureLabel label="Modified" />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass("h-5");
+    });
+
+    it.each([
+      ["12", "h-3", "text-[8px]", "text-[6px]"],
+      ["16", "h-4", "text-[11px]", "text-[8px]"],
+      ["20", "h-5", "text-[13px]", "text-[10px]"],
+    ] as const)("scales pill, mark and wording together at %s", (size, height, mark, wording) => {
+      render(<AiDisclosureLabel label="Modified" size={size} />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass(height);
+      expect(screen.getByText("AI")).toHaveClass(mark);
+      expect(screen.getByText("Modified")).toHaveClass(wording);
+    });
+
+    it("combines a non-default size with a non-default tone", () => {
+      render(<AiDisclosureLabel label="Generated" size="12" tone="transparent" />);
+      expect(screen.getByTestId("ai-disclosure-label")).toHaveClass(
+        "h-3",
+        "bg-background-overlay-default",
+      );
+      expect(screen.getByText("Generated")).toHaveClass("text-[6px]");
+    });
+  });
+});

--- a/src/components/AiDisclosureLabel/AiDisclosureLabel.tsx
+++ b/src/components/AiDisclosureLabel/AiDisclosureLabel.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+import { cn } from "../../utils/cn";
+/** The three treatments the EU disclosure spec defines. */
+export type AiDisclosureLabelTone = "dark" | "light" | "transparent";
+
+/** Overall pill height in px. */
+export type AiDisclosureLabelSize = "12" | "16" | "20";
+
+const toneVariants: Record<AiDisclosureLabelTone, string> = {
+  dark: "bg-buttons-always-black-default text-content-always-white",
+  light: "bg-buttons-always-white-default text-content-always-black",
+  transparent: "bg-background-overlay-default text-content-always-white",
+};
+
+/** Padding and gap are proportional to the pill height, taken from the Figma mark. */
+const sizeVariants: Record<AiDisclosureLabelSize, string> = {
+  "12": "h-3 gap-1 px-[5px]",
+  "16": "h-4 gap-1.5 px-[7px]",
+  "20": "h-5 gap-[7px] px-[9px]",
+};
+
+/**
+ * Tracking has to sit on each run rather than the pill: as an `em` it resolves
+ * against the element's own font size, so putting it on the pill would freeze it
+ * at one absolute value for every size and anchor it to whatever font size the
+ * host happens to inherit.
+ */
+const TRACKING = "tracking-[0.1em]";
+
+/**
+ * The "AI" run sits at roughly two thirds of the pill height and the wording at
+ * just over half. Both land below the 12px floor of the typography scale, so
+ * they are spelled out in px, over a base utility that supplies the family.
+ */
+const markSizeVariants: Record<AiDisclosureLabelSize, string> = {
+  "12": "text-[8px]",
+  "16": "text-[11px]",
+  "20": "text-[13px]",
+};
+
+const labelSizeVariants: Record<AiDisclosureLabelSize, string> = {
+  "12": "text-[6px]",
+  "16": "text-[8px]",
+  "20": "text-[10px]",
+};
+
+/** Props for {@link AiDisclosureLabel}. */
+export interface AiDisclosureLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Wording after the "AI" mark, e.g. a translated "Generated" or "Modified". */
+  label: string;
+  /** @default "20" */
+  size?: AiDisclosureLabelSize;
+  /** Colour of the mark itself, chosen for the media behind it. @default "dark" */
+  tone?: AiDisclosureLabelTone;
+}
+
+/**
+ * EU AI-disclosure label: an "AI" mark followed by wording, on a filled pill,
+ * for marking AI-generated or AI-modified media.
+ *
+ * The wording is live text rather than baked artwork, so it translates and
+ * scales with the reader's font settings. It is uppercased in CSS, which keeps
+ * the mark consistent without forcing callers to pass shouting strings.
+ *
+ * For the compact disc form with no wording, use `AiDisclosureBadge`.
+ *
+ * @example
+ * ```tsx
+ * <AiDisclosureLabel label={t("ai.modified")} tone="transparent" />
+ * ```
+ */
+export const AiDisclosureLabel = React.forwardRef<HTMLSpanElement, AiDisclosureLabelProps>(
+  ({ className, label, size = "20", tone = "dark", ...props }, ref) => (
+    <span
+      ref={ref}
+      data-testid="ai-disclosure-label"
+      // "AI" and the wording are separate elements with only a flex gap
+      // between them, so without a name of its own the pill is announced as
+      // the single token "AIGenerated".
+      role="img"
+      aria-label={`AI ${label}`}
+      className={cn(
+        "inline-flex select-none items-center justify-center whitespace-nowrap rounded-full",
+        // Carries `font-family: Inter` and weight 600; the per-run `text-[Npx]`
+        // below overrides its size, as `Count` does for its sub-12px steps.
+        "typography-description-12px-semibold uppercase leading-none",
+        sizeVariants[size],
+        toneVariants[tone],
+        className,
+      )}
+      {...props}
+    >
+      <span className={cn(TRACKING, markSizeVariants[size])}>AI</span>
+      <span className={cn(TRACKING, labelSizeVariants[size])}>{label}</span>
+    </span>
+  ),
+);
+
+AiDisclosureLabel.displayName = "AiDisclosureLabel";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ export type {
   AiButtonSize,
 } from "./components/AiButton/AiButton";
 export { AiButton } from "./components/AiButton/AiButton";
+export type {
+  AiDisclosureLabelProps,
+  AiDisclosureLabelSize,
+  AiDisclosureLabelTone,
+} from "./components/AiDisclosureLabel/AiDisclosureLabel";
+export { AiDisclosureLabel } from "./components/AiDisclosureLabel/AiDisclosureLabel";
 export type { AlertProps, AlertVariant } from "./components/Alert/Alert";
 export { Alert } from "./components/Alert/Alert";
 export type {


### PR DESCRIPTION
The other half of the EU AI Act disclosure set. Independent of #650, either order.

`AiDisclosureLabel` is Figma's `AI Modified Label (EU)`: an "AI" mark followed by wording, on a filled pill.

**The wording ships as live text, not Figma's outlines.** Figma draws it as vector paths and enumerates the two English wordings as variants. Outlines would be pixel-exact and permanently English: no translation, no scaling with the reader's font settings, nothing for a screen reader. So `label` is a required string the caller passes already translated, uppercased in CSS so callers pass sentence case rather than shouting. The cost is that it is not pixel-identical to the frame. There is deliberately no `kind` prop supplying English defaults, since a design system shipping those is how untranslated strings reach production.

**`tone` is `dark | light | transparent`, not Figma's `Default | Negative | Transparent`** — same reason as #650: `negative` already maps to `bg-buttons-secondary-negative-default` in `Pill` and `Badge`. Figma should be renamed to match.

**Two typography details are load-bearing.** The pill layers `typography-description-12px-semibold` under per-run `text-[Npx]` sizes, because those utilities are the only place this library sets `font-family: Inter` and without it the mark fell back to a system font. `Count` layers the same way for its sub-12px steps. Letter-spacing sits on each text run as an `em` rather than on the pill, so it scales with `size`; on the pill it would resolve once against the inherited font size and freeze at one absolute value for all three.

**`role="img"` with a composed accessible name.** "AI" and the wording are separate elements with only a flex gap between them, so without a name of its own the mark announces as the single token "AIGenerated".

Three for design, all implemented as drawn rather than quietly diverged: `transparent` puts white text at about 3.45:1 over near-white media, under the 4.5:1 text bar (it clears it while media is darker than roughly `#d9d9d9`, and the 50% opacity is from the spec); at `size="12"` the wording renders at 6px, which does not clip but is a legibility question; and both runs are weight 600, though the Figma render reads as though the "AI" is heavier — not recoverable from outlined vectors, so say the word and I will split it.

`Badge` already has an `aiGenerated` variant whose classes are exactly this component's `light` tone. Worth deciding whether a spec-driven disclosure mark and general AI tagging converge or stay separate.

`Security Audit` fails on a pre-existing `fast-uri` advisory reached through devDependencies. No dependency changed here and it reproduces on `main`.

22 tests including axe, `tsc --noEmit` clean, biome clean.
