### PR TITLE
fix(deps): raise the fast-uri override past GHSA-7p8r-x3mc-p8w7

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
       "lodash-es": ">=4.18.0",
       "minimatch": ">=10.2.3",
       "ajv": ">=8.18.0",
-      "fast-uri": ">=3.1.4",
+      "fast-uri": ">=4.1.2",
       "brace-expansion": ">=5.0.9",
       "yaml": ">=2.8.3",
       "postcss": ">=8.5.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   lodash-es: '>=4.18.0'
   minimatch: '>=10.2.3'
   ajv: '>=8.18.0'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   brace-expansion: '>=5.0.9'
   yaml: '>=2.8.3'
   postcss: '>=8.5.18'
@@ -2695,8 +2695,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6275,7 +6275,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6795,7 +6795,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
`Security Audit` is failing on every PR opened since yesterday, including #651, #652 and #653. It is not any of those changes — `pnpm audit --audit-level=high` queries the live advisory database, so a newly published advisory turns previously-green CI red with no code change. Main's last CI run was the 3.25.0 release on Aug 3, before it landed.

## The advisory

[GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — `fast-uri` host confusion via a backslash authority introducer. **High.** Vulnerable `>=4.0.0 <4.1.2`, patched in `4.1.2`.

We were on `4.1.1`, and the reason is the override itself:

```
"fast-uri": ">=3.1.4"
```

That floor is satisfied by `4.1.1`, so the override that exists to keep this package patched was pinning us **inside** the vulnerable range. Raised to `>=4.1.2`, which is the same remedy the rest of that list already applies (`minimatch >=10.2.3`, `brace-expansion >=5.0.9`, and so on).

`pnpm audit --audit-level=high` now exits 0.

## Notes for review

- **Two files, six lines.** `fast-uri` reaches us only through `ajv`, under `@commitlint/cli` and `vite-plugin-dts > @microsoft/api-extractor`, so nothing in the published bundle changes — 16 paths, all dev tooling.
- Verified locally after a real install: `pnpm build` succeeds, `tsc --noEmit` clean, `biome check .` reports the same 42 pre-existing warnings as main, and all 3,657 unit tests pass.
- **The audit gate itself is untouched.** No ignore list, no lowered `--audit-level` — the vulnerable version is gone instead.
- One **moderate** finding remains and is worth a follow-up on the same pattern: `postcss` is overridden at `>=8.5.18` while GHSA-6g55-p6wh-862q's incomplete-fix advisory wants `>=8.5.23`. It does not fail the `high` gate, and postcss sits in the Tailwind build path, so it deserves its own PR and its own build check rather than riding along with an unblocking fix.
- Once this merges, #652 and #653 need their branches updated to pick it up before they can go green.
