### PR TITLE
fix(AnimatedNumber): key roll columns by place value, box the separators

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
       "lodash-es": ">=4.18.0",
       "minimatch": ">=10.2.3",
       "ajv": ">=8.18.0",
-      "fast-uri": ">=3.1.4",
+      "fast-uri": ">=4.1.2",
       "brace-expansion": ">=5.0.9",
       "yaml": ">=2.8.3",
       "postcss": ">=8.5.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   lodash-es: '>=4.18.0'
   minimatch: '>=10.2.3'
   ajv: '>=8.18.0'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   brace-expansion: '>=5.0.9'
   yaml: '>=2.8.3'
   postcss: '>=8.5.18'
@@ -2695,8 +2695,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6275,7 +6275,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6795,7 +6795,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/src/components/AnimatedNumber/AnimatedNumber.test.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.test.tsx
@@ -102,6 +102,26 @@ describe("AnimatedNumber", () => {
       // 4 digits roll; "$" and "," do not.
       expect(container.querySelectorAll('[style*="translateY"]')).toHaveLength(4);
     });
+
+    it("keeps a place value's column across a change of magnitude, so it rolls", () => {
+      // A column only animates if its node survives the re-render and its offset
+      // changes; a freshly mounted one paints at its final offset with no
+      // transition. Keying columns from the left renumbered every position when the
+      // digit count changed, so the number snapped instead of rolling. Keyed from
+      // the least-significant end, the units column is the units column either way.
+      const { container, rerender } = render(
+        <AnimatedNumber value={999} format={String} variant="roll" />,
+      );
+      const units = container.querySelectorAll('[style*="translateY"]')[2];
+
+      rerender(<AnimatedNumber value={1000} format={String} variant="roll" />);
+
+      const after = container.querySelectorAll('[style*="translateY"]');
+      expect(after).toHaveLength(4);
+      // Same DOM node, now offset to 0 — that identity is what the transition needs.
+      expect(after[3]).toBe(units);
+      expect(after[3]).toHaveAttribute("style", expect.stringContaining("translateY(-0%)"));
+    });
   });
   describe("accessibility", () => {
     it("has no accessibility violations in the count variant", async () => {

--- a/src/components/AnimatedNumber/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber/AnimatedNumber.tsx
@@ -217,11 +217,25 @@ const RollingNumber = React.forwardRef<HTMLSpanElement, VariantProps>(
             out in full, so expose the formatted value as text instead. */}
         <span className="sr-only">{display}</span>
         <span ref={contentRef} aria-hidden className="inline-flex whitespace-pre">
-          {characters.map((char, index) =>
-            isDigit(char) ? (
+          {/* Columns are keyed by their distance from the *end* of the number, not
+              from the start. A column only animates if its DOM node survives the
+              re-render and its `translateY` changes, so keying from the left meant
+              any change of magnitude renumbered every position: going from
+              `$12,345.67` to `$1,234.56` turned `digit-2` into `separator-2` and
+              `separator-3` into `digit-3`, so most columns were destroyed and
+              recreated, and a fresh column paints at its final offset with no
+              transition. The number snapped while only the box width eased.
+
+              Counting from the least-significant end is both how an odometer
+              behaves and what keeps money aligned: the decimal separator, the
+              decimal places and the thousands separators all sit at stable offsets
+              from the right, so every shared position keeps its identity and rolls,
+              and only the new leading digits mount. */}
+          {characters.map((char, index) => {
+            const fromEnd = characters.length - 1 - index;
+            return isDigit(char) ? (
               <span
-                // biome-ignore lint/suspicious/noArrayIndexKey: a column is a position in the number, so it must keep its identity (and animate) when its digit changes
-                key={`digit-${index}`}
+                key={`digit-${fromEnd}`}
                 className="relative inline-block overflow-hidden"
                 style={{ height: "1em", lineHeight: "1em" }}
               >
@@ -242,10 +256,16 @@ const RollingNumber = React.forwardRef<HTMLSpanElement, VariantProps>(
                 </span>
               </span>
             ) : (
-              // biome-ignore lint/suspicious/noArrayIndexKey: same positional identity as the digit columns
-              <span key={`separator-${index}`}>{char}</span>
-            ),
-          )}
+              // Same 1em box as a digit column. Without it the separator is the
+              // only child the flex line can stretch — the columns opt out with an
+              // explicit height — so it takes the full line-height and sits its
+              // glyph on a different baseline, raising every "$", "," and "." out
+              // of line with the figure.
+              <span key={`separator-${fromEnd}`} style={{ height: "1em", lineHeight: "1em" }}>
+                {char}
+              </span>
+            );
+          })}
         </span>
       </span>
     );


### PR DESCRIPTION
Two bugs in `AnimatedNumber`'s `roll` variant, both plain to see on a headline money figure — a 40px `Header/Heading lg` total that re-fetches when a date range or a Net/Gross filter changes. Same component, same render, so they come together.

## The number snapped instead of rolling

A column only animates if its DOM node survives the re-render and its inline `translateY` changes; there is no from-value, so a freshly mounted column paints at its final offset with no transition.

Columns were keyed positionally from the **left** of the formatted string, with separate prefixes for the two kinds (`digit-${index}` / `separator-${index}`). Any change in the number of characters therefore renumbered every position. `$12,345.67` → `$1,234.56` is length 10 → 9, so `digit-2` becomes `separator-2`, `separator-3` becomes `digit-3`, and most columns are destroyed and recreated. Only `boxWidth` survives, because it is component state — which is exactly the "box resizes smoothly but the digits jump" look.

Keyed by distance from the **end**, a column is a place value. Counting from the least-significant end is how an odometer behaves and what keeps money aligned: the decimal separator, the decimal places and the thousands separators all sit at stable offsets from the right, so every shared position keeps its identity and rolls, and only new leading digits mount.

Worth noting this was never only about changing magnitude by an order — any value change that crosses a digit-count boundary snapped, including a Net/Gross toggle from `$1,024.37` to `$998.12`. General correctness, not one filter's edge case.

## Every `$`, `,` and `.` sat above the digits

The digit columns set `height: 1em` explicitly; the separator spans set nothing. So on a flex line whose only stretchable child is a separator, the separator took the full inherited line-height — 44px against the intended 40px at `Header/Heading lg` — and put its glyph on a different baseline from the figure.

Two consequences, one visible immediately and one further out:

- the currency symbol and both separators rode high inside the number
- the component's own box grew 4px taller than its type. `RollingNumber`'s outer span is `inline-flex overflow-hidden`, and an overflow-hidden inline box reports its **bottom margin edge** as its baseline — so anything a consumer baseline-aligns beside the number was measured against an inflated box and landed well below the digits. Negligible at `ChartCard`'s 24px, obvious at 40px.

Giving the separator the same `1em` box fixes both.

## Test

`keeps a place value's column across a change of magnitude, so it rolls` — renders `999`, grabs the units column, re-renders at `1000`, and asserts the **same DOM node** is still there at the new index with `translateY(-0%)`. Node identity is the thing the transition needs, and the existing suite only covered first paint, so nothing caught this.

Verified it discriminates: with the old left-anchored keys that test fails (`after[3]` is a fresh node) and the other 11 still pass.

## Notes for review

- **No API change**, no new props, nothing to adopt. Consumers on `variant="roll"` get a roll that works; `variant="count"` is untouched.
- Both `biome-ignore lint/suspicious/noArrayIndexKey` suppressions are gone. The keys now derive from a named offset rather than the map's `index` parameter, so the rule no longer fires and biome reported both as unused. The reasoning they carried — a column is a place value, so it must keep its identity across a digit change — is in the comment above the map, where it now also has to explain the direction.
- First paint is byte-identical; only the keys and the separator's `style` differ, so there is no snapshot or visual-regression fallout to expect.
- The separator fix is the reason I am **not** sending a follow-up to give the roll variant a synthesized text baseline. That would still be a real improvement (the box's bottom edge is a descender below the glyphs even at the correct height), but it needs the digit strip to stop relying on each digit being exactly 1/10 of a 1em window, and it is no longer blocking anything.
