### PR TITLE
feat(SegmentedControl): collapse to a cycling icon toggle when narrow

### DIFF
--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -34,6 +34,9 @@ const meta = {
     disabled: {
       control: "boolean",
     },
+    collapsible: {
+      control: "boolean",
+    },
   },
 } satisfies Meta<typeof SegmentedControl>;
 
@@ -174,6 +177,49 @@ export const Brand: Story = {
       type: "figma",
       url: "https://www.figma.com/design/fDlJj7bf7KXQlibPoujgaC/Creator---AI-Features?node-id=6470-48376",
     },
+  },
+};
+
+/**
+ * With `collapsible`, an icon-bearing control (`plain` or `brand`) collapses to a single icon
+ * toggle when its container is too narrow to show every segment, and expands again when the
+ * space returns. Collapsed, it shows the selected option's icon; clicking it (or pressing
+ * Enter/Space) cycles to the next option, wrapping around.
+ *
+ * Drag the right edge of the box to shrink it and watch the control collapse.
+ */
+export const Collapsible: Story = {
+  args: {
+    appearance: "plain",
+    collapsible: true,
+    options: iconOnlyOptions,
+    "aria-label": "View",
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/LB9q4XzCNlbOaeW3xN6tQo/Creator---Content---Creation?node-id=4506-17416",
+    },
+  },
+  render: function CollapsibleRender(args) {
+    const [view, setView] = useState("list");
+    return (
+      <div className="flex flex-col items-start gap-3">
+        <span className="typography-body-small-14px-regular text-content-secondary">
+          Drag the right edge to shrink the container — the control collapses to the selected icon
+          and cycles on click.
+        </span>
+        <div
+          className="resize-x overflow-auto rounded-lg border border-border-primary p-4"
+          style={{ width: 260, minWidth: 72, maxWidth: 420 }}
+        >
+          <SegmentedControl {...args} value={view} onChange={setView} />
+        </div>
+        <span className="typography-body-small-14px-regular text-content-secondary">
+          Selected: {view}
+        </span>
+      </div>
+    );
   },
 };
 

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,6 +21,12 @@ const threeOptions = [
 const iconOptions = [
   { label: "List view", value: "list", icon: <ListViewIcon size={16} aria-hidden="true" /> },
   { label: "Grid view", value: "grid", icon: <GridViewIcon size={16} aria-hidden="true" /> },
+];
+
+const threeIconOptions = [
+  { label: "List view", value: "list", icon: <ListViewIcon size={16} aria-hidden="true" /> },
+  { label: "Grid view", value: "grid", icon: <GridViewIcon size={16} aria-hidden="true" /> },
+  { label: "Table view", value: "table", icon: <ListViewIcon size={16} aria-hidden="true" /> },
 ];
 
 const brandOptions = [
@@ -369,6 +375,271 @@ describe("SegmentedControl", () => {
       const radios = screen.getAllByRole("radio");
       expect(radios[0]).toHaveAttribute("tabIndex", "0");
       expect(radios[1]).toHaveAttribute("tabIndex", "-1");
+    });
+  });
+
+  describe("collapsible", () => {
+    /**
+     * jsdom has no layout, so drive the auto-collapse measurement directly: the off-screen
+     * replica is the only `aria-hidden="true"` element the hook measures, so return the
+     * "required" width for it and the "available" width for everything else (notably the
+     * root's parent). A controllable ResizeObserver lets tests re-evaluate after changing
+     * the widths, standing in for a real resize.
+     */
+    let rectSpy: ReturnType<typeof vi.spyOn> | undefined;
+    const resizeCallbacks: ResizeObserverCallback[] = [];
+
+    const setWidths = ({ available, required }: { available: number; required: number }) => {
+      rectSpy?.mockRestore();
+      rectSpy = vi
+        .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+        .mockImplementation(function (this: HTMLElement) {
+          const width = this.getAttribute("aria-hidden") === "true" ? required : available;
+          return {
+            width,
+            height: 0,
+            top: 0,
+            left: 0,
+            right: width,
+            bottom: 0,
+            x: 0,
+            y: 0,
+          } as DOMRect;
+        });
+    };
+
+    const fireResize = () => {
+      act(() => {
+        for (const cb of resizeCallbacks) {
+          cb([], {} as ResizeObserver);
+        }
+      });
+    };
+
+    beforeEach(() => {
+      resizeCallbacks.length = 0;
+      vi.stubGlobal(
+        "ResizeObserver",
+        class {
+          constructor(cb: ResizeObserverCallback) {
+            resizeCallbacks.push(cb);
+          }
+          observe() {}
+          unobserve() {}
+          disconnect() {}
+        },
+      );
+    });
+
+    afterEach(() => {
+      rectSpy?.mockRestore();
+      rectSpy = undefined;
+      vi.unstubAllGlobals();
+    });
+
+    it("collapses to a single icon toggle when the container is too narrow", () => {
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl appearance="plain" collapsible options={iconOptions} aria-label="View" />,
+      );
+
+      // No radiogroup semantics while collapsed — a single button that cycles.
+      expect(screen.queryAllByRole("radio")).toHaveLength(0);
+      const toggle = screen.getByRole("button", { name: "List view" });
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).not.toHaveAttribute("role", "radio");
+    });
+
+    it("stays expanded when the container has room", () => {
+      setWidths({ available: 300, required: 100 });
+      render(
+        <SegmentedControl appearance="plain" collapsible options={iconOptions} aria-label="View" />,
+      );
+      expect(screen.getAllByRole("radio")).toHaveLength(2);
+    });
+
+    it("cycles to the next option when the collapsed toggle is clicked", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl
+          appearance="plain"
+          collapsible
+          options={iconOptions}
+          onChange={handleChange}
+          aria-label="View"
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: "List view" }));
+      expect(handleChange).toHaveBeenCalledWith("grid");
+      // Uncontrolled: the toggle now reflects the new selection.
+      expect(screen.getByRole("button", { name: "Grid view" })).toBeInTheDocument();
+    });
+
+    it("wraps from the last option back to the first (three options)", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl
+          appearance="plain"
+          collapsible
+          options={threeIconOptions}
+          defaultValue="table"
+          onChange={handleChange}
+          aria-label="View"
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: "Table view" }));
+      expect(handleChange).toHaveBeenCalledWith("list");
+    });
+
+    it("cycles with the keyboard (Enter)", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl
+          appearance="plain"
+          collapsible
+          options={iconOptions}
+          onChange={handleChange}
+          aria-label="View"
+        />,
+      );
+      screen.getByRole("button", { name: "List view" }).focus();
+      await user.keyboard("{Enter}");
+      expect(handleChange).toHaveBeenCalledWith("grid");
+    });
+
+    it("does not cycle when disabled", async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl
+          appearance="plain"
+          collapsible
+          disabled
+          options={iconOptions}
+          onChange={handleChange}
+          aria-label="View"
+        />,
+      );
+      await user.click(screen.getByRole("button", { name: "List view" }));
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it("expands again when the container grows", () => {
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl appearance="plain" collapsible options={iconOptions} aria-label="View" />,
+      );
+      expect(screen.queryAllByRole("radio")).toHaveLength(0);
+
+      setWidths({ available: 400, required: 300 });
+      fireResize();
+      expect(screen.getAllByRole("radio")).toHaveLength(2);
+    });
+
+    it("supports the brand appearance", () => {
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl
+          appearance="brand"
+          collapsible
+          options={brandOptions}
+          aria-label="Mode"
+        />,
+      );
+      // Collapsed brand shows the selected icon only: the visible toggle has no label text
+      // (the off-screen measurement replica still carries it, so assert on the toggle itself).
+      const toggle = screen.getByRole("button", { name: "Home" });
+      expect(toggle).toBeInTheDocument();
+      expect(toggle.textContent).toBe("");
+    });
+
+    it("renders the collapsed brand toggle as a square (circular once rounded)", () => {
+      setWidths({ available: 100, required: 300 });
+      render(
+        <SegmentedControl
+          appearance="brand"
+          collapsible
+          options={brandOptions}
+          aria-label="Mode"
+        />,
+      );
+      const toggle = screen.getByRole("button", { name: "Home" });
+      // Symmetric padding + aspect-square give a circle rather than the wider-than-tall pill.
+      expect(toggle).toHaveClass("aspect-square");
+      expect(toggle).toHaveClass("rounded-full");
+    });
+
+    it("has no accessibility violations while collapsed", async () => {
+      setWidths({ available: 100, required: 300 });
+      const { container } = render(
+        <SegmentedControl appearance="plain" collapsible options={iconOptions} aria-label="View" />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    describe("dev warnings", () => {
+      let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        consoleWarnSpy.mockRestore();
+      });
+
+      it("warns and does not collapse for the pill appearance", () => {
+        setWidths({ available: 100, required: 300 });
+        render(<SegmentedControl collapsible options={twoOptions} aria-label="Amount" />);
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('`collapsible` is only supported for the "plain" and "brand"'),
+        );
+        expect(screen.getAllByRole("radio")).toHaveLength(2);
+      });
+
+      it("warns and does not collapse when an option is missing an icon", () => {
+        setWidths({ available: 100, required: 300 });
+        render(
+          <SegmentedControl
+            appearance="plain"
+            collapsible
+            options={[
+              {
+                label: "List view",
+                value: "list",
+                icon: <ListViewIcon size={16} aria-hidden="true" />,
+              },
+              { label: "Grid view", value: "grid" },
+            ]}
+            aria-label="View"
+          />,
+        );
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("`collapsible` requires every option to define an `icon`"),
+        );
+        expect(screen.getAllByRole("radio")).toHaveLength(2);
+      });
+
+      it("does not warn for a valid collapsible plain control", () => {
+        setWidths({ available: 300, required: 100 });
+        render(
+          <SegmentedControl
+            appearance="plain"
+            collapsible
+            options={iconOptions}
+            aria-label="View"
+          />,
+        );
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -36,7 +36,8 @@ export interface SegmentedControlOption {
   /**
    * Icon to render for the segment. In `pill`/`plain` appearances the segment renders icon-only and
    * `label` becomes required as its accessible name (applied as `aria-label`, no visible text). In
-   * the `brand` appearance the icon renders alongside the visible `label`.
+   * the `brand` appearance the icon renders alongside the visible `label`. Required for every option
+   * when `collapsible` is set, since the collapsed control shows the selected option's icon alone.
    */
   icon?: React.ReactNode;
 }
@@ -59,6 +60,17 @@ export interface SegmentedControlProps
   onChange?: (value: string) => void;
   /** Whether the control is disabled. @default false */
   disabled?: boolean;
+  /**
+   * When `true`, the control automatically collapses to a single icon-only toggle whenever its
+   * container is too narrow to show every segment side by side, and expands again when the space
+   * returns. Collapsed, it shows the currently-selected option's `icon`; clicking it (or pressing
+   * Enter/Space) advances to the next option, wrapping around from the last back to the first.
+   *
+   * Only supported for the icon-bearing `"plain"` and `"brand"` appearances, and every option must
+   * define an `icon` (there is nothing to show otherwise). Ignored, with a dev-time warning, when
+   * those conditions are not met. @default false
+   */
+  collapsible?: boolean;
 }
 
 /** Padding and typography per size. Combined with the container's `p-1` these hit the 32/40/48px heights. */
@@ -86,6 +98,23 @@ function warnMissingOptionAccessibleName(options: SegmentedControlOption[]) {
           `SegmentedControl: icon-only segment "${option.value}" is missing a non-empty \`label\` to use as its accessible name.`,
         );
       }
+    }
+  }
+}
+
+function warnUnsupportedCollapsible(
+  appearance: SegmentedControlAppearance,
+  options: SegmentedControlOption[],
+) {
+  if (process.env.NODE_ENV !== "production") {
+    if (appearance === "pill") {
+      console.warn(
+        'SegmentedControl: `collapsible` is only supported for the "plain" and "brand" appearances; ignoring it.',
+      );
+    } else if (!options.every((option) => option.icon)) {
+      console.warn(
+        "SegmentedControl: `collapsible` requires every option to define an `icon`; ignoring it.",
+      );
     }
   }
 }
