### PR TITLE
feat(Chart): add ChartAreaGradientDefs for area fills

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
       "lodash-es": ">=4.18.0",
       "minimatch": ">=10.2.3",
       "ajv": ">=8.18.0",
-      "fast-uri": ">=3.1.4",
+      "fast-uri": ">=4.1.2",
       "brace-expansion": ">=5.0.9",
       "yaml": ">=2.8.3",
       "postcss": ">=8.5.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   lodash-es: '>=4.18.0'
   minimatch: '>=10.2.3'
   ajv: '>=8.18.0'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   brace-expansion: '>=5.0.9'
   yaml: '>=2.8.3'
   postcss: '>=8.5.18'
@@ -2695,8 +2695,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6275,7 +6275,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6795,7 +6795,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/src/charts.ts
+++ b/src/charts.ts
@@ -1,4 +1,6 @@
 export type { CardHierarchy } from "./components/Card/Card";
+export type { ChartAreaGradientDefsProps } from "./components/Chart/ChartAreaGradient";
+export { ChartAreaGradientDefs, chartAreaGradientFill } from "./components/Chart/ChartAreaGradient";
 export type { ChartCardProps } from "./components/Chart/ChartCard";
 export { ChartCard } from "./components/Chart/ChartCard";
 export type { ChartCenterLabelProps } from "./components/Chart/ChartCenterLabel";

--- a/src/components/Chart/Chart.test.tsx
+++ b/src/components/Chart/Chart.test.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Bar, BarChart } from "recharts";
 import { describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
+import { ChartAreaGradientDefs, chartAreaGradientFill } from "./ChartAreaGradient";
 import { ChartCard } from "./ChartCard";
 import { ChartCenterLabel } from "./ChartCenterLabel";
 import { ChartContainer } from "./ChartContainer";
@@ -650,6 +651,102 @@ describe("Chart", () => {
 
       const rows = render(<ChartSkeleton variant="rows" rows={3} />);
       expect(await axe(rows.container)).toHaveNoViolations();
+    });
+  });
+
+  describe("ChartAreaGradientDefs", () => {
+    const renderDefs = (props: React.ComponentProps<typeof ChartAreaGradientDefs>) =>
+      render(
+        <svg aria-hidden="true">
+          <ChartAreaGradientDefs {...props} />
+        </svg>,
+      );
+
+    /**
+     * Stops are read off the gradient node rather than with a descendant selector:
+     * jsdom lowercases a camelCase type selector when it is part of a combinator, so
+     * `linearGradient stop` matches nothing while `linearGradient` alone matches.
+     */
+    const stopsOf = (container: HTMLElement) => [
+      ...(container.querySelector("linearGradient")?.querySelectorAll("stop") ?? []),
+    ];
+
+    it("emits one gradient per series, namespaced by the given prefix", () => {
+      const { container } = renderDefs({
+        idPrefix: "chart-1",
+        seriesKeys: ["revenue", "subscribers"],
+      });
+
+      expect([...container.querySelectorAll("linearGradient")].map((node) => node.id)).toEqual([
+        "chart-1-revenue",
+        "chart-1-subscribers",
+      ]);
+    });
+
+    it("resolves each series to the custom property ChartStyle publishes", () => {
+      // Rather than taking a colour: the gradient then tracks whatever colour the
+      // chart config gives that series, including its dark-theme override.
+      const { container } = renderDefs({
+        idPrefix: "chart-1",
+        seriesKeys: ["revenue"],
+      });
+
+      expect(stopsOf(container).map((stop) => stop.getAttribute("stop-color"))).toEqual([
+        "var(--color-revenue)",
+        "var(--color-revenue)",
+      ]);
+    });
+
+    it("fades from a translucent top to nothing at the baseline", () => {
+      const { container } = renderDefs({
+        idPrefix: "chart-1",
+        seriesKeys: ["revenue"],
+      });
+
+      const stops = stopsOf(container);
+      expect(stops[0]).toHaveAttribute("stop-opacity", "0.3");
+      expect(stops[1]).toHaveAttribute("stop-opacity", "0");
+    });
+
+    it("takes a stronger top opacity when one is given", () => {
+      const { container } = renderDefs({
+        idPrefix: "chart-1",
+        seriesKeys: ["revenue"],
+        topOpacity: 0.6,
+      });
+
+      expect(stopsOf(container)[0]).toHaveAttribute("stop-opacity", "0.6");
+    });
+
+    it("runs the gradient down the value axis, not along the series", () => {
+      const { container } = renderDefs({
+        idPrefix: "chart-1",
+        seriesKeys: ["revenue"],
+      });
+
+      const gradient = container.querySelector("linearGradient");
+      expect(gradient).toHaveAttribute("x1", "0");
+      expect(gradient).toHaveAttribute("x2", "0");
+      expect(gradient).toHaveAttribute("y1", "0");
+      expect(gradient).toHaveAttribute("y2", "1");
+    });
+
+    it("addresses a series' gradient with the same id it emitted", () => {
+      const { container } = renderDefs({
+        idPrefix: "chart-1",
+        seriesKeys: ["revenue"],
+      });
+
+      expect(chartAreaGradientFill("chart-1", "revenue")).toBe("url(#chart-1-revenue)");
+      expect(container.querySelector("linearGradient")?.id).toBe("chart-1-revenue");
+    });
+
+    it("has no accessibility violations", async () => {
+      const { container } = renderDefs({
+        idPrefix: "chart-1",
+        seriesKeys: ["revenue", "subscribers"],
+      });
+      expect(await axe(container)).toHaveNoViolations();
     });
   });
 });