@@ -131,6 +160,88 @@ function getSegmentClassName({
   );
 }
 
+/** Symmetric padding per size so the collapsed toggle is a square (a circle once `rounded-full`). */
+const collapsedPaddingClasses: Record<SegmentedControlSize, string> = {
+  "32": "p-1",
+  "40": "p-2",
+  "48": "p-3",
+};
+
+/**
+ * Classes for the single button shown while the control is collapsed. Unlike an expanded segment
+ * (which carries asymmetric `px`/`py` padding and so reads slightly wider than tall), the collapsed
+ * toggle is forced to an `aspect-square` circle via symmetric padding and `rounded-full`, so the
+ * icon-only control reads as a round button.
+ */
+function getCollapsedButtonClassName({
+  appearance,
+  size,
+  disabled,
+}: {
+  appearance: SegmentedControlAppearance;
+  size: SegmentedControlSize;
+  disabled: boolean;
+}) {
+  return cn(
+    "relative inline-flex aspect-square shrink-0 cursor-pointer items-center justify-center rounded-full",
+    "motion-safe:transition-colors motion-safe:duration-150 motion-safe:ease-in-out",
+    "focus-visible:shadow-focus-ring focus-visible:outline-none",
+    appearance === "plain"
+      ? // Glyph-only: no pill, just the selected icon colour. The negative margin keeps the visual
+        // footprint icon-sized while the padding enlarges the hit target.
+        "-m-1 p-1 text-icons-primary"
+      : cn(
+          collapsedPaddingClasses[size],
+          "bg-brand-primary-muted text-content-always-black shadow-sm ring-1 ring-brand-primary-default",
+        ),
+    disabled && "pointer-events-none",
+  );
+}
+
+/**
+ * Watches `rootRef`'s available width against the natural width of the fully expanded control
+ * (measured from `measureRef`, an off-screen replica) and returns whether the control should
+ * collapse. Comparing available space to a stable off-screen measurement — rather than to the
+ * live control, which shrinks when it collapses — avoids the expand/collapse oscillation that a
+ * self-referential measurement would cause. Returns `false` until both widths are measurable
+ * (SSR, jsdom, or a zero-width layout), so the control renders expanded by default.
+ */
+function useAutoCollapse(
+  rootRef: React.RefObject<HTMLDivElement | null>,
+  measureRef: React.RefObject<HTMLDivElement | null>,
+  enabled: boolean,
+): boolean {
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setCollapsed(false);
+      return;
+    }
+    const root = rootRef.current;
+    const measure = measureRef.current;
+    const parent = root?.parentElement;
+    if (!root || !measure || !parent) return;
+
+    const evaluate = () => {
+      const available = parent.getBoundingClientRect().width;
+      const required = measure.getBoundingClientRect().width;
+      // Both unmeasured (SSR/jsdom/zero-width): leave the current state untouched.
+      if (available <= 0 || required <= 0) return;
+      setCollapsed(required > available);
+    };
+
+    evaluate();
+
+    const observer = new ResizeObserver(evaluate);
+    observer.observe(parent);
+    observer.observe(measure);
+    return () => observer.disconnect();
+  }, [enabled, rootRef, measureRef]);
+
+  return enabled && collapsed;
+}
+
 /**
  * A compact selector for choosing between two or three mutually exclusive
  * options where the choice affects the content immediately below it. Use
@@ -138,7 +249,9 @@ function getSegmentClassName({
  * navigation, such as toggling a list/grid view or a monthly/annual price.
  *
  * Rendered as a `radiogroup` with roving-tabindex keyboard navigation. Supports
- * both controlled and uncontrolled usage.
+ * both controlled and uncontrolled usage. With `collapsible`, the icon-bearing
+ * `plain`/`brand` appearances shrink to a single cycling icon toggle when space
+ * is tight (rendered as a `group` containing one button).
  *
  * @example
  * ```tsx
@@ -180,6 +293,21 @@ function getSegmentClassName({
  *   aria-label="Navigation mode"
  * />
  * ```
+ *
+ * @example Collapses to a cycling icon toggle when the container is too narrow
+ * ```tsx
+ * <SegmentedControl
+ *   appearance="plain"
+ *   collapsible
+ *   options={[
+ *     { label: "List view", value: "list", icon: <ListViewIcon size={16} /> },
+ *     { label: "Grid view", value: "grid", icon: <GridViewIcon size={16} /> },
+ *   ]}
+ *   value={view}
+ *   onChange={setView}
+ *   aria-label="View"
+ * />
+ * ```
  */
 export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>(
   (
@@ -193,12 +321,14 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedContro
       defaultValue,
       onChange,
       disabled = false,
+      collapsible = false,
       ...props
     },
     ref,
   ) => {
     warnMissingAccessibleName(props["aria-label"], props["aria-labelledby"]);
     warnMissingOptionAccessibleName(options);
+    if (collapsible) warnUnsupportedCollapsible(appearance, options);
 
     // Tracks selection for uncontrolled usage; ignored when `value` prop is provided
     const [internalValue, setInternalValue] = React.useState(defaultValue ?? options[0]?.value);
@@ -206,6 +336,25 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedContro
     const currentValue = isControlled ? controlledValue : internalValue;
     const anySelected = options.some((o) => o.value === currentValue);
     const buttonRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+
+    // Collapsing only makes sense for icon-bearing appearances where every option has an icon
+    // to show. Anything else falls back to the normal expanded control (a dev warning fires above).
+    const canCollapse =
+      collapsible &&
+      (appearance === "plain" || appearance === "brand") &&
+      options.every((option) => option.icon);
+
+    const rootRef = React.useRef<HTMLDivElement | null>(null);
+    const measureRef = React.useRef<HTMLDivElement | null>(null);
+    const setRootRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        rootRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref],
+    );
+    const isCollapsed = useAutoCollapse(rootRef, measureRef, canCollapse);
 
     const handleSelect = (optionValue: string) => {
       if (disabled || optionValue === currentValue) return;
@@ -229,10 +378,84 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedContro
       buttonRefs.current[nextIndex]?.focus();
     };
 