--- a/src/components/Chart/ChartAreaGradient.tsx
+++ b/src/components/Chart/ChartAreaGradient.tsx
@@ -1,0 +1,73 @@
+/** Props for {@link ChartAreaGradientDefs}. */
+export interface ChartAreaGradientDefsProps {
+  /**
+   * Namespace for the generated gradient ids. SVG ids are document-global, so this
+   * has to be unique per chart on the page — pass a `React.useId()`.
+   */
+  idPrefix: string;
+  /**
+   * Series to emit a gradient for. Each resolves `var(--color-<key>)`, the custom
+   * property {@link ChartStyle} already publishes from the chart config, so the
+   * gradient tracks whatever colour that series is given.
+   */
+  seriesKeys: readonly string[];
+  /**
+   * Opacity where the fill meets the line, fading to nothing at the baseline.
+   * @default 0.3
+   */
+  topOpacity?: number;
+}
+
+/** The `fill` value for a series' gradient, as emitted by {@link ChartAreaGradientDefs}. */
+export const chartAreaGradientFill = (idPrefix: string, seriesKey: string) =>
+  `url(#${idPrefix}-${seriesKey})`;
+
+/**
+ * One vertical gradient per series, for the area fills on a line or area chart:
+ * the series colour where it meets its line, fading out towards the baseline.
+ *
+ * Render it inside the chart — SVG resolves `url(#…)` against the document, but the
+ * `defs` must be part of the chart's own SVG for recharts to keep it mounted — and
+ * fill each `Area` with {@link chartAreaGradientFill}. Do not also set
+ * `fillOpacity`: it multiplies the gradient's own alpha and flattens it.
+ *
+ * A flat translucent fill is what this replaces. Two of them overlapping read as a
+ * third colour, and the eye cannot tell which series is in front; a fade keeps each
+ * series legible where they cross and puts the weight on the line.
+ *
+ * @example
+ * ```tsx
+ * const gradientId = React.useId();
+ *
+ * <AreaChart data={rows}>
+ *   <ChartAreaGradientDefs idPrefix={gradientId} seriesKeys={seriesKeys} />
+ *   {seriesKeys.map((key) => (
+ *     <Area key={key} dataKey={key} stroke={`var(--color-${key})`}
+ *           fill={chartAreaGradientFill(gradientId, key)} />
+ *   ))}
+ * </AreaChart>
+ * ```
+ */
+export const ChartAreaGradientDefs = ({
+  idPrefix,
+  seriesKeys,
+  topOpacity = 0.3,
+}: ChartAreaGradientDefsProps) => (
+  <defs>
+    {seriesKeys.map((key) => (
+      <linearGradient
+        key={key}
+        id={`${idPrefix}-${key}`}
+        // Top to bottom in the plot's own space, so the fade follows the value axis
+        // rather than the shape of the series.
+        x1="0"
+        y1="0"
+        x2="0"
+        y2="1"
+      >
+        <stop offset="0%" stopColor={`var(--color-${key})`} stopOpacity={topOpacity} />
+        <stop offset="100%" stopColor={`var(--color-${key})`} stopOpacity={0} />
+      </linearGradient>
+    ))}
+  </defs>
+);

--- a/src/components/Chart/ChartHelpers.stories.tsx
+++ b/src/components/Chart/ChartHelpers.stories.tsx
@@ -1,12 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState } from "react";
+import { useId, useState } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
 import { cn } from "../../utils/cn";
+import { ChartAreaGradientDefs, chartAreaGradientFill } from "./ChartAreaGradient";
 import { ChartCard } from "./ChartCard";
+import { ChartContainer } from "./ChartContainer";
 import { ChartLoadingOverlay } from "./ChartLoadingOverlay";
 import { ChartPieLegend } from "./ChartPieLegend";
 import { ChartSeriesToggle } from "./ChartSeriesToggle";
 import { ChartSkeleton } from "./ChartSkeleton";
+import { ChartTooltip, ChartTooltipContent } from "./ChartTooltip";
 import { SimpleLineChart, simpleLineConfig } from "./chartStoryFixtures";
+import type { ChartConfig } from "./types";
 
 const meta = {
   title: "Components/Charts/Helpers",
@@ -296,6 +301,69 @@ export const LoadingOverlayWithSkeleton: Story = {
       <ChartLoadingOverlay loading variant="bar" className="h-48">
         <SimpleLineChart config={simpleLineConfig} />
       </ChartLoadingOverlay>
+    </div>
+  ),
+};
+
+const overlappingSeriesData = [
+  { month: "Jan", subs: 2400, tips: 1400 },
+  { month: "Feb", subs: 1900, tips: 2100 },
+  { month: "Mar", subs: 3200, tips: 1800 },
+  { month: "Apr", subs: 2100, tips: 2600 },
+  { month: "May", subs: 3900, tips: 2200 },
+  { month: "Jun", subs: 2800, tips: 3100 },
+];
+
+const overlappingSeriesConfig = {
+  subs: { label: "Subscriptions", color: "var(--color-special-chart-teal)" },
+  tips: { label: "Tips", color: "var(--color-special-chart-purple)" },
+} satisfies ChartConfig;
+
+const overlappingSeriesKeys = ["subs", "tips"] as const;
+
+const GradientAreaChart = ({ topOpacity }: { topOpacity?: number }) => {
+  const gradientId = useId();
+
+  return (
+    <ChartContainer config={overlappingSeriesConfig} className="h-48 w-full">
+      <AreaChart accessibilityLayer data={overlappingSeriesData}>
+        <ChartAreaGradientDefs
+          idPrefix={gradientId}
+          seriesKeys={overlappingSeriesKeys}
+          topOpacity={topOpacity}
+        />
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} tickMargin={8} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        {overlappingSeriesKeys.map((key) => (
+          <Area
+            key={key}
+            type="monotone"
+            dataKey={key}
+            stroke={`var(--color-${key})`}
+            strokeWidth={2}
+            fill={chartAreaGradientFill(gradientId, key)}
+          />
+        ))}
+      </AreaChart>
+    </ChartContainer>
+  );
+};
+
+export const AreaGradients: Story = {
+  name: "Area gradients (two crossing series)",
+  render: () => (
+    <div className="w-full max-w-lg">
+      <GradientAreaChart />
+    </div>
+  ),
+};
+
+export const AreaGradientsStrongerFill: Story = {
+  name: "Area gradients (stronger fill)",
+  render: () => (
+    <div className="w-full max-w-lg">
+      <GradientAreaChart topOpacity={0.6} />
     </div>
   ),
 };


### PR DESCRIPTION
One vertical gradient per series for the area fills on a line or area chart: the series colour where it meets its line, fading to nothing at the baseline. `ChartAreaGradientDefs` emits the `<defs>`, `chartAreaGradientFill(idPrefix, key)` addresses one.

## Why not a flat fill

A flat translucent fill is what this replaces. Two of them overlapping read as a third colour and the eye cannot tell which series is in front — a fade keeps each series legible where they cross and puts the visual weight on the line, which is where the value is.

The `AreaGradients` story renders two series that cross three times, which is the case that motivated it.

## Why it belongs in the DS

`AreaChart.stories.tsx` already hand-rolls exactly this, through a story-only `AreaGradient` fixture in `chartStoryFixtures.tsx`, at seven call sites with hardcoded ids (`fillEarnings`, `fillDesktop`, `fillMobile`, …). Eden carries a second copy for the insights earnings chart. Same three-line `<linearGradient>` in three places, none of them shared.

## Design notes

- **Colours resolve through `var(--color-${key})`**, the custom property `ChartStyle` already publishes from the chart config, rather than taking a colour prop. A gradient therefore tracks whatever colour that series is given, including its dark-theme override, with no second place to keep in sync.
- **`idPrefix` is required, not generated.** SVG ids are document-global and several of these charts appear on one page, so the prefix has to come from the caller's `useId()`. Generating one inside would either need the component to own the fill lookup too or hand back an id the caller cannot reconstruct.
- **The defs render inside the chart**, not beside it. `url(#…)` resolves against the document, but recharts will unmount anything outside its own SVG subtree.
- **`topOpacity` defaults to 0.3**, taken from the V2 insights frames. The story fixture's 0.8 → 0.1 is a recharts-example value, not a design one; the prop is there for anyone who genuinely needs a heavier fill (`AreaGradientsStrongerFill` shows 0.6).
- **Do not also set `fillOpacity`** on the `Area` — it multiplies the gradient's own alpha and flattens the fade. Documented in the JSDoc.

## Notes for review

- **No `ref`, no `className`.** It emits `<defs>`; there is no box to style and no host element a consumer would reach for. Same shape as `ChartStyle`, which is also a plain function component with neither.
- Exported from `charts.ts` only, alongside the other chart helpers — not from `src/index.ts`, matching how the chart entrypoint is split today.
- One test carries a comment worth knowing about: jsdom lowercases a camelCase type selector when it appears in a combinator, so `querySelectorAll("linearGradient stop")` matches **nothing** while `querySelectorAll("linearGradient")` matches fine. Stops are read off the gradient node instead. I lost a few minutes to that; the next person doesn't have to.
- **Deliberately not converting `AreaChart.stories.tsx`** to use this. Those seven call sites would change appearance (0.8 → 0.1 becomes 0.3 → 0), so it is a visual review of six stories rather than a mechanical swap, and the story fixture can go in the same follow-up.
- 129 chart tests pass, `tsc` clean, and `biome check .` reports the same 42 pre-existing warnings as `main` — none added.