+    const renderSegment = (option: SegmentedControlOption, index: number) => {
+      const isSelected = currentValue === option.value;
+      // `brand` shows the label as visible text (with the icon); `pill`/`plain` render
+      // icon-only when an icon is given, falling back to the label otherwise.
+      const showLabelText = appearance === "brand" || !option.icon;
+      return (
+        // biome-ignore lint/a11y/useSemanticElements: native radio inputs only allow Tab-focus on the checked item; buttons with roving tabindex give full keyboard navigation
+        <button
+          key={option.value}
+          ref={(el) => {
+            buttonRefs.current[index] = el;
+          }}
+          type="button"
+          role="radio"
+          aria-checked={isSelected}
+          tabIndex={isSelected || (!anySelected && index === 0) ? 0 : -1}
+          disabled={disabled}
+          aria-label={showLabelText ? undefined : option.label}
+          onClick={() => handleSelect(option.value)}
+          onKeyDown={(e) => handleKeyDown(e, index)}
+          className={getSegmentClassName({ appearance, size, variant, isSelected, disabled })}
+        >
+          {option.icon && (
+            <span className="flex shrink-0 items-center justify-center" aria-hidden="true">
+              {option.icon}
+            </span>
+          )}
+          {showLabelText && <span className="min-w-0 truncate">{option.label}</span>}
+        </button>
+      );
+    };
+
+    // Off-screen replica of one segment used only to size the expanded control. Rendered as an
+    // inert (disabled + `aria-hidden`) button with no `radio` semantics so it stays out of the
+    // accessibility tree and tab order, and always with hug sizing so the replica reflects the
+    // natural (uncompressed) width even under a `fill` layout.
+    const renderMeasureSegment = (option: SegmentedControlOption) => {
+      const showLabelText = appearance === "brand" || !option.icon;
+      return (
+        <button
+          key={option.value}
+          type="button"
+          disabled
+          aria-hidden="true"
+          tabIndex={-1}
+          className={getSegmentClassName({
+            appearance,
+            size,
+            variant: "hug",
+            isSelected: currentValue === option.value,
+            disabled,
+          })}
+        >
+          {option.icon && (
+            <span className="flex shrink-0 items-center justify-center" aria-hidden="true">
+              {option.icon}
+            </span>
+          )}
+          {showLabelText && <span className="min-w-0 truncate">{option.label}</span>}
+        </button>
+      );
+    };
+
+    // Collapsed: a single button showing the selected option's icon that cycles to the next
+    // option on activation, wrapping from the last option back to the first.
+    const selectedIndex = options.findIndex((option) => option.value === currentValue);
+    const selectedOption = options[selectedIndex] ?? options[0];
+    const handleCycle = () => {
+      if (disabled || options.length === 0) return;
+      const from = selectedIndex < 0 ? 0 : selectedIndex;
+      const nextOption = options[(from + 1) % options.length] as SegmentedControlOption;
+      handleSelect(nextOption.value);
+    };
+
     return (
       <div
-        ref={ref}
-        role="radiogroup"
+        ref={setRootRef}
+        role={isCollapsed ? "group" : "radiogroup"}
         className={cn(
           "relative items-center rounded-full",
           variant === "fill" ? "flex w-full" : "inline-flex",
@@ -242,37 +465,39 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedContro
         )}
         {...props}
       >
-        {options.map((option, index) => {
-          const isSelected = currentValue === option.value;
-          // `brand` shows the label as visible text (with the icon); `pill`/`plain` render
-          // icon-only when an icon is given, falling back to the label otherwise.
-          const showLabelText = appearance === "brand" || !option.icon;
-          return (
-            // biome-ignore lint/a11y/useSemanticElements: native radio inputs only allow Tab-focus on the checked item; buttons with roving tabindex give full keyboard navigation
-            <button
-              key={option.value}
-              ref={(el) => {
-                buttonRefs.current[index] = el;
-              }}
-              type="button"
-              role="radio"
-              aria-checked={isSelected}
-              tabIndex={isSelected || (!anySelected && index === 0) ? 0 : -1}
-              disabled={disabled}
-              aria-label={showLabelText ? undefined : option.label}
-              onClick={() => handleSelect(option.value)}
-              onKeyDown={(e) => handleKeyDown(e, index)}
-              className={getSegmentClassName({ appearance, size, variant, isSelected, disabled })}
-            >
-              {option.icon && (
-                <span className="flex shrink-0 items-center justify-center" aria-hidden="true">
-                  {option.icon}
-                </span>
-              )}
-              {showLabelText && <span className="min-w-0 truncate">{option.label}</span>}
-            </button>
-          );
-        })}
+        {isCollapsed && selectedOption ? (
+          <button
+            type="button"
+            disabled={disabled}
+            aria-label={selectedOption.label}
+            onClick={handleCycle}
+            className={getCollapsedButtonClassName({ appearance, size, disabled })}
+          >
+            {selectedOption.icon && (
+              <span className="flex shrink-0 items-center justify-center" aria-hidden="true">
+                {selectedOption.icon}
+              </span>
+            )}
+          </button>
+        ) : (
+          options.map((option, index) => renderSegment(option, index))
+        )}
+
+        {canCollapse && (
+          // Off-screen replica of the fully expanded control. Kept in the DOM (out of flow, hidden
+          // from AT and tab order) so its natural width is always measurable, whether the visible
+          // control is currently expanded or collapsed.
+          <div
+            ref={measureRef}
+            aria-hidden="true"
+            className={cn(
+              "pointer-events-none invisible absolute top-0 left-0 -z-10 flex items-center whitespace-nowrap rounded-full",
+              appearance === "plain" ? "gap-2" : "bg-surface-tertiary p-1",
+            )}
+          >
+            {options.map((option) => renderMeasureSegment(option))}
+          </div>
+        )}
       </div>
     );
   },


### PR DESCRIPTION
Adds an opt-in `collapsible` prop. When set, the control measures its available width against an off-screen replica of the fully expanded control and, if there isn't room, renders a single button showing the selected option's icon. Clicking it (or pressing Enter/Space) advances to the next option, wrapping from the last back to the first. It expands again via ResizeObserver when the space returns.

Measuring against a stable off-screen replica rather than the live control avoids the expand/collapse oscillation a self-referential measurement would cause.

Only supported for the icon-bearing `plain` and `brand` appearances with an `icon` on every option; other combinations warn in dev and render as normal. Collapsed, the root drops `radiogroup` for `group` since a cycling button is not a radio.

## Summary

<!-- What does this PR do and why? Link related issues with "Closes #123". -->

## Changes

-

## Checklist

- [ ] TypeScript compiles (`pnpm typecheck`)
- [ ] Linter passes (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] New/updated components have stories
- [ ] New/updated components have accessibility tests
- [ ] New/updated components have forwardRef unit tests
- [ ] New/updated components have className chaining unit tests
- [ ] Exported in `src/index.ts` (if consumable by vendors)
- [ ] Figma link added to story `design` parameter (if applicable)
- [ ] Does not have barrel file `src/YourComponent/index.ts`

## Screenshots / Storybook

This:

<img width="248" height="112" alt="image" src="https://github.com/user-attachments/assets/7d1b2231-714f-4ad0-8533-a7781fdc6c35" />

becomes this:
<img width="86" height="122" alt="image" src="https://github.com/user-attachments/assets/e2e534f0-2257-4aea-81c4-6da739e75ff5" />
